### PR TITLE
Adds default rust-toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.88"


### PR DESCRIPTION
Adds a simple rust-toolchain.

Allows rustup users who haven't upgraded yet to build it.