### PR TITLE
Nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+# Rust build cache and outputs
 /target
+# Nix outputs
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,97 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1751562746,
+        "narHash": "sha256-smpugNIkmDeicNz301Ll1bD7nFOty97T79m4GUMUczA=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "aed2020fd3dc26e1e857d4107a5a67a33ab6c1fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751584797,
+        "narHash": "sha256-1st3Qy4AE2Qycm/2Vy1XJ4IMDR7IEhpgAClwMVP1D5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f404c776a76b6deaef99b873ee295be6c5d12e44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1751510438,
+        "narHash": "sha256-m8PjOoyyCR4nhqtHEBP1tB/jF+gJYYguSZmUmVTEAQE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "7f415261f298656f8164bd636c0dc05af4e95b6b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+{
+  description = "A Rust port of tmux";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    crane.url = "github:ipetkov/crane";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      crane,
+      flake-utils,
+      rust-overlay,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+
+        inherit (pkgs) lib;
+
+        # use latest stable Rust compiler
+        craneLib = (crane.mkLib pkgs).overrideToolchain (p: p.rust-bin.stable.latest.default);
+
+        commonArgs = {
+          # include Rust sources, and anything else required by build
+          src = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              (craneLib.fileset.commonCargoSources ./.)
+              (lib.fileset.fileFilter (file: file.hasExt "lalrpop") ./.)
+              ./README.md
+            ];
+          };
+          strictDeps = true;
+        };
+
+        tmux-rs = craneLib.buildPackage (
+          commonArgs
+          // {
+            cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+            cargoExtraArgs = "--verbose";
+
+            # libraries we link with (per build.rs)
+            buildInputs = [
+              pkgs.libevent
+              pkgs.ncurses
+            ];
+          }
+        );
+      in
+      {
+        checks = {
+          inherit tmux-rs;
+        };
+
+        packages.default = tmux-rs;
+        apps.default = flake-utils.lib.mkApp {
+          drv = tmux-rs;
+        };
+        devShells.default = craneLib.devShell {
+          checks = self.checks.${system};
+          packages = [
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
This adds a `flake.nix`, addressing #10.

I had to a few weird things to make this work...

First, I had to pin `nixpkgs` to an older release. Because it looks like the `libtinfo` in nixpkgs is broken. When I try to use it, I get some errors about broken symlinks. I googled it, apparently others have the same issue. So this work around should only be in place until the upstream libtinfo package is fixed.

I had to disable two tests. This is not directly related to the nix stuff, but they are just broken (at least on my machine). 

Finally, the `src/main.rs` uses `#[no_main]`, and for some reason that breaks `cargo test`. When you try to run tests, it will actually run the binary. Which then fails, because it's not connected to a TTY directly. So I added a `[[bin]]` section to the Cargo.toml file which essentially disables building unit tests for the binary crate.

With all of this, I can run `nix build`, at least on Linux. On macOS, I get a bunch of errors. I suppose macOS is not supported at this point.

 