### PR TITLE
Changes most functions to use native calling convention

### DIFF
--- a/src/alerts.rs
+++ b/src/alerts.rs
@@ -22,7 +22,7 @@ static mut alerts_fired: i32 = 0;
 
 static mut alerts_list: tailq_head<window> = compat::TAILQ_HEAD_INITIALIZER!(alerts_list);
 
-unsafe fn alerts_timer(_fd: i32, _events: i16, arg: *mut c_void) {
+unsafe extern "C" fn alerts_timer(_fd: i32, _events: i16, arg: *mut c_void) {
     let w = arg as *mut window;
 
     unsafe {
@@ -31,7 +31,7 @@ unsafe fn alerts_timer(_fd: i32, _events: i16, arg: *mut c_void) {
     }
 }
 
-unsafe fn alerts_callback(_fd: c_int, _events: c_short, _arg: *mut c_void) {
+unsafe extern "C" fn alerts_callback(_fd: c_int, _events: c_short, _arg: *mut c_void) {
     unsafe {
         for w in tailq_foreach::<_, crate::discr_alerts_entry>(&raw mut alerts_list) {
             let alerts = alerts_check_all(w);

--- a/src/alerts.rs
+++ b/src/alerts.rs
@@ -22,7 +22,7 @@ static mut alerts_fired: i32 = 0;
 
 static mut alerts_list: tailq_head<window> = compat::TAILQ_HEAD_INITIALIZER!(alerts_list);
 
-unsafe extern "C" fn alerts_timer(_fd: i32, _events: i16, arg: *mut c_void) {
+unsafe fn alerts_timer(_fd: i32, _events: i16, arg: *mut c_void) {
     let w = arg as *mut window;
 
     unsafe {
@@ -31,7 +31,7 @@ unsafe extern "C" fn alerts_timer(_fd: i32, _events: i16, arg: *mut c_void) {
     }
 }
 
-unsafe extern "C" fn alerts_callback(_fd: c_int, _events: c_short, _arg: *mut c_void) {
+unsafe fn alerts_callback(_fd: c_int, _events: c_short, _arg: *mut c_void) {
     unsafe {
         for w in tailq_foreach::<_, crate::discr_alerts_entry>(&raw mut alerts_list) {
             let alerts = alerts_check_all(w);

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -54,11 +54,11 @@ pub struct args_command_state<'a> {
 
 crate::compat::RB_GENERATE!(args_tree, args_entry, entry, discr_entry, args_cmp);
 
-unsafe extern "C" fn args_cmp(a1: *const args_entry, a2: *const args_entry) -> Ordering {
+unsafe fn args_cmp(a1: *const args_entry, a2: *const args_entry) -> Ordering {
     unsafe { ((*a1).flag).cmp(&(*a2).flag) }
 }
 
-pub unsafe extern "C" fn args_find(args: *mut args, flag: c_uchar) -> *mut args_entry {
+pub unsafe fn args_find(args: *mut args, flag: c_uchar) -> *mut args_entry {
     unsafe {
         let mut entry: args_entry = args_entry { flag, ..zeroed() };
 
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn args_find(args: *mut args, flag: c_uchar) -> *mut args_
     }
 }
 
-pub unsafe extern "C" fn args_copy_value(to: *mut args_value, from: *const args_value) {
+pub unsafe fn args_copy_value(to: *mut args_value, from: *const args_value) {
     unsafe {
         (*to).type_ = (*from).type_;
         match (*from).type_ {
@@ -90,7 +90,7 @@ pub fn args_type_to_string(type_: args_type) -> &'static str {
     }
 }
 
-pub unsafe extern "C" fn args_value_as_string(value: *mut args_value) -> *const c_char {
+pub unsafe fn args_value_as_string(value: *mut args_value) -> *const c_char {
     unsafe {
         match (*value).type_ {
             args_type::ARGS_NONE => c"".as_ptr(),
@@ -119,7 +119,7 @@ pub fn args_create<'a>() -> &'a mut args {
     Box::leak(args::create())
 }
 
-pub unsafe extern "C" fn args_parse_flag_argument(
+pub unsafe fn args_parse_flag_argument(
     values: *mut args_value,
     count: u32,
     cause: *mut *mut c_char,
@@ -179,7 +179,7 @@ pub unsafe extern "C" fn args_parse_flag_argument(
     0
 }
 
-pub unsafe extern "C" fn args_parse_flags(
+pub unsafe fn args_parse_flags(
     parse: *mut args_parse,
     values: *mut args_value,
     count: u32,
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn args_parse_flags(
 }
 
 /// Parse arguments into a new argument set.
-pub unsafe extern "C" fn args_parse(
+pub unsafe fn args_parse(
     parse: *mut args_parse,
     values: *mut args_value,
     count: u32,
@@ -349,7 +349,7 @@ pub unsafe extern "C" fn args_parse(
     }
 }
 
-pub unsafe extern "C" fn args_copy_copy_value(
+pub unsafe fn args_copy_copy_value(
     to: *mut args_value,
     from: *mut args_value,
     argc: i32,
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn args_copy_copy_value(
 }
 
 /// Copy an arguments set.
-pub unsafe extern "C" fn args_copy(
+pub unsafe fn args_copy(
     args: *mut args,
     argc: i32,
     argv: *mut *mut c_char,
@@ -646,7 +646,7 @@ pub unsafe fn args_has(args: *mut args, flag: u8) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn args_set(
+pub unsafe fn args_set(
     args: *mut args,
     flag: c_uchar,
     value: *mut args_value,
@@ -673,7 +673,7 @@ pub unsafe extern "C" fn args_set(
     }
 }
 
-pub unsafe extern "C" fn args_get(args: *mut args, flag: u8) -> *const c_char {
+pub unsafe fn args_get(args: *mut args, flag: u8) -> *const c_char {
     unsafe {
         let entry = args_find(args, flag);
 
@@ -687,7 +687,7 @@ pub unsafe extern "C" fn args_get(args: *mut args, flag: u8) -> *const c_char {
     }
 }
 
-pub unsafe extern "C" fn args_first(args: *mut args, entry: *mut *mut args_entry) -> u8 {
+pub unsafe fn args_first(args: *mut args, entry: *mut *mut args_entry) -> u8 {
     unsafe {
         *entry = rb_min(&raw mut (*args).tree);
         if (*entry).is_null() {
@@ -698,7 +698,7 @@ pub unsafe extern "C" fn args_first(args: *mut args, entry: *mut *mut args_entry
 }
 
 /// Get next argument.
-pub unsafe extern "C" fn args_next(entry: *mut *mut args_entry) -> u8 {
+pub unsafe fn args_next(entry: *mut *mut args_entry) -> u8 {
     unsafe {
         *entry = rb_next(*entry);
         if (*entry).is_null() {
@@ -709,17 +709,17 @@ pub unsafe extern "C" fn args_next(entry: *mut *mut args_entry) -> u8 {
 }
 
 /// Get argument count.
-pub unsafe extern "C" fn args_count(args: *const args) -> u32 {
+pub unsafe fn args_count(args: *const args) -> u32 {
     unsafe { (*args).count }
 }
 
 /// Get argument values.
-pub unsafe extern "C" fn args_values(args: *mut args) -> *mut args_value {
+pub unsafe fn args_values(args: *mut args) -> *mut args_value {
     unsafe { (*args).values }
 }
 
 /// Get argument value.
-pub unsafe extern "C" fn args_value(args: *mut args, idx: u32) -> *mut args_value {
+pub unsafe fn args_value(args: *mut args, idx: u32) -> *mut args_value {
     unsafe {
         if idx >= (*args).count {
             return null_mut();
@@ -729,7 +729,7 @@ pub unsafe extern "C" fn args_value(args: *mut args, idx: u32) -> *mut args_valu
 }
 
 /// Return argument as string.
-pub unsafe extern "C" fn args_string(args: *mut args, idx: u32) -> *const c_char {
+pub unsafe fn args_string(args: *mut args, idx: u32) -> *const c_char {
     unsafe {
         if idx >= (*args).count {
             return null();
@@ -739,7 +739,7 @@ pub unsafe extern "C" fn args_string(args: *mut args, idx: u32) -> *const c_char
 }
 
 /// Make a command now.
-pub unsafe extern "C" fn args_make_commands_now(
+pub unsafe fn args_make_commands_now(
     self_: *mut cmd,
     item: *mut cmdq_item,
     idx: u32,
@@ -761,7 +761,7 @@ pub unsafe extern "C" fn args_make_commands_now(
 }
 
 /// Save bits to make a command later.
-pub unsafe extern "C" fn args_make_commands_prepare<'a>(
+pub unsafe fn args_make_commands_prepare<'a>(
     self_: *mut cmd,
     item: *mut cmdq_item,
     idx: u32,
@@ -818,7 +818,7 @@ pub unsafe extern "C" fn args_make_commands_prepare<'a>(
 }
 
 /// Return argument as command.
-pub unsafe extern "C" fn args_make_commands(
+pub unsafe fn args_make_commands(
     state: *mut args_command_state,
     argc: i32,
     argv: *mut *mut c_char,
@@ -864,7 +864,7 @@ pub unsafe extern "C" fn args_make_commands(
 }
 
 /// Free commands state.
-pub unsafe extern "C" fn args_make_commands_free(state: *mut args_command_state) {
+pub unsafe fn args_make_commands_free(state: *mut args_command_state) {
     unsafe {
         if !(*state).cmdlist.is_null() {
             cmd_list_free((*state).cmdlist);
@@ -886,7 +886,7 @@ pub unsafe extern "C" fn args_make_commands_free(state: *mut args_command_state)
 }
 
 /// Get prepared command.
-pub unsafe extern "C" fn args_make_commands_get_command(
+pub unsafe fn args_make_commands_get_command(
     state: *mut args_command_state,
 ) -> *mut c_char {
     unsafe {
@@ -903,7 +903,7 @@ pub unsafe extern "C" fn args_make_commands_get_command(
 }
 
 /// Get first value in argument.
-pub unsafe extern "C" fn args_first_value(args: *mut args, flag: u8) -> *mut args_value {
+pub unsafe fn args_first_value(args: *mut args, flag: u8) -> *mut args_value {
     unsafe {
         let entry = args_find(args, flag);
         if entry.is_null() {
@@ -914,12 +914,12 @@ pub unsafe extern "C" fn args_first_value(args: *mut args, flag: u8) -> *mut arg
 }
 
 /// Get next value in argument.
-pub unsafe extern "C" fn args_next_value(value: *mut args_value) -> *mut args_value {
+pub unsafe fn args_next_value(value: *mut args_value) -> *mut args_value {
     unsafe { tailq_next(value) }
 }
 
 /// Convert an argument value to a number.
-pub unsafe extern "C" fn args_strtonum(
+pub unsafe fn args_strtonum(
     args: *mut args,
     flag: u8,
     minval: i64,
@@ -955,7 +955,7 @@ pub unsafe extern "C" fn args_strtonum(
 }
 
 /// Convert an argument value to a number, and expand formats.
-pub unsafe extern "C" fn args_strtonum_and_expand(
+pub unsafe fn args_strtonum_and_expand(
     args: *mut args,
     flag: u8,
     minval: c_longlong,
@@ -995,7 +995,7 @@ pub unsafe extern "C" fn args_strtonum_and_expand(
 }
 
 /// Convert an argument to a number which may be a percentage.
-pub unsafe extern "C" fn args_percentage(
+pub unsafe fn args_percentage(
     args: *mut args,
     flag: u8,
     minval: i64,
@@ -1019,7 +1019,7 @@ pub unsafe extern "C" fn args_percentage(
 }
 
 /// Convert a string to a number which may be a percentage.
-pub unsafe extern "C" fn args_string_percentage(
+pub unsafe fn args_string_percentage(
     value: *const c_char,
     minval: i64,
     maxval: i64,
@@ -1073,7 +1073,7 @@ pub unsafe extern "C" fn args_string_percentage(
 }
 
 /// Convert an argument to a number which may be a percentage, and expand formats.
-pub unsafe extern "C" fn args_percentage_and_expand(
+pub unsafe fn args_percentage_and_expand(
     args: *mut args,
     flag: u8,
     minval: i64,
@@ -1098,7 +1098,7 @@ pub unsafe extern "C" fn args_percentage_and_expand(
 }
 
 /// Convert a string to a number which may be a percentage, and expand formats.
-pub unsafe extern "C" fn args_string_percentage_and_expand(
+pub unsafe fn args_string_percentage_and_expand(
     value: *mut c_char,
     minval: i64,
     maxval: i64,

--- a/src/cfg_.rs
+++ b/src/cfg_.rs
@@ -32,7 +32,7 @@ pub static mut cfg_files: *mut *mut c_char = null_mut();
 
 pub static mut cfg_nfiles: c_uint = 0;
 
-unsafe extern "C" fn cfg_client_done(_item: *mut cmdq_item, _data: *mut c_void) -> cmd_retval {
+unsafe fn cfg_client_done(_item: *mut cmdq_item, _data: *mut c_void) -> cmd_retval {
     if unsafe { cfg_finished } == 0 {
         cmd_retval::CMD_RETURN_WAIT
     } else {
@@ -40,7 +40,7 @@ unsafe extern "C" fn cfg_client_done(_item: *mut cmdq_item, _data: *mut c_void) 
     }
 }
 
-unsafe extern "C" fn cfg_done(_item: *mut cmdq_item, _data: *mut c_void) -> cmd_retval {
+unsafe fn cfg_done(_item: *mut cmdq_item, _data: *mut c_void) -> cmd_retval {
     unsafe {
         if cfg_finished != 0 {
             return cmd_retval::CMD_RETURN_NORMAL;
@@ -59,7 +59,7 @@ unsafe extern "C" fn cfg_done(_item: *mut cmdq_item, _data: *mut c_void) -> cmd_
     }
 }
 
-pub unsafe extern "C" fn start_cfg() {
+pub unsafe fn start_cfg() {
     let c: *mut client;
     let mut i: u32;
     let mut flags: cmd_parse_input_flags = cmd_parse_input_flags::empty();
@@ -268,7 +268,7 @@ pub unsafe fn cfg_add_cause_(args: std::fmt::Arguments) {
     }
 }
 
-pub unsafe extern "C" fn cfg_print_causes(item: *mut cmdq_item) {
+pub unsafe fn cfg_print_causes(item: *mut cmdq_item) {
     unsafe {
         for i in 0..cfg_ncauses {
             cmdq_print!(item, "{}", _s(*cfg_causes.add(i as usize)));
@@ -281,7 +281,7 @@ pub unsafe extern "C" fn cfg_print_causes(item: *mut cmdq_item) {
     }
 }
 
-pub unsafe extern "C" fn cfg_show_causes(mut s: *mut session) {
+pub unsafe fn cfg_show_causes(mut s: *mut session) {
     unsafe {
         'out: {
             let c = tailq_first(&raw mut clients);

--- a/src/client_.rs
+++ b/src/client_.rs
@@ -78,7 +78,7 @@ static mut client_attached: i32 = 0;
 
 static mut client_files: client_files = rb_initializer();
 
-pub unsafe extern "C" fn client_get_lock(lockfile: *mut c_char) -> i32 {
+pub unsafe fn client_get_lock(lockfile: *mut c_char) -> i32 {
     unsafe {
         log_debug!("lock file is {}", _s(lockfile));
 
@@ -103,7 +103,7 @@ pub unsafe extern "C" fn client_get_lock(lockfile: *mut c_char) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn client_connect(
+pub unsafe fn client_connect(
     base: *mut event_base,
     path: *const c_char,
     flags: client_flag,
@@ -197,7 +197,7 @@ pub unsafe extern "C" fn client_connect(
     }
 }
 
-pub unsafe extern "C" fn client_exit_message() -> *const c_char {
+pub unsafe fn client_exit_message() -> *const c_char {
     type msgbuf = [c_char; 256];
     static mut msg: msgbuf = [0; 256];
 
@@ -241,7 +241,7 @@ pub unsafe extern "C" fn client_exit_message() -> *const c_char {
     }
 }
 
-unsafe extern "C" fn client_exit() {
+unsafe fn client_exit() {
     unsafe {
         if file_write_left(&raw mut client_files) == 0 {
             proc_exit(client_proc);
@@ -497,7 +497,7 @@ pub unsafe extern "C-unwind" fn client_main(
     }
 }
 
-unsafe extern "C" fn client_send_identify(
+unsafe fn client_send_identify(
     ttynam: *const c_char,
     termname: *const c_char,
     caps: *mut *mut c_char,
@@ -611,7 +611,7 @@ unsafe extern "C" fn client_send_identify(
 }
 
 #[expect(clippy::deref_addrof)]
-unsafe extern "C" fn client_exec(shell: *mut c_char, shellcmd: *mut c_char) {
+unsafe fn client_exec(shell: *mut c_char, shellcmd: *mut c_char) {
     unsafe {
         log_debug!("shell {}, command {}", _s(shell), _s(shellcmd));
         let argv0 = shell_argv0(
@@ -632,7 +632,7 @@ unsafe extern "C" fn client_exec(shell: *mut c_char, shellcmd: *mut c_char) {
     }
 }
 
-unsafe extern "C" fn client_signal(sig: i32) {
+unsafe fn client_signal(sig: i32) {
     unsafe {
         let mut sigact: sigaction = zeroed();
         let mut status: i32 = 0;
@@ -690,7 +690,7 @@ unsafe extern "C" fn client_signal(sig: i32) {
     }
 }
 
-unsafe extern "C" fn client_file_check_cb(
+unsafe fn client_file_check_cb(
     _c: *mut client,
     _path: *mut c_char,
     _error: i32,
@@ -705,7 +705,7 @@ unsafe extern "C" fn client_file_check_cb(
     }
 }
 
-unsafe extern "C" fn client_dispatch(imsg: *mut imsg, _arg: *mut c_void) {
+unsafe fn client_dispatch(imsg: *mut imsg, _arg: *mut c_void) {
     unsafe {
         if imsg.is_null() {
             if client_exitflag == 0 {
@@ -724,7 +724,7 @@ unsafe extern "C" fn client_dispatch(imsg: *mut imsg, _arg: *mut c_void) {
     }
 }
 
-unsafe extern "C" fn client_dispatch_exit_message(mut data: *const c_char, mut datalen: usize) {
+unsafe fn client_dispatch_exit_message(mut data: *const c_char, mut datalen: usize) {
     unsafe {
         let mut retval = 0;
         const size_of_retval: usize = size_of::<i32>();
@@ -752,7 +752,7 @@ unsafe extern "C" fn client_dispatch_exit_message(mut data: *const c_char, mut d
 }
 
 #[expect(clippy::deref_addrof)]
-unsafe extern "C" fn client_dispatch_wait(imsg: *mut imsg) {
+unsafe fn client_dispatch_wait(imsg: *mut imsg) {
     static mut pledge_applied: i32 = 0;
 
     unsafe {
@@ -859,7 +859,7 @@ unsafe extern "C" fn client_dispatch_wait(imsg: *mut imsg) {
 }
 
 #[expect(clippy::deref_addrof)]
-unsafe extern "C" fn client_dispatch_attached(imsg: *mut imsg) {
+unsafe fn client_dispatch_attached(imsg: *mut imsg) {
     unsafe {
         let mut sigact: sigaction = zeroed();
         let data: *mut c_char = (*imsg).data as _;

--- a/src/cmd_/cmd_attach_session.rs
+++ b/src/cmd_/cmd_attach_session.rs
@@ -28,7 +28,7 @@ pub static mut cmd_attach_session_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-pub unsafe extern "C" fn cmd_attach_session(
+pub unsafe fn cmd_attach_session(
     item: *mut cmdq_item,
     tflag: *const c_char,
     dflag: c_int,
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn cmd_attach_session(
     }
 }
 
-unsafe extern "C" fn cmd_attach_session_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_attach_session_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
 

--- a/src/cmd_/cmd_bind_key.rs
+++ b/src/cmd_/cmd_bind_key.rs
@@ -26,7 +26,7 @@ pub static mut cmd_bind_key_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_bind_key_args_parse(
+unsafe fn cmd_bind_key_args_parse(
     _args: *mut args,
     _idx: u32,
     _cause: *mut *mut c_char,
@@ -34,7 +34,7 @@ unsafe extern "C" fn cmd_bind_key_args_parse(
     args_parse_type::ARGS_PARSE_COMMANDS_OR_STRING
 }
 
-unsafe extern "C" fn cmd_bind_key_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_bind_key_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args: *mut args = cmd_get_args(self_);
         let note = args_get(args, b'N');

--- a/src/cmd_/cmd_break_pane.rs
+++ b/src/cmd_/cmd_break_pane.rs
@@ -30,7 +30,7 @@ pub static mut cmd_break_pane_entry: cmd_entry = cmd_entry {
     exec: Some(cmd_break_pane_exec),
 };
 
-pub unsafe extern "C" fn cmd_break_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+pub unsafe fn cmd_break_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let current = cmdq_get_current(item);

--- a/src/cmd_/cmd_capture_pane.rs
+++ b/src/cmd_/cmd_capture_pane.rs
@@ -48,7 +48,7 @@ pub static mut cmd_clear_history_entry: cmd_entry = cmd_entry {
     exec: Some(cmd_capture_pane_exec),
 };
 
-unsafe extern "C" fn cmd_capture_pane_append(
+unsafe fn cmd_capture_pane_append(
     mut buf: *mut c_char,
     len: *mut usize,
     line: *mut c_char,
@@ -62,7 +62,7 @@ unsafe extern "C" fn cmd_capture_pane_append(
     }
 }
 
-unsafe extern "C" fn cmd_capture_pane_pending(
+unsafe fn cmd_capture_pane_pending(
     args: *mut args,
     wp: *const window_pane,
     len: *mut usize,
@@ -102,7 +102,7 @@ unsafe extern "C" fn cmd_capture_pane_pending(
     }
 }
 
-unsafe extern "C" fn cmd_capture_pane_history(
+unsafe fn cmd_capture_pane_history(
     args: *mut args,
     item: *mut cmdq_item,
     wp: *mut window_pane,
@@ -228,7 +228,7 @@ unsafe extern "C" fn cmd_capture_pane_history(
     }
 }
 
-unsafe extern "C" fn cmd_capture_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_capture_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let c = cmdq_get_client(item);

--- a/src/cmd_/cmd_choose_tree.rs
+++ b/src/cmd_/cmd_choose_tree.rs
@@ -70,7 +70,7 @@ pub static mut cmd_customize_mode_entry: cmd_entry = cmd_entry {
     exec: Some(cmd_choose_tree_exec),
 };
 
-unsafe extern "C" fn cmd_choose_tree_args_parse(
+unsafe fn cmd_choose_tree_args_parse(
     _args: *mut args,
     _idx: u32,
     _cause: *mut *mut c_char,
@@ -78,7 +78,7 @@ unsafe extern "C" fn cmd_choose_tree_args_parse(
     args_parse_type::ARGS_PARSE_COMMANDS_OR_STRING
 }
 
-unsafe extern "C" fn cmd_choose_tree_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_choose_tree_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_command_prompt.rs
+++ b/src/cmd_/cmd_command_prompt.rs
@@ -45,7 +45,7 @@ struct cmd_command_prompt_cdata<'a> {
     argv: *mut *mut c_char,
 }
 
-unsafe extern "C" fn cmd_command_prompt_args_parse(
+unsafe fn cmd_command_prompt_args_parse(
     _args: *mut args,
     _idx: u32,
     _cause: *mut *mut c_char,
@@ -53,7 +53,7 @@ unsafe extern "C" fn cmd_command_prompt_args_parse(
     args_parse_type::ARGS_PARSE_COMMANDS_OR_STRING
 }
 
-unsafe extern "C" fn cmd_command_prompt_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_command_prompt_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let tc = cmdq_get_target_client(item);
@@ -180,7 +180,7 @@ unsafe extern "C" fn cmd_command_prompt_exec(self_: *mut cmd, item: *mut cmdq_it
     }
 }
 
-unsafe extern "C" fn cmd_command_prompt_callback(
+unsafe fn cmd_command_prompt_callback(
     c: *mut client,
     data: NonNull<c_void>,
     s: *const c_char,
@@ -257,7 +257,7 @@ unsafe extern "C" fn cmd_command_prompt_callback(
     }
 }
 
-unsafe extern "C" fn cmd_command_prompt_free(data: NonNull<c_void>) {
+unsafe fn cmd_command_prompt_free(data: NonNull<c_void>) {
     unsafe {
         let cdata: NonNull<cmd_command_prompt_cdata> = data.cast();
 

--- a/src/cmd_/cmd_confirm_before.rs
+++ b/src/cmd_/cmd_confirm_before.rs
@@ -32,7 +32,7 @@ pub struct cmd_confirm_before_data {
     default_yes: i32,
 }
 
-unsafe extern "C" fn cmd_confirm_before_args_parse(
+unsafe fn cmd_confirm_before_args_parse(
     _: *mut args,
     _: u32,
     _: *mut *mut c_char,
@@ -40,7 +40,7 @@ unsafe extern "C" fn cmd_confirm_before_args_parse(
     args_parse_type::ARGS_PARSE_COMMANDS_OR_STRING
 }
 
-unsafe extern "C" fn cmd_confirm_before_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_confirm_before_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let tc = cmdq_get_target_client(item);
@@ -105,7 +105,7 @@ unsafe extern "C" fn cmd_confirm_before_exec(self_: *mut cmd, item: *mut cmdq_it
     }
 }
 
-unsafe extern "C" fn cmd_confirm_before_callback(
+unsafe fn cmd_confirm_before_callback(
     c: *mut client,
     data: NonNull<c_void>,
     s: *const c_char,
@@ -152,7 +152,7 @@ unsafe extern "C" fn cmd_confirm_before_callback(
     }
 }
 
-unsafe extern "C" fn cmd_confirm_before_free(data: NonNull<c_void>) {
+unsafe fn cmd_confirm_before_free(data: NonNull<c_void>) {
     unsafe {
         let cdata: NonNull<cmd_confirm_before_data> = data.cast();
         cmd_list_free((*cdata.as_ptr()).cmdlist);

--- a/src/cmd_/cmd_copy_mode.rs
+++ b/src/cmd_/cmd_copy_mode.rs
@@ -42,7 +42,7 @@ pub static mut cmd_clock_mode_entry: cmd_entry = cmd_entry {
     exec: Some(cmd_copy_mode_exec),
 };
 
-unsafe extern "C" fn cmd_copy_mode_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_copy_mode_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let event = cmdq_get_event(item);

--- a/src/cmd_/cmd_detach_client.rs
+++ b/src/cmd_/cmd_detach_client.rs
@@ -41,7 +41,7 @@ pub static mut cmd_suspend_client_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-pub unsafe extern "C" fn cmd_detach_client_exec(
+pub unsafe fn cmd_detach_client_exec(
     self_: *mut cmd,
     item: *mut cmdq_item,
 ) -> cmd_retval {

--- a/src/cmd_/cmd_display_menu.rs
+++ b/src/cmd_/cmd_display_menu.rs
@@ -44,7 +44,7 @@ pub static mut cmd_display_popup_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_display_menu_args_parse(
+unsafe fn cmd_display_menu_args_parse(
     args: *mut args,
     idx: u32,
     cause: *mut *mut c_char,
@@ -81,7 +81,7 @@ unsafe extern "C" fn cmd_display_menu_args_parse(
     type_
 }
 
-unsafe extern "C" fn cmd_display_menu_get_position(
+unsafe fn cmd_display_menu_get_position(
     tc: *mut client,
     item: *mut cmdq_item,
     args: *mut args,
@@ -340,7 +340,7 @@ unsafe extern "C" fn cmd_display_menu_get_position(
     }
 }
 
-unsafe extern "C" fn cmd_display_menu_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_display_menu_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);
@@ -477,7 +477,7 @@ unsafe extern "C" fn cmd_display_menu_exec(self_: *mut cmd, item: *mut cmdq_item
     }
 }
 
-unsafe extern "C" fn cmd_display_popup_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_display_popup_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_display_message.rs
+++ b/src/cmd_/cmd_display_message.rs
@@ -33,7 +33,7 @@ pub static mut cmd_display_message_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_display_message_each(
+unsafe fn cmd_display_message_each(
     key: *const c_char,
     value: *const c_char,
     arg: *mut c_void,
@@ -45,7 +45,7 @@ unsafe extern "C" fn cmd_display_message_each(
     }
 }
 
-unsafe extern "C" fn cmd_display_message_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_display_message_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_display_panes.rs
+++ b/src/cmd_/cmd_display_panes.rs
@@ -33,7 +33,7 @@ pub struct cmd_display_panes_data<'a> {
     pub state: *mut args_command_state<'a>,
 }
 
-unsafe extern "C" fn cmd_display_panes_args_parse(
+unsafe fn cmd_display_panes_args_parse(
     _: *mut args,
     _: u32,
     _: *mut *mut c_char,
@@ -41,7 +41,7 @@ unsafe extern "C" fn cmd_display_panes_args_parse(
     args_parse_type::ARGS_PARSE_COMMANDS_OR_STRING
 }
 
-unsafe extern "C" fn cmd_display_panes_draw_pane(
+unsafe fn cmd_display_panes_draw_pane(
     ctx: *mut screen_redraw_ctx,
     wp: *mut window_pane,
 ) {
@@ -234,7 +234,7 @@ unsafe extern "C" fn cmd_display_panes_draw_pane(
     }
 }
 
-unsafe extern "C" fn cmd_display_panes_draw(
+unsafe fn cmd_display_panes_draw(
     c: *mut client,
     data: *mut c_void,
     ctx: *mut screen_redraw_ctx,
@@ -257,7 +257,7 @@ unsafe extern "C" fn cmd_display_panes_draw(
     }
 }
 
-unsafe extern "C" fn cmd_display_panes_free(c: *mut client, data: *mut c_void) {
+unsafe fn cmd_display_panes_free(c: *mut client, data: *mut c_void) {
     unsafe {
         let cdata = data as *mut cmd_display_panes_data;
 
@@ -269,7 +269,7 @@ unsafe extern "C" fn cmd_display_panes_free(c: *mut client, data: *mut c_void) {
     }
 }
 
-unsafe extern "C" fn cmd_display_panes_key(
+unsafe fn cmd_display_panes_key(
     c: *mut client,
     data: *mut c_void,
     event: *mut key_event,
@@ -325,7 +325,7 @@ unsafe extern "C" fn cmd_display_panes_key(
     }
 }
 
-unsafe extern "C" fn cmd_display_panes_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_display_panes_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let tc = cmdq_get_target_client(item);

--- a/src/cmd_/cmd_find.rs
+++ b/src/cmd_/cmd_find.rs
@@ -51,7 +51,7 @@ static mut cmd_find_pane_table: [[*const c_char; 2]; 16] = [
     [null(), null()],
 ];
 
-pub unsafe extern "C" fn cmd_find_inside_pane(c: *mut client) -> *mut window_pane {
+pub unsafe fn cmd_find_inside_pane(c: *mut client) -> *mut window_pane {
     let __func__ = "cmd_find_inside_pane";
     unsafe {
         if c.is_null() {
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn cmd_find_inside_pane(c: *mut client) -> *mut window_pan
     }
 }
 
-pub unsafe extern "C" fn cmd_find_client_better(c: *mut client, than: *mut client) -> i32 {
+pub unsafe fn cmd_find_client_better(c: *mut client, than: *mut client) -> i32 {
     if than.is_null() {
         return 1;
     }
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn cmd_find_client_better(c: *mut client, than: *mut clien
     }
 }
 
-pub unsafe extern "C" fn cmd_find_best_client(mut s: *mut session) -> *mut client {
+pub unsafe fn cmd_find_best_client(mut s: *mut session) -> *mut client {
     unsafe {
         if (*s).attached == 0 {
             s = null_mut();
@@ -117,7 +117,7 @@ pub unsafe extern "C" fn cmd_find_best_client(mut s: *mut session) -> *mut clien
     }
 }
 
-pub unsafe extern "C" fn cmd_find_session_better(
+pub unsafe fn cmd_find_session_better(
     s: *mut session,
     than: *mut session,
     flags: i32,
@@ -140,7 +140,7 @@ pub unsafe extern "C" fn cmd_find_session_better(
     }
 }
 
-pub unsafe extern "C" fn cmd_find_best_session(
+pub unsafe fn cmd_find_best_session(
     slist: *mut *mut session,
     ssize: u32,
     flags: i32,
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn cmd_find_best_session(
     }
 }
 
-pub unsafe extern "C" fn cmd_find_best_session_with_window(fs: *mut cmd_find_state) -> i32 {
+pub unsafe fn cmd_find_best_session_with_window(fs: *mut cmd_find_state) -> i32 {
     let __func__ = "cmd_find_best_session_with_window";
     unsafe {
         let mut slist: *mut *mut session = null_mut();
@@ -200,7 +200,7 @@ pub unsafe extern "C" fn cmd_find_best_session_with_window(fs: *mut cmd_find_sta
     }
 }
 
-pub unsafe extern "C" fn cmd_find_best_winlink_with_window(fs: *mut cmd_find_state) -> i32 {
+pub unsafe fn cmd_find_best_winlink_with_window(fs: *mut cmd_find_state) -> i32 {
     let __func__ = "cmd_find_best_winlink_with_window";
     unsafe {
         log_debug!("{}: window is @{}", __func__, (*(*fs).w).id);
@@ -225,7 +225,7 @@ pub unsafe extern "C" fn cmd_find_best_winlink_with_window(fs: *mut cmd_find_sta
     0
 }
 
-pub unsafe extern "C" fn cmd_find_map_table(
+pub unsafe fn cmd_find_map_table(
     table: *const [*const c_char; 2],
     s: *const c_char,
 ) -> *const c_char {
@@ -241,7 +241,7 @@ pub unsafe extern "C" fn cmd_find_map_table(
     }
 }
 
-pub unsafe extern "C" fn cmd_find_get_session(
+pub unsafe fn cmd_find_get_session(
     fs: *mut cmd_find_state,
     session: *const c_char,
 ) -> i32 {
@@ -303,7 +303,7 @@ pub unsafe extern "C" fn cmd_find_get_session(
     -1
 }
 
-pub unsafe extern "C" fn cmd_find_get_window(
+pub unsafe fn cmd_find_get_window(
     fs: *mut cmd_find_state,
     window: *const c_char,
     only: i32,
@@ -338,7 +338,7 @@ pub unsafe extern "C" fn cmd_find_get_window(
     -1
 }
 
-pub unsafe extern "C" fn cmd_find_get_window_with_session(
+pub unsafe fn cmd_find_get_window_with_session(
     fs: *mut cmd_find_state,
     window: *const c_char,
 ) -> i32 {
@@ -494,7 +494,7 @@ pub unsafe extern "C" fn cmd_find_get_window_with_session(
     -1
 }
 
-pub unsafe extern "C" fn cmd_find_get_pane(
+pub unsafe fn cmd_find_get_pane(
     fs: *mut cmd_find_state,
     pane: *const c_char,
     only: i32,
@@ -529,7 +529,7 @@ pub unsafe extern "C" fn cmd_find_get_pane(
     -1
 }
 
-pub unsafe extern "C" fn cmd_find_get_pane_with_session(
+pub unsafe fn cmd_find_get_pane_with_session(
     fs: *mut cmd_find_state,
     pane: *const c_char,
 ) -> i32 {
@@ -554,7 +554,7 @@ pub unsafe extern "C" fn cmd_find_get_pane_with_session(
     }
 }
 
-pub unsafe extern "C" fn cmd_find_get_pane_with_window(
+pub unsafe fn cmd_find_get_pane_with_window(
     fs: *mut cmd_find_state,
     pane: *const c_char,
 ) -> i32 {
@@ -640,7 +640,7 @@ pub unsafe extern "C" fn cmd_find_get_pane_with_window(
     -1
 }
 
-pub unsafe extern "C" fn cmd_find_clear_state(fs: *mut cmd_find_state, flags: i32) {
+pub unsafe fn cmd_find_clear_state(fs: *mut cmd_find_state, flags: i32) {
     unsafe {
         memset0(fs);
 
@@ -650,13 +650,13 @@ pub unsafe extern "C" fn cmd_find_clear_state(fs: *mut cmd_find_state, flags: i3
     }
 }
 
-pub unsafe extern "C" fn cmd_find_empty_state(fs: *mut cmd_find_state) -> i32 {
+pub unsafe fn cmd_find_empty_state(fs: *mut cmd_find_state) -> i32 {
     unsafe {
         ((*fs).s.is_null() && (*fs).wl.is_null() && (*fs).w.is_null() && (*fs).wp.is_null()) as i32
     }
 }
 
-pub unsafe extern "C" fn cmd_find_valid_state(fs: *const cmd_find_state) -> bool {
+pub unsafe fn cmd_find_valid_state(fs: *const cmd_find_state) -> bool {
     unsafe {
         if (*fs).s.is_null() || (*fs).wl.is_null() || (*fs).w.is_null() || (*fs).wp.is_null() {
             return false;
@@ -686,7 +686,7 @@ pub unsafe extern "C" fn cmd_find_valid_state(fs: *const cmd_find_state) -> bool
     }
 }
 
-pub unsafe extern "C" fn cmd_find_copy_state(dst: *mut cmd_find_state, src: *mut cmd_find_state) {
+pub unsafe fn cmd_find_copy_state(dst: *mut cmd_find_state, src: *mut cmd_find_state) {
     unsafe {
         (*dst).s = (*src).s;
         (*dst).wl = (*src).wl;
@@ -696,7 +696,7 @@ pub unsafe extern "C" fn cmd_find_copy_state(dst: *mut cmd_find_state, src: *mut
     }
 }
 
-pub unsafe extern "C" fn cmd_find_log_state(prefix: *const c_char, fs: *const cmd_find_state) {
+pub unsafe fn cmd_find_log_state(prefix: *const c_char, fs: *const cmd_find_state) {
     unsafe {
         if !(*fs).s.is_null() {
             log_debug!(
@@ -726,7 +726,7 @@ pub unsafe extern "C" fn cmd_find_log_state(prefix: *const c_char, fs: *const cm
     }
 }
 
-pub unsafe extern "C" fn cmd_find_from_session(
+pub unsafe fn cmd_find_from_session(
     fs: *mut cmd_find_state,
     s: *mut session,
     flags: i32,
@@ -743,7 +743,7 @@ pub unsafe extern "C" fn cmd_find_from_session(
     }
 }
 
-pub unsafe extern "C" fn cmd_find_from_winlink(
+pub unsafe fn cmd_find_from_winlink(
     fs: *mut cmd_find_state,
     wl: *mut winlink,
     flags: i32,
@@ -760,7 +760,7 @@ pub unsafe extern "C" fn cmd_find_from_winlink(
     }
 }
 
-pub unsafe extern "C" fn cmd_find_from_session_window(
+pub unsafe fn cmd_find_from_session_window(
     fs: *mut cmd_find_state,
     s: *mut session,
     w: *mut window,
@@ -782,7 +782,7 @@ pub unsafe extern "C" fn cmd_find_from_session_window(
     0
 }
 
-pub unsafe extern "C" fn cmd_find_from_window(
+pub unsafe fn cmd_find_from_window(
     fs: *mut cmd_find_state,
     w: *mut window,
     flags: i32,
@@ -806,7 +806,7 @@ pub unsafe extern "C" fn cmd_find_from_window(
     }
 }
 
-pub unsafe extern "C" fn cmd_find_from_winlink_pane(
+pub unsafe fn cmd_find_from_winlink_pane(
     fs: *mut cmd_find_state,
     wl: *mut winlink,
     wp: *mut window_pane,
@@ -825,7 +825,7 @@ pub unsafe extern "C" fn cmd_find_from_winlink_pane(
     }
 }
 
-pub unsafe extern "C" fn cmd_find_from_pane(
+pub unsafe fn cmd_find_from_pane(
     fs: *mut cmd_find_state,
     wp: *mut window_pane,
     flags: i32,
@@ -842,7 +842,7 @@ pub unsafe extern "C" fn cmd_find_from_pane(
     0
 }
 
-pub unsafe extern "C" fn cmd_find_from_nothing(fs: *mut cmd_find_state, flags: i32) -> i32 {
+pub unsafe fn cmd_find_from_nothing(fs: *mut cmd_find_state, flags: i32) -> i32 {
     unsafe {
         cmd_find_clear_state(fs, flags);
 
@@ -861,7 +861,7 @@ pub unsafe extern "C" fn cmd_find_from_nothing(fs: *mut cmd_find_state, flags: i
     0
 }
 
-pub unsafe extern "C" fn cmd_find_from_mouse(
+pub unsafe fn cmd_find_from_mouse(
     fs: *mut cmd_find_state,
     m: *mut mouse_event,
     flags: i32,
@@ -885,7 +885,7 @@ pub unsafe extern "C" fn cmd_find_from_mouse(
     0
 }
 
-pub unsafe extern "C" fn cmd_find_from_client(
+pub unsafe fn cmd_find_from_client(
     fs: *mut cmd_find_state,
     c: *mut client,
     flags: i32,
@@ -937,7 +937,7 @@ pub unsafe extern "C" fn cmd_find_from_client(
     }
 }
 
-pub unsafe extern "C" fn cmd_find_target(
+pub unsafe fn cmd_find_target(
     fs: *mut cmd_find_state,
     item: *mut cmdq_item,
     target: *const c_char,
@@ -1359,7 +1359,7 @@ pub unsafe extern "C" fn cmd_find_target(
     }
 }
 
-pub unsafe extern "C" fn cmd_find_current_client(item: *mut cmdq_item, quiet: i32) -> *mut client {
+pub unsafe fn cmd_find_current_client(item: *mut cmdq_item, quiet: i32) -> *mut client {
     let __func__ = "cmd_find_current_client";
     unsafe {
         let mut c: *mut client = null_mut();
@@ -1401,7 +1401,7 @@ pub unsafe extern "C" fn cmd_find_current_client(item: *mut cmdq_item, quiet: i3
     }
 }
 
-pub unsafe extern "C" fn cmd_find_client(
+pub unsafe fn cmd_find_client(
     item: *mut cmdq_item,
     target: *const c_char,
     quiet: i32,

--- a/src/cmd_/cmd_find_window.rs
+++ b/src/cmd_/cmd_find_window.rs
@@ -28,7 +28,7 @@ pub static mut cmd_find_window_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_find_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_find_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_if_shell.rs
+++ b/src/cmd_/cmd_if_shell.rs
@@ -40,7 +40,7 @@ pub struct cmd_if_shell_data<'a> {
     pub item: *mut cmdq_item,
 }
 
-unsafe extern "C" fn cmd_if_shell_args_parse(
+unsafe fn cmd_if_shell_args_parse(
     _: *mut args,
     idx: u32,
     _: *mut *mut c_char,
@@ -52,7 +52,7 @@ unsafe extern "C" fn cmd_if_shell_args_parse(
     }
 }
 
-unsafe extern "C" fn cmd_if_shell_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_if_shell_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);
@@ -128,7 +128,7 @@ unsafe extern "C" fn cmd_if_shell_exec(self_: *mut cmd, item: *mut cmdq_item) ->
     }
 }
 
-unsafe extern "C" fn cmd_if_shell_callback(job: *mut job) {
+unsafe fn cmd_if_shell_callback(job: *mut job) {
     unsafe {
         let cdata = job_get_data(job) as *mut cmd_if_shell_data;
         let c = (*cdata).client;
@@ -173,7 +173,7 @@ unsafe extern "C" fn cmd_if_shell_callback(job: *mut job) {
     }
 }
 
-unsafe extern "C" fn cmd_if_shell_free(data: *mut c_void) {
+unsafe fn cmd_if_shell_free(data: *mut c_void) {
     unsafe {
         let cdata = data as *mut cmd_if_shell_data;
 

--- a/src/cmd_/cmd_join_pane.rs
+++ b/src/cmd_/cmd_join_pane.rs
@@ -45,7 +45,7 @@ pub static mut cmd_move_pane_entry: cmd_entry = cmd_entry {
     exec: Some(cmd_join_pane_exec),
 };
 
-unsafe extern "C" fn cmd_join_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_join_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let current = cmdq_get_current(item);

--- a/src/cmd_/cmd_kill_pane.rs
+++ b/src/cmd_/cmd_kill_pane.rs
@@ -28,7 +28,7 @@ pub static mut cmd_kill_pane_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_kill_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_kill_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_kill_server.rs
+++ b/src/cmd_/cmd_kill_server.rs
@@ -40,7 +40,7 @@ pub static mut cmd_start_server_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_kill_server_exec(self_: *mut cmd, _: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_kill_server_exec(self_: *mut cmd, _: *mut cmdq_item) -> cmd_retval {
     unsafe {
         if cmd_get_entry(self_) == &raw mut cmd_kill_server_entry {
             kill(std::process::id() as pid_t, SIGTERM);

--- a/src/cmd_/cmd_kill_session.rs
+++ b/src/cmd_/cmd_kill_session.rs
@@ -29,7 +29,7 @@ pub static mut cmd_kill_session_entry: cmd_entry = cmd_entry {
     exec: Some(cmd_kill_session_exec),
 };
 
-unsafe extern "C" fn cmd_kill_session_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_kill_session_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_kill_window.rs
+++ b/src/cmd_/cmd_kill_window.rs
@@ -44,7 +44,7 @@ pub static mut cmd_unlink_window_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_kill_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_kill_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_list_buffers.rs
+++ b/src/cmd_/cmd_list_buffers.rs
@@ -26,7 +26,7 @@ pub static mut cmd_list_buffers_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_list_buffers_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_list_buffers_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let mut flag = 0;

--- a/src/cmd_/cmd_list_clients.rs
+++ b/src/cmd_/cmd_list_clients.rs
@@ -32,7 +32,7 @@ pub static mut cmd_list_clients_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_list_clients_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_list_clients_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_list_keys.rs
+++ b/src/cmd_/cmd_list_keys.rs
@@ -40,7 +40,7 @@ pub static mut cmd_list_commands_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_list_keys_get_width(tablename: *const c_char, only: key_code) -> u32 {
+unsafe fn cmd_list_keys_get_width(tablename: *const c_char, only: key_code) -> u32 {
     unsafe {
         let mut keywidth = 0u32;
 
@@ -69,7 +69,7 @@ unsafe extern "C" fn cmd_list_keys_get_width(tablename: *const c_char, only: key
     }
 }
 
-unsafe extern "C" fn cmd_list_keys_print_notes(
+unsafe fn cmd_list_keys_print_notes(
     item: *mut cmdq_item,
     args: *mut args,
     tablename: *const c_char,
@@ -122,7 +122,7 @@ unsafe extern "C" fn cmd_list_keys_print_notes(
     }
 }
 
-unsafe extern "C" fn cmd_list_keys_get_prefix(
+unsafe fn cmd_list_keys_get_prefix(
     args: *mut args,
     prefix: *mut key_code,
 ) -> NonNull<c_char> {
@@ -141,7 +141,7 @@ unsafe extern "C" fn cmd_list_keys_get_prefix(
     }
 }
 
-unsafe extern "C" fn cmd_list_keys_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_list_keys_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let tc = cmdq_get_target_client(item);
@@ -349,7 +349,7 @@ unsafe extern "C" fn cmd_list_keys_exec(self_: *mut cmd, item: *mut cmdq_item) -
     }
 }
 
-unsafe extern "C" fn cmd_list_keys_commands(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_list_keys_commands(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         //const struct cmd_entry **entryp;

--- a/src/cmd_/cmd_list_panes.rs
+++ b/src/cmd_/cmd_list_panes.rs
@@ -29,7 +29,7 @@ pub static mut cmd_list_panes_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_list_panes_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_list_panes_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);
@@ -48,7 +48,7 @@ unsafe extern "C" fn cmd_list_panes_exec(self_: *mut cmd, item: *mut cmdq_item) 
     }
 }
 
-unsafe extern "C" fn cmd_list_panes_server(self_: *mut cmd, item: *mut cmdq_item) {
+unsafe fn cmd_list_panes_server(self_: *mut cmd, item: *mut cmdq_item) {
     unsafe {
         for s in rb_foreach(&raw mut sessions).map(NonNull::as_ptr) {
             cmd_list_panes_session(self_, s, item, 2);
@@ -56,7 +56,7 @@ unsafe extern "C" fn cmd_list_panes_server(self_: *mut cmd, item: *mut cmdq_item
     }
 }
 
-unsafe extern "C" fn cmd_list_panes_session(
+unsafe fn cmd_list_panes_session(
     self_: *mut cmd,
     s: *mut session,
     item: *mut cmdq_item,

--- a/src/cmd_/cmd_list_sessions.rs
+++ b/src/cmd_/cmd_list_sessions.rs
@@ -29,7 +29,7 @@ pub static mut cmd_list_sessions_entry: cmd_entry = cmd_entry {
 
 const LIST_SESSIONS_TEMPLATE: *const i8 = c"#{session_name}: #{session_windows} windows (created #{t:session_created})#{?session_grouped, (group ,}#{session_group}#{?session_grouped,),}#{?session_attached, (attached),}".as_ptr();
 
-unsafe extern "C" fn cmd_list_sessions_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_list_sessions_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
 

--- a/src/cmd_/cmd_list_windows.rs
+++ b/src/cmd_/cmd_list_windows.rs
@@ -32,7 +32,7 @@ pub static mut cmd_list_windows_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_list_windows_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_list_windows_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);
@@ -47,7 +47,7 @@ unsafe extern "C" fn cmd_list_windows_exec(self_: *mut cmd, item: *mut cmdq_item
     }
 }
 
-unsafe extern "C" fn cmd_list_windows_server(self_: *mut cmd, item: *mut cmdq_item) {
+unsafe fn cmd_list_windows_server(self_: *mut cmd, item: *mut cmdq_item) {
     unsafe {
         for s in rb_foreach(&raw mut sessions) {
             cmd_list_windows_session(self_, s, item, 1);
@@ -55,7 +55,7 @@ unsafe extern "C" fn cmd_list_windows_server(self_: *mut cmd, item: *mut cmdq_it
     }
 }
 
-unsafe extern "C" fn cmd_list_windows_session(
+unsafe fn cmd_list_windows_session(
     self_: *mut cmd,
     s: NonNull<session>,
     item: *mut cmdq_item,

--- a/src/cmd_/cmd_load_buffer.rs
+++ b/src/cmd_/cmd_load_buffer.rs
@@ -34,7 +34,7 @@ pub struct cmd_load_buffer_data {
     pub name: *mut c_char,
 }
 
-unsafe extern "C" fn cmd_load_buffer_done(
+unsafe fn cmd_load_buffer_done(
     _c: *mut client,
     path: *mut c_char,
     error: i32,
@@ -80,7 +80,7 @@ unsafe extern "C" fn cmd_load_buffer_done(
     }
 }
 
-unsafe extern "C" fn cmd_load_buffer_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_load_buffer_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let tc = cmdq_get_target_client(item);

--- a/src/cmd_/cmd_lock_server.rs
+++ b/src/cmd_/cmd_lock_server.rs
@@ -51,7 +51,7 @@ pub static mut cmd_lock_client_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_lock_server_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_lock_server_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let target = cmdq_get_target(item);
         let tc = cmdq_get_target_client(item);

--- a/src/cmd_/cmd_move_window.rs
+++ b/src/cmd_/cmd_move_window.rs
@@ -41,7 +41,7 @@ pub static mut cmd_link_window_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_move_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_move_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let source = cmdq_get_source(item);

--- a/src/cmd_/cmd_new_session.rs
+++ b/src/cmd_/cmd_new_session.rs
@@ -48,7 +48,7 @@ pub static mut cmd_has_session_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_new_session_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_new_session_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     let __func__ = c"cmd_new_session_exec".as_ptr();
 
     unsafe {

--- a/src/cmd_/cmd_new_window.rs
+++ b/src/cmd_/cmd_new_window.rs
@@ -31,7 +31,7 @@ pub static mut cmd_new_window_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_new_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_new_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let c = cmdq_get_client(item);

--- a/src/cmd_/cmd_paste_buffer.rs
+++ b/src/cmd_/cmd_paste_buffer.rs
@@ -27,7 +27,7 @@ pub static mut cmd_paste_buffer_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_paste_buffer_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_paste_buffer_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_pipe_pane.rs
+++ b/src/cmd_/cmd_pipe_pane.rs
@@ -35,7 +35,7 @@ pub static mut cmd_pipe_pane_entry: cmd_entry = cmd_entry {
     exec: Some(cmd_pipe_pane_exec),
 };
 
-pub unsafe extern "C" fn cmd_pipe_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+pub unsafe fn cmd_pipe_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);
@@ -202,7 +202,7 @@ pub unsafe extern "C" fn cmd_pipe_pane_exec(self_: *mut cmd, item: *mut cmdq_ite
     }
 }
 
-pub unsafe extern "C" fn cmd_pipe_pane_read_callback(_bufev: *mut bufferevent, data: *mut c_void) {
+pub unsafe fn cmd_pipe_pane_read_callback(_bufev: *mut bufferevent, data: *mut c_void) {
     unsafe {
         let wp: *mut window_pane = data as *mut window_pane;
         let evb = (*(*wp).pipe_event).input;
@@ -219,7 +219,7 @@ pub unsafe extern "C" fn cmd_pipe_pane_read_callback(_bufev: *mut bufferevent, d
     }
 }
 
-pub unsafe extern "C" fn cmd_pipe_pane_write_callback(_bufev: *mut bufferevent, data: *mut c_void) {
+pub unsafe fn cmd_pipe_pane_write_callback(_bufev: *mut bufferevent, data: *mut c_void) {
     unsafe {
         let wp: *mut window_pane = data as *mut window_pane;
 
@@ -231,7 +231,7 @@ pub unsafe extern "C" fn cmd_pipe_pane_write_callback(_bufev: *mut bufferevent, 
     }
 }
 
-pub unsafe extern "C" fn cmd_pipe_pane_error_callback(
+pub unsafe fn cmd_pipe_pane_error_callback(
     _bufev: *mut bufferevent,
     _what: i16,
     data: *mut c_void,

--- a/src/cmd_/cmd_pipe_pane.rs
+++ b/src/cmd_/cmd_pipe_pane.rs
@@ -202,7 +202,7 @@ pub unsafe fn cmd_pipe_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_r
     }
 }
 
-pub unsafe fn cmd_pipe_pane_read_callback(_bufev: *mut bufferevent, data: *mut c_void) {
+pub unsafe extern "C" fn cmd_pipe_pane_read_callback(_bufev: *mut bufferevent, data: *mut c_void) {
     unsafe {
         let wp: *mut window_pane = data as *mut window_pane;
         let evb = (*(*wp).pipe_event).input;
@@ -219,7 +219,7 @@ pub unsafe fn cmd_pipe_pane_read_callback(_bufev: *mut bufferevent, data: *mut c
     }
 }
 
-pub unsafe fn cmd_pipe_pane_write_callback(_bufev: *mut bufferevent, data: *mut c_void) {
+pub unsafe extern "C" fn cmd_pipe_pane_write_callback(_bufev: *mut bufferevent, data: *mut c_void) {
     unsafe {
         let wp: *mut window_pane = data as *mut window_pane;
 
@@ -231,7 +231,7 @@ pub unsafe fn cmd_pipe_pane_write_callback(_bufev: *mut bufferevent, data: *mut 
     }
 }
 
-pub unsafe fn cmd_pipe_pane_error_callback(
+pub unsafe extern "C" fn cmd_pipe_pane_error_callback(
     _bufev: *mut bufferevent,
     _what: i16,
     data: *mut c_void,

--- a/src/cmd_/cmd_queue.rs
+++ b/src/cmd_/cmd_queue.rs
@@ -94,7 +94,7 @@ pub struct cmdq_list {
     pub list: cmdq_item_list,
 }
 
-pub unsafe extern "C" fn cmdq_name(c: *const client) -> *const c_char {
+pub unsafe fn cmdq_name(c: *const client) -> *const c_char {
     static mut buf: [c_char; 256] = [0; 256];
     let s = &raw mut buf as *mut i8;
 
@@ -113,7 +113,7 @@ pub unsafe extern "C" fn cmdq_name(c: *const client) -> *const c_char {
     s
 }
 
-pub unsafe extern "C" fn cmdq_get(c: *mut client) -> *mut cmdq_list {
+pub unsafe fn cmdq_get(c: *mut client) -> *mut cmdq_list {
     static mut global_queue: *mut cmdq_list = null_mut();
 
     unsafe {
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn cmdq_get(c: *mut client) -> *mut cmdq_list {
     }
 }
 
-pub unsafe extern "C" fn cmdq_new() -> NonNull<cmdq_list> {
+pub unsafe fn cmdq_new() -> NonNull<cmdq_list> {
     unsafe {
         let queue = NonNull::from(xcalloc1::<cmdq_list>());
         tailq_init(&raw mut (*queue.as_ptr()).list);
@@ -136,7 +136,7 @@ pub unsafe extern "C" fn cmdq_new() -> NonNull<cmdq_list> {
     }
 }
 
-pub unsafe extern "C" fn cmdq_free(queue: *mut cmdq_list) {
+pub unsafe fn cmdq_free(queue: *mut cmdq_list) {
     unsafe {
         if !tailq_empty(&raw mut (*queue).list) {
             fatalx(c"queue not empty");
@@ -149,39 +149,39 @@ pub unsafe fn cmdq_get_name(item: *mut cmdq_item) -> *mut c_char {
     unsafe { (*item).name }
 }
 
-pub unsafe extern "C" fn cmdq_get_client(item: *mut cmdq_item) -> *mut client {
+pub unsafe fn cmdq_get_client(item: *mut cmdq_item) -> *mut client {
     unsafe { (*item).client }
 }
 
-pub unsafe extern "C" fn cmdq_get_target_client(item: *mut cmdq_item) -> *mut client {
+pub unsafe fn cmdq_get_target_client(item: *mut cmdq_item) -> *mut client {
     unsafe { (*item).target_client }
 }
 
-pub unsafe extern "C" fn cmdq_get_state(item: *mut cmdq_item) -> *mut cmdq_state {
+pub unsafe fn cmdq_get_state(item: *mut cmdq_item) -> *mut cmdq_state {
     unsafe { (*item).state }
 }
 
-pub unsafe extern "C" fn cmdq_get_target(item: *mut cmdq_item) -> *mut cmd_find_state {
+pub unsafe fn cmdq_get_target(item: *mut cmdq_item) -> *mut cmd_find_state {
     unsafe { &raw mut (*item).target }
 }
 
-pub unsafe extern "C" fn cmdq_get_source(item: *mut cmdq_item) -> *mut cmd_find_state {
+pub unsafe fn cmdq_get_source(item: *mut cmdq_item) -> *mut cmd_find_state {
     unsafe { &raw mut (*item).source }
 }
 
-pub unsafe extern "C" fn cmdq_get_event(item: *mut cmdq_item) -> *mut key_event {
+pub unsafe fn cmdq_get_event(item: *mut cmdq_item) -> *mut key_event {
     unsafe { &raw mut (*(*item).state).event }
 }
 
-pub unsafe extern "C" fn cmdq_get_current(item: *mut cmdq_item) -> *mut cmd_find_state {
+pub unsafe fn cmdq_get_current(item: *mut cmdq_item) -> *mut cmd_find_state {
     unsafe { &raw mut (*(*item).state).current }
 }
 
-pub unsafe extern "C" fn cmdq_get_flags(item: *mut cmdq_item) -> cmdq_state_flags {
+pub unsafe fn cmdq_get_flags(item: *mut cmdq_item) -> cmdq_state_flags {
     unsafe { (*(*item).state).flags }
 }
 
-pub unsafe extern "C" fn cmdq_new_state(
+pub unsafe fn cmdq_new_state(
     current: *mut cmd_find_state,
     event: *mut key_event,
     flags: cmdq_state_flags,
@@ -206,14 +206,14 @@ pub unsafe extern "C" fn cmdq_new_state(
     }
 }
 
-pub unsafe extern "C" fn cmdq_link_state(state: *mut cmdq_state) -> *mut cmdq_state {
+pub unsafe fn cmdq_link_state(state: *mut cmdq_state) -> *mut cmdq_state {
     unsafe {
         (*state).references += 1;
     }
     state
 }
 
-pub unsafe extern "C" fn cmdq_copy_state(
+pub unsafe fn cmdq_copy_state(
     state: *mut cmdq_state,
     current: *mut cmd_find_state,
 ) -> *mut cmdq_state {
@@ -230,7 +230,7 @@ pub unsafe extern "C" fn cmdq_copy_state(
     }
 }
 
-pub unsafe extern "C" fn cmdq_free_state(state: *mut cmdq_state) {
+pub unsafe fn cmdq_free_state(state: *mut cmdq_state) {
     unsafe {
         (*state).references -= 1;
         if (*state).references != 0 {
@@ -267,7 +267,7 @@ pub unsafe fn cmdq_add_format_(
     }
 }
 
-pub unsafe extern "C" fn cmdq_add_formats(state: *mut cmdq_state, ft: *mut format_tree) {
+pub unsafe fn cmdq_add_formats(state: *mut cmdq_state, ft: *mut format_tree) {
     unsafe {
         if (*state).formats.is_null() {
             (*state).formats =
@@ -277,7 +277,7 @@ pub unsafe extern "C" fn cmdq_add_formats(state: *mut cmdq_state, ft: *mut forma
     }
 }
 
-pub unsafe extern "C" fn cmdq_merge_formats(item: *mut cmdq_item, ft: *mut format_tree) {
+pub unsafe fn cmdq_merge_formats(item: *mut cmdq_item, ft: *mut format_tree) {
     unsafe {
         if !(*item).cmd.is_null() {
             let entry = cmd_get_entry((*item).cmd);
@@ -290,7 +290,7 @@ pub unsafe extern "C" fn cmdq_merge_formats(item: *mut cmdq_item, ft: *mut forma
     }
 }
 
-pub unsafe extern "C" fn cmdq_append(c: *mut client, mut item: *mut cmdq_item) -> *mut cmdq_item {
+pub unsafe fn cmdq_append(c: *mut client, mut item: *mut cmdq_item) -> *mut cmdq_item {
     let __func__ = "cmdq_append";
 
     unsafe {
@@ -321,7 +321,7 @@ pub unsafe extern "C" fn cmdq_append(c: *mut client, mut item: *mut cmdq_item) -
 
 // TODO crashes with this one
 
-pub unsafe extern "C" fn cmdq_insert_after(
+pub unsafe fn cmdq_insert_after(
     mut after: *mut cmdq_item,
     mut item: *mut cmdq_item,
 ) -> *mut cmdq_item {
@@ -463,13 +463,13 @@ pub unsafe fn cmdq_insert_hook_(
     }
 }
 
-pub unsafe extern "C" fn cmdq_continue(item: *mut cmdq_item) {
+pub unsafe fn cmdq_continue(item: *mut cmdq_item) {
     unsafe {
         (*item).flags &= !CMDQ_WAITING;
     }
 }
 
-pub unsafe extern "C" fn cmdq_remove(item: *mut cmdq_item) {
+pub unsafe fn cmdq_remove(item: *mut cmdq_item) {
     unsafe {
         if !(*item).client.is_null() {
             server_client_unref((*item).client);
@@ -486,7 +486,7 @@ pub unsafe extern "C" fn cmdq_remove(item: *mut cmdq_item) {
     }
 }
 
-pub unsafe extern "C" fn cmdq_remove_group(item: *mut cmdq_item) {
+pub unsafe fn cmdq_remove_group(item: *mut cmdq_item) {
     unsafe {
         if (*item).group == 0 {
             return;
@@ -502,14 +502,14 @@ pub unsafe extern "C" fn cmdq_remove_group(item: *mut cmdq_item) {
     }
 }
 
-pub unsafe extern "C" fn cmdq_empty_command(
+pub unsafe fn cmdq_empty_command(
     _item: *mut cmdq_item,
     _data: *mut c_void,
 ) -> cmd_retval {
     cmd_retval::CMD_RETURN_NORMAL
 }
 
-pub unsafe extern "C" fn cmdq_get_command(
+pub unsafe fn cmdq_get_command(
     cmdlist: *mut cmd_list,
     mut state: *mut cmdq_state,
 ) -> *mut cmdq_item {
@@ -562,7 +562,7 @@ pub unsafe extern "C" fn cmdq_get_command(
     }
 }
 
-pub unsafe extern "C" fn cmdq_find_flag(
+pub unsafe fn cmdq_find_flag(
     item: *mut cmdq_item,
     fs: *mut cmd_find_state,
     flag: *mut cmd_entry_flag,
@@ -583,7 +583,7 @@ pub unsafe extern "C" fn cmdq_find_flag(
     }
 }
 
-pub unsafe extern "C" fn cmdq_add_message(item: *mut cmdq_item) {
+pub unsafe fn cmdq_add_message(item: *mut cmdq_item) {
     unsafe {
         let c = (*item).client;
         let state = (*item).state;
@@ -616,7 +616,7 @@ pub unsafe extern "C" fn cmdq_add_message(item: *mut cmdq_item) {
     }
 }
 
-pub unsafe extern "C" fn cmdq_fire_command(item: *mut cmdq_item) -> cmd_retval {
+pub unsafe fn cmdq_fire_command(item: *mut cmdq_item) -> cmd_retval {
     let __func__ = "cmdq_fire_command";
 
     unsafe {
@@ -743,7 +743,7 @@ pub unsafe fn cmdq_get_callback1(name: &str, cb: cmdq_cb, data: *mut c_char) -> 
     }
 }
 
-pub unsafe extern "C" fn cmdq_error_callback(
+pub unsafe fn cmdq_error_callback(
     item: *mut cmdq_item,
     data: *mut c_void,
 ) -> cmd_retval {
@@ -757,15 +757,15 @@ pub unsafe extern "C" fn cmdq_error_callback(
     cmd_retval::CMD_RETURN_NORMAL
 }
 
-pub unsafe extern "C" fn cmdq_get_error(error: *const c_char) -> NonNull<cmdq_item> {
+pub unsafe fn cmdq_get_error(error: *const c_char) -> NonNull<cmdq_item> {
     unsafe { cmdq_get_callback!(cmdq_error_callback, xstrdup(error).as_ptr()) }
 }
 
-pub unsafe extern "C" fn cmdq_fire_callback(item: *mut cmdq_item) -> cmd_retval {
+pub unsafe fn cmdq_fire_callback(item: *mut cmdq_item) -> cmd_retval {
     unsafe { ((*item).cb.unwrap())(item, (*item).data) }
 }
 
-pub unsafe extern "C" fn cmdq_next(c: *mut client) -> u32 {
+pub unsafe fn cmdq_next(c: *mut client) -> u32 {
     let __func__ = "cmdq_next";
     static mut number: u32 = 0;
     let mut items = 0;
@@ -842,7 +842,7 @@ pub unsafe extern "C" fn cmdq_next(c: *mut client) -> u32 {
     }
 }
 
-pub unsafe extern "C" fn cmdq_running(c: *mut client) -> *mut cmdq_item {
+pub unsafe fn cmdq_running(c: *mut client) -> *mut cmdq_item {
     unsafe {
         let queue = cmdq_get(c);
 
@@ -856,7 +856,7 @@ pub unsafe extern "C" fn cmdq_running(c: *mut client) -> *mut cmdq_item {
     }
 }
 
-pub unsafe extern "C" fn cmdq_guard(item: *mut cmdq_item, guard: *const c_char, flags: bool) {
+pub unsafe fn cmdq_guard(item: *mut cmdq_item, guard: *const c_char, flags: bool) {
     unsafe {
         let c = (*item).client;
         let t = (*item).time;
@@ -868,7 +868,7 @@ pub unsafe extern "C" fn cmdq_guard(item: *mut cmdq_item, guard: *const c_char, 
     }
 }
 
-pub unsafe extern "C" fn cmdq_print_data(item: *mut cmdq_item, parse: i32, evb: *mut evbuffer) {
+pub unsafe fn cmdq_print_data(item: *mut cmdq_item, parse: i32, evb: *mut evbuffer) {
     unsafe {
         server_client_print((*item).client, parse, evb);
     }

--- a/src/cmd_/cmd_refresh_client.rs
+++ b/src/cmd_/cmd_refresh_client.rs
@@ -28,7 +28,7 @@ pub static mut cmd_refresh_client_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-pub unsafe extern "C" fn cmd_refresh_client_update_subscription(
+pub unsafe fn cmd_refresh_client_update_subscription(
     tc: *mut client,
     value: *const c_char,
 ) {
@@ -74,7 +74,7 @@ pub unsafe extern "C" fn cmd_refresh_client_update_subscription(
     }
 }
 
-pub unsafe extern "C" fn cmd_refresh_client_control_client_size(
+pub unsafe fn cmd_refresh_client_control_client_size(
     self_: *mut cmd,
     item: *mut cmdq_item,
 ) -> cmd_retval {
@@ -150,7 +150,7 @@ pub unsafe extern "C" fn cmd_refresh_client_control_client_size(
     cmd_retval::CMD_RETURN_NORMAL
 }
 
-pub unsafe extern "C" fn cmd_refresh_client_update_offset(tc: *mut client, value: *const c_char) {
+pub unsafe fn cmd_refresh_client_update_offset(tc: *mut client, value: *const c_char) {
     unsafe {
         let mut pane: u32 = 0;
 
@@ -190,7 +190,7 @@ pub unsafe extern "C" fn cmd_refresh_client_update_offset(tc: *mut client, value
     }
 }
 
-pub unsafe extern "C" fn cmd_refresh_client_clipboard(
+pub unsafe fn cmd_refresh_client_clipboard(
     self_: *mut cmd,
     item: *mut cmdq_item,
 ) -> cmd_retval {
@@ -232,7 +232,7 @@ pub unsafe extern "C" fn cmd_refresh_client_clipboard(
     cmd_retval::CMD_RETURN_NORMAL
 }
 
-pub unsafe extern "C" fn cmd_refresh_report(tty: *mut tty, value: *const c_char) {
+pub unsafe fn cmd_refresh_report(tty: *mut tty, value: *const c_char) {
     unsafe {
         let pane: u32 = 0;
         let mut size: usize = 0;
@@ -271,7 +271,7 @@ pub unsafe extern "C" fn cmd_refresh_report(tty: *mut tty, value: *const c_char)
     }
 }
 
-pub unsafe extern "C" fn cmd_refresh_client_exec(
+pub unsafe fn cmd_refresh_client_exec(
     self_: *mut cmd,
     item: *mut cmdq_item,
 ) -> cmd_retval {

--- a/src/cmd_/cmd_rename_session.rs
+++ b/src/cmd_/cmd_rename_session.rs
@@ -30,7 +30,7 @@ pub static mut cmd_rename_session_entry: cmd_entry = cmd_entry {
     exec: Some(cmd_rename_session_exec),
 };
 
-unsafe extern "C" fn cmd_rename_session_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_rename_session_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_rename_window.rs
+++ b/src/cmd_/cmd_rename_window.rs
@@ -27,7 +27,7 @@ pub static mut cmd_rename_window_entry: cmd_entry = cmd_entry {
     exec: Some(cmd_rename_window_exec),
 };
 
-unsafe extern "C" fn cmd_rename_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_rename_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_resize_pane.rs
+++ b/src/cmd_/cmd_resize_pane.rs
@@ -29,7 +29,7 @@ pub static mut cmd_resize_pane_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_resize_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_resize_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);
@@ -159,7 +159,7 @@ unsafe extern "C" fn cmd_resize_pane_exec(self_: *mut cmd, item: *mut cmdq_item)
     cmd_retval::CMD_RETURN_NORMAL
 }
 
-unsafe extern "C" fn cmd_resize_pane_mouse_update(c: *mut client, m: *mut mouse_event) {
+unsafe fn cmd_resize_pane_mouse_update(c: *mut client, m: *mut mouse_event) {
     unsafe {
         let mut w: *mut window = null_mut();
         let mut y: u32 = 0;

--- a/src/cmd_/cmd_resize_window.rs
+++ b/src/cmd_/cmd_resize_window.rs
@@ -27,7 +27,7 @@ pub static mut cmd_resize_window_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_resize_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_resize_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_respawn_pane.rs
+++ b/src/cmd_/cmd_respawn_pane.rs
@@ -28,7 +28,7 @@ pub static mut cmd_respawn_pane_entry: cmd_entry = cmd_entry {
     source: unsafe { zeroed() },
 };
 
-unsafe extern "C" fn cmd_respawn_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_respawn_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_respawn_window.rs
+++ b/src/cmd_/cmd_respawn_window.rs
@@ -28,7 +28,7 @@ pub static mut cmd_respawn_window_entry: cmd_entry = cmd_entry {
     exec: Some(cmd_respawn_window_exec),
 };
 
-unsafe extern "C" fn cmd_respawn_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_respawn_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_rotate_window.rs
+++ b/src/cmd_/cmd_rotate_window.rs
@@ -32,7 +32,7 @@ pub static mut cmd_rotate_window_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_rotate_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_rotate_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let current = cmdq_get_current(item);

--- a/src/cmd_/cmd_run_shell.rs
+++ b/src/cmd_/cmd_run_shell.rs
@@ -184,7 +184,7 @@ pub unsafe fn cmd_run_shell_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_r
     cmd_retval::CMD_RETURN_WAIT
 }
 
-pub unsafe fn cmd_run_shell_timer(_fd: i32, _events: i16, arg: *mut c_void) {
+pub unsafe extern "C" fn cmd_run_shell_timer(_fd: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let cdata = arg as *mut cmd_run_shell_data;
         let c = (*cdata).client;

--- a/src/cmd_/cmd_run_shell.rs
+++ b/src/cmd_/cmd_run_shell.rs
@@ -46,7 +46,7 @@ pub struct cmd_run_shell_data<'a> {
     pub flags: job_flag,
 }
 
-pub unsafe extern "C" fn cmd_run_shell_args_parse(
+pub unsafe fn cmd_run_shell_args_parse(
     args: *mut args,
     _idx: u32,
     cause: *mut *mut c_char,
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn cmd_run_shell_args_parse(
     args_parse_type::ARGS_PARSE_STRING
 }
 
-pub unsafe extern "C" fn cmd_run_shell_print(job: *mut job, msg: *const c_char) {
+pub unsafe fn cmd_run_shell_print(job: *mut job, msg: *const c_char) {
     unsafe {
         let cdata: *mut cmd_run_shell_data = job_get_data(job) as *mut cmd_run_shell_data;
         let mut wp = null_mut();
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn cmd_run_shell_print(job: *mut job, msg: *const c_char) 
     }
 }
 
-pub unsafe extern "C" fn cmd_run_shell_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+pub unsafe fn cmd_run_shell_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     let __func__ = c"cmd_run_shell_exec".as_ptr();
     unsafe {
         let args = cmd_get_args(self_);
@@ -184,7 +184,7 @@ pub unsafe extern "C" fn cmd_run_shell_exec(self_: *mut cmd, item: *mut cmdq_ite
     cmd_retval::CMD_RETURN_WAIT
 }
 
-pub unsafe extern "C" fn cmd_run_shell_timer(_fd: i32, _events: i16, arg: *mut c_void) {
+pub unsafe fn cmd_run_shell_timer(_fd: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let cdata = arg as *mut cmd_run_shell_data;
         let c = (*cdata).client;
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn cmd_run_shell_timer(_fd: i32, _events: i16, arg: *mut c
     }
 }
 
-pub unsafe extern "C" fn cmd_run_shell_callback(job: *mut job) {
+pub unsafe fn cmd_run_shell_callback(job: *mut job) {
     unsafe {
         let cdata = job_get_data(job) as *mut cmd_run_shell_data;
         let event = job_get_event(job);
@@ -316,7 +316,7 @@ pub unsafe extern "C" fn cmd_run_shell_callback(job: *mut job) {
     }
 }
 
-pub unsafe extern "C" fn cmd_run_shell_free(data: *mut c_void) {
+pub unsafe fn cmd_run_shell_free(data: *mut c_void) {
     unsafe {
         let __func__ = c"cmd_run_shell_free".as_ptr();
         let cdata = data as *mut cmd_run_shell_data;

--- a/src/cmd_/cmd_save_buffer.rs
+++ b/src/cmd_/cmd_save_buffer.rs
@@ -40,7 +40,7 @@ pub static mut cmd_show_buffer_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_save_buffer_done(
+unsafe fn cmd_save_buffer_done(
     _c: *mut client,
     path: *mut c_char,
     error: i32,
@@ -62,7 +62,7 @@ unsafe extern "C" fn cmd_save_buffer_done(
     }
 }
 
-unsafe extern "C" fn cmd_save_buffer_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_save_buffer_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let c = cmdq_get_client(item);

--- a/src/cmd_/cmd_select_layout.rs
+++ b/src/cmd_/cmd_select_layout.rs
@@ -55,7 +55,7 @@ pub static mut cmd_previous_layout_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_select_layout_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_select_layout_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_select_pane.rs
+++ b/src/cmd_/cmd_select_pane.rs
@@ -44,7 +44,7 @@ pub static mut cmd_last_pane_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-pub unsafe extern "C" fn cmd_select_pane_redraw(w: *mut window) {
+pub unsafe fn cmd_select_pane_redraw(w: *mut window) {
     unsafe {
         /*
          * Redraw entire window if it is bigger than the client (the
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn cmd_select_pane_redraw(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn cmd_select_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+pub unsafe fn cmd_select_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let entry = cmd_get_entry(self_);

--- a/src/cmd_/cmd_select_window.rs
+++ b/src/cmd_/cmd_select_window.rs
@@ -70,7 +70,7 @@ pub static mut cmd_last_window_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_select_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_select_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let c = cmdq_get_client(item);

--- a/src/cmd_/cmd_send_keys.rs
+++ b/src/cmd_/cmd_send_keys.rs
@@ -49,7 +49,7 @@ pub static mut cmd_send_prefix_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-pub unsafe extern "C" fn cmd_send_keys_inject_key(
+pub unsafe fn cmd_send_keys_inject_key(
     item: *mut cmdq_item,
     mut after: *mut cmdq_item,
     args: *mut args,
@@ -98,7 +98,7 @@ pub unsafe extern "C" fn cmd_send_keys_inject_key(
     }
 }
 
-pub unsafe extern "C" fn cmd_send_keys_inject_string(
+pub unsafe fn cmd_send_keys_inject_string(
     item: *mut cmdq_item,
     mut after: *mut cmdq_item,
     args: *mut args,
@@ -160,7 +160,7 @@ pub unsafe extern "C" fn cmd_send_keys_inject_string(
     }
 }
 
-pub unsafe extern "C" fn cmd_send_keys_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+pub unsafe fn cmd_send_keys_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_server_access.rs
+++ b/src/cmd_/cmd_server_access.rs
@@ -29,7 +29,7 @@ pub static mut cmd_server_access_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_server_access_deny(
+unsafe fn cmd_server_access_deny(
     item: *mut cmdq_item,
     pw: *mut libc::passwd,
 ) -> cmd_retval {
@@ -52,7 +52,7 @@ unsafe extern "C" fn cmd_server_access_deny(
     }
 }
 
-unsafe extern "C" fn cmd_server_access_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_server_access_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let c = cmdq_get_target_client(item);

--- a/src/cmd_/cmd_set_buffer.rs
+++ b/src/cmd_/cmd_set_buffer.rs
@@ -39,7 +39,7 @@ pub static mut cmd_delete_buffer_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_set_buffer_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_set_buffer_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let tc = cmdq_get_target_client(item);

--- a/src/cmd_/cmd_set_environment.rs
+++ b/src/cmd_/cmd_set_environment.rs
@@ -27,7 +27,7 @@ pub static mut cmd_set_environment_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_set_environment_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_set_environment_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);

--- a/src/cmd_/cmd_set_option.rs
+++ b/src/cmd_/cmd_set_option.rs
@@ -57,7 +57,7 @@ pub static mut cmd_set_hook_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-pub unsafe extern "C" fn cmd_set_option_args_parse(
+pub unsafe fn cmd_set_option_args_parse(
     _args: *mut args,
     idx: u32,
     cause: *mut *mut c_char,
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn cmd_set_option_args_parse(
     args_parse_type::ARGS_PARSE_STRING
 }
 
-pub unsafe extern "C" fn cmd_set_option_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+pub unsafe fn cmd_set_option_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let append = args_has(args, b'a');

--- a/src/cmd_/cmd_show_environment.rs
+++ b/src/cmd_/cmd_show_environment.rs
@@ -28,7 +28,7 @@ pub static mut cmd_show_environment_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_show_environment_escape(envent: *mut environ_entry) -> *mut c_char {
+unsafe fn cmd_show_environment_escape(envent: *mut environ_entry) -> *mut c_char {
     unsafe {
         let mut value = transmute_ptr((*envent).value);
         let ret: *mut i8 = xmalloc(strlen(value) * 2 + 1).as_ptr().cast(); /* at most twice the size */
@@ -54,7 +54,7 @@ unsafe extern "C" fn cmd_show_environment_escape(envent: *mut environ_entry) -> 
     }
 }
 
-unsafe extern "C" fn cmd_show_environment_print(
+unsafe fn cmd_show_environment_print(
     self_: *mut cmd,
     item: *mut cmdq_item,
     envent: *mut environ_entry,
@@ -100,7 +100,7 @@ unsafe extern "C" fn cmd_show_environment_print(
     }
 }
 
-unsafe extern "C" fn cmd_show_environment_exec(
+unsafe fn cmd_show_environment_exec(
     self_: *mut cmd,
     item: *mut cmdq_item,
 ) -> cmd_retval {

--- a/src/cmd_/cmd_show_messages.rs
+++ b/src/cmd_/cmd_show_messages.rs
@@ -29,7 +29,7 @@ pub static mut cmd_show_messages_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_show_messages_terminals(
+unsafe fn cmd_show_messages_terminals(
     self_: *mut cmd,
     item: *mut cmdq_item,
     mut blank: i32,
@@ -68,7 +68,7 @@ unsafe extern "C" fn cmd_show_messages_terminals(
     }
 }
 
-unsafe extern "C" fn cmd_show_messages_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_show_messages_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
 

--- a/src/cmd_/cmd_show_options.rs
+++ b/src/cmd_/cmd_show_options.rs
@@ -57,7 +57,7 @@ pub static mut cmd_show_hooks_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_show_options_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_show_options_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let target = cmdq_get_target(item);
@@ -148,7 +148,7 @@ unsafe extern "C" fn cmd_show_options_exec(self_: *mut cmd, item: *mut cmdq_item
     }
 }
 
-pub unsafe extern "C" fn cmd_show_options_print(
+pub unsafe fn cmd_show_options_print(
     self_: *mut cmd,
     item: *mut cmdq_item,
     o: *mut options_entry,
@@ -204,7 +204,7 @@ pub unsafe extern "C" fn cmd_show_options_print(
     }
 }
 
-pub unsafe extern "C" fn cmd_show_options_all(
+pub unsafe fn cmd_show_options_all(
     self_: *mut cmd,
     item: *mut cmdq_item,
     scope: i32,

--- a/src/cmd_/cmd_show_prompt_history.rs
+++ b/src/cmd_/cmd_show_prompt_history.rs
@@ -37,7 +37,7 @@ pub static mut cmd_clear_prompt_history_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_show_prompt_history_exec(
+unsafe fn cmd_show_prompt_history_exec(
     self_: *mut cmd,
     item: *mut cmdq_item,
 ) -> cmd_retval {

--- a/src/cmd_/cmd_source_file.rs
+++ b/src/cmd_/cmd_source_file.rs
@@ -42,7 +42,7 @@ pub struct cmd_source_file_data {
     pub nfiles: u32,
 }
 
-unsafe extern "C" fn cmd_source_file_complete_cb(
+unsafe fn cmd_source_file_complete_cb(
     item: *mut cmdq_item,
     data: *mut c_void,
 ) -> cmd_retval {
@@ -52,7 +52,7 @@ unsafe extern "C" fn cmd_source_file_complete_cb(
     }
 }
 
-unsafe extern "C" fn cmd_source_file_complete(c: *mut client, cdata: *mut cmd_source_file_data) {
+unsafe fn cmd_source_file_complete(c: *mut client, cdata: *mut cmd_source_file_data) {
     unsafe {
         if cfg_finished != 0 {
             if (*cdata).retval == cmd_retval::CMD_RETURN_ERROR
@@ -73,7 +73,7 @@ unsafe extern "C" fn cmd_source_file_complete(c: *mut client, cdata: *mut cmd_so
     }
 }
 
-unsafe extern "C" fn cmd_source_file_done(
+unsafe fn cmd_source_file_done(
     c: *mut client,
     path: *mut c_char,
     error: i32,
@@ -128,7 +128,7 @@ unsafe extern "C" fn cmd_source_file_done(
     }
 }
 
-unsafe extern "C" fn cmd_source_file_add(cdata: *mut cmd_source_file_data, path: *const c_char) {
+unsafe fn cmd_source_file_add(cdata: *mut cmd_source_file_data, path: *const c_char) {
     unsafe {
         let mut __func__ = "cmd_source_file_add";
         log_debug!("{}: {}", __func__, _s(path));
@@ -138,7 +138,7 @@ unsafe extern "C" fn cmd_source_file_add(cdata: *mut cmd_source_file_data, path:
     }
 }
 
-unsafe extern "C" fn cmd_source_file_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_source_file_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     let __func__ = "cmd_source_file_exec";
 
     unsafe {

--- a/src/cmd_/cmd_split_window.rs
+++ b/src/cmd_/cmd_split_window.rs
@@ -29,7 +29,7 @@ pub static mut cmd_split_window_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_split_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_split_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let current = cmdq_get_current(item);

--- a/src/cmd_/cmd_swap_pane.rs
+++ b/src/cmd_/cmd_swap_pane.rs
@@ -33,7 +33,7 @@ pub static mut cmd_swap_pane_entry: cmd_entry = cmd_entry {
     exec: Some(cmd_swap_pane_exec),
 };
 
-unsafe extern "C" fn cmd_swap_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_swap_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let source = cmdq_get_source(item);

--- a/src/cmd_/cmd_swap_window.rs
+++ b/src/cmd_/cmd_swap_window.rs
@@ -34,7 +34,7 @@ pub static mut cmd_swap_window_entry: cmd_entry = cmd_entry {
     exec: Some(cmd_swap_window_exec),
 };
 
-unsafe extern "C" fn cmd_swap_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_swap_window_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let source = cmdq_get_source(item);

--- a/src/cmd_/cmd_switch_client.rs
+++ b/src/cmd_/cmd_switch_client.rs
@@ -28,7 +28,7 @@ pub static mut cmd_switch_client_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_switch_client_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_switch_client_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let current = cmdq_get_current(item);

--- a/src/cmd_/cmd_unbind_key.rs
+++ b/src/cmd_/cmd_unbind_key.rs
@@ -26,7 +26,7 @@ pub static mut cmd_unbind_key_entry: cmd_entry = cmd_entry {
     ..unsafe { zeroed() }
 };
 
-unsafe extern "C" fn cmd_unbind_key_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+unsafe fn cmd_unbind_key_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let mut tablename: *const c_char = null_mut();

--- a/src/cmd_/cmd_wait_for.rs
+++ b/src/cmd_/cmd_wait_for.rs
@@ -64,14 +64,14 @@ RB_GENERATE!(
     wait_channel_cmp
 );
 
-pub unsafe extern "C" fn wait_channel_cmp(
+pub unsafe fn wait_channel_cmp(
     wc1: *const wait_channel,
     wc2: *const wait_channel,
 ) -> Ordering {
     unsafe { i32_to_ordering(libc::strcmp((*wc1).name, (*wc2).name)) }
 }
 
-pub unsafe extern "C" fn cmd_wait_for_add(name: *const c_char) -> *mut wait_channel {
+pub unsafe fn cmd_wait_for_add(name: *const c_char) -> *mut wait_channel {
     let wc: *mut wait_channel = xmalloc_().as_ptr();
     unsafe {
         (*wc).name = xstrdup(name).as_ptr();
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn cmd_wait_for_add(name: *const c_char) -> *mut wait_chan
     wc
 }
 
-pub unsafe extern "C" fn cmd_wait_for_remove(wc: *mut wait_channel) {
+pub unsafe fn cmd_wait_for_remove(wc: *mut wait_channel) {
     unsafe {
         if (*wc).locked != 0 {
             return;
@@ -107,7 +107,7 @@ pub unsafe extern "C" fn cmd_wait_for_remove(wc: *mut wait_channel) {
     }
 }
 
-pub unsafe extern "C" fn cmd_wait_for_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
+pub unsafe fn cmd_wait_for_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retval {
     unsafe {
         let args = cmd_get_args(self_);
         let name = args_string(args, 0);
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn cmd_wait_for_exec(self_: *mut cmd, item: *mut cmdq_item
     }
 }
 
-pub unsafe extern "C" fn cmd_wait_for_signal(
+pub unsafe fn cmd_wait_for_signal(
     _item: *mut cmdq_item,
     name: *const c_char,
     mut wc: *mut wait_channel,
@@ -161,7 +161,7 @@ pub unsafe extern "C" fn cmd_wait_for_signal(
     }
 }
 
-pub unsafe extern "C" fn cmd_wait_for_wait(
+pub unsafe fn cmd_wait_for_wait(
     item: *mut cmdq_item,
     name: *const c_char,
     mut wc: *mut wait_channel,
@@ -192,7 +192,7 @@ pub unsafe extern "C" fn cmd_wait_for_wait(
     cmd_retval::CMD_RETURN_WAIT
 }
 
-pub unsafe extern "C" fn cmd_wait_for_lock(
+pub unsafe fn cmd_wait_for_lock(
     item: *mut cmdq_item,
     name: *const c_char,
     mut wc: *mut wait_channel,
@@ -218,7 +218,7 @@ pub unsafe extern "C" fn cmd_wait_for_lock(
     cmd_retval::CMD_RETURN_NORMAL
 }
 
-pub unsafe extern "C" fn cmd_wait_for_unlock(
+pub unsafe fn cmd_wait_for_unlock(
     item: *mut cmdq_item,
     name: *const c_char,
     wc: *mut wait_channel,
@@ -242,7 +242,7 @@ pub unsafe extern "C" fn cmd_wait_for_unlock(
     cmd_retval::CMD_RETURN_NORMAL
 }
 
-pub unsafe extern "C" fn cmd_wait_for_flush() {
+pub unsafe fn cmd_wait_for_flush() {
     unsafe {
         for wc in rb_foreach(&raw mut wait_channels).map(NonNull::as_ptr) {
             for wi in tailq_foreach(&raw mut (*wc).waiters).map(NonNull::as_ptr) {

--- a/src/cmd_/mod.rs
+++ b/src/cmd_/mod.rs
@@ -306,7 +306,7 @@ pub unsafe fn cmd_log_argv_(argc: i32, argv: *mut *mut c_char, args: std::fmt::A
     }
 }
 
-pub unsafe extern "C" fn cmd_append_argv(
+pub unsafe fn cmd_append_argv(
     argc: *mut c_int,
     argv: *mut *mut *mut c_char,
     arg: *const c_char,
@@ -318,7 +318,7 @@ pub unsafe extern "C" fn cmd_append_argv(
     }
 }
 
-pub unsafe extern "C" fn cmd_pack_argv(
+pub unsafe fn cmd_pack_argv(
     argc: c_int,
     argv: *mut *mut c_char,
     mut buf: *mut c_char,
@@ -345,7 +345,7 @@ pub unsafe extern "C" fn cmd_pack_argv(
     }
 }
 
-pub unsafe extern "C" fn cmd_unpack_argv(
+pub unsafe fn cmd_unpack_argv(
     mut buf: *mut c_char,
     mut len: usize,
     argc: c_int,
@@ -376,7 +376,7 @@ pub unsafe extern "C" fn cmd_unpack_argv(
     }
 }
 
-pub unsafe extern "C" fn cmd_copy_argv(argc: c_int, argv: *mut *mut c_char) -> *mut *mut c_char {
+pub unsafe fn cmd_copy_argv(argc: c_int, argv: *mut *mut c_char) -> *mut *mut c_char {
     unsafe {
         if argc == 0 {
             return null_mut();
@@ -393,7 +393,7 @@ pub unsafe extern "C" fn cmd_copy_argv(argc: c_int, argv: *mut *mut c_char) -> *
     }
 }
 
-pub unsafe extern "C" fn cmd_free_argv(argc: c_int, argv: *mut *mut c_char) {
+pub unsafe fn cmd_free_argv(argc: c_int, argv: *mut *mut c_char) {
     unsafe {
         if argc == 0 {
             return;
@@ -405,7 +405,7 @@ pub unsafe extern "C" fn cmd_free_argv(argc: c_int, argv: *mut *mut c_char) {
     }
 }
 
-pub unsafe extern "C" fn cmd_stringify_argv(argc: c_int, argv: *mut *mut c_char) -> *mut c_char {
+pub unsafe fn cmd_stringify_argv(argc: c_int, argv: *mut *mut c_char) -> *mut c_char {
     unsafe {
         let mut buf: *mut c_char = null_mut();
         let mut len: usize = 0;
@@ -440,15 +440,15 @@ pub unsafe extern "C" fn cmd_stringify_argv(argc: c_int, argv: *mut *mut c_char)
     }
 }
 
-pub unsafe extern "C" fn cmd_get_entry(cmd: *mut cmd) -> *mut cmd_entry {
+pub unsafe fn cmd_get_entry(cmd: *mut cmd) -> *mut cmd_entry {
     unsafe { (*cmd).entry }
 }
 
-pub unsafe extern "C" fn cmd_get_args(cmd: *mut cmd) -> *mut args {
+pub unsafe fn cmd_get_args(cmd: *mut cmd) -> *mut args {
     unsafe { (*cmd).args }
 }
 
-pub unsafe extern "C" fn cmd_get_group(cmd: *mut cmd) -> c_uint {
+pub unsafe fn cmd_get_group(cmd: *mut cmd) -> c_uint {
     unsafe { (*cmd).group }
 }
 
@@ -461,7 +461,7 @@ pub unsafe fn cmd_get_source(cmd: *mut cmd, file: *mut *const c_char, line: &Ato
     }
 }
 
-pub unsafe extern "C" fn cmd_get_alias(name: *const c_char) -> *mut c_char {
+pub unsafe fn cmd_get_alias(name: *const c_char) -> *mut c_char {
     unsafe {
         let o = options_get_only(global_options, c"command-alias".as_ptr());
         if o.is_null() {
@@ -599,7 +599,7 @@ pub unsafe fn cmd_parse(
     }
 }
 
-pub unsafe extern "C" fn cmd_free(cmd: *mut cmd) {
+pub unsafe fn cmd_free(cmd: *mut cmd) {
     unsafe {
         free((*cmd).file as _);
 
@@ -608,7 +608,7 @@ pub unsafe extern "C" fn cmd_free(cmd: *mut cmd) {
     }
 }
 
-pub unsafe extern "C" fn cmd_copy(cmd: *mut cmd, argc: c_int, argv: *mut *mut c_char) -> *mut cmd {
+pub unsafe fn cmd_copy(cmd: *mut cmd, argc: c_int, argv: *mut *mut c_char) -> *mut cmd {
     unsafe {
         let new_cmd: *mut cmd = xcalloc(1, size_of::<cmd>()).cast().as_ptr();
         (*new_cmd).entry = (*cmd).entry;
@@ -623,7 +623,7 @@ pub unsafe extern "C" fn cmd_copy(cmd: *mut cmd, argc: c_int, argv: *mut *mut c_
     }
 }
 
-pub unsafe extern "C" fn cmd_print(cmd: *mut cmd) -> *mut c_char {
+pub unsafe fn cmd_print(cmd: *mut cmd) -> *mut c_char {
     unsafe {
         let s = args_print((*cmd).args);
         let out = if *s != b'\0' as c_char {
@@ -652,14 +652,14 @@ pub unsafe fn cmd_list_new<'a>() -> &'a mut cmd_list {
     }
 }
 
-pub unsafe extern "C" fn cmd_list_append(cmdlist: *mut cmd_list, cmd: *mut cmd) {
+pub unsafe fn cmd_list_append(cmdlist: *mut cmd_list, cmd: *mut cmd) {
     unsafe {
         (*cmd).group = (*cmdlist).group;
         tailq_insert_tail::<_, qentry>((*cmdlist).list, cmd);
     }
 }
 
-pub unsafe extern "C" fn cmd_list_append_all(cmdlist: *mut cmd_list, from: *mut cmd_list) {
+pub unsafe fn cmd_list_append_all(cmdlist: *mut cmd_list, from: *mut cmd_list) {
     unsafe {
         for cmd in tailq_foreach::<_, qentry>((*from).list).map(NonNull::as_ptr) {
             (*cmd).group = (*cmdlist).group;
@@ -668,14 +668,14 @@ pub unsafe extern "C" fn cmd_list_append_all(cmdlist: *mut cmd_list, from: *mut 
     }
 }
 
-pub unsafe extern "C" fn cmd_list_move(cmdlist: *mut cmd_list, from: *mut cmd_list) {
+pub unsafe fn cmd_list_move(cmdlist: *mut cmd_list, from: *mut cmd_list) {
     unsafe {
         tailq_concat::<_, qentry>((*cmdlist).list, (*from).list);
         (*cmdlist).group = cmd_list_next_group.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     }
 }
 
-pub unsafe extern "C" fn cmd_list_free(cmdlist: *mut cmd_list) {
+pub unsafe fn cmd_list_free(cmdlist: *mut cmd_list) {
     unsafe {
         (*cmdlist).references -= 1;
         if (*cmdlist).references != 0 {
@@ -691,7 +691,7 @@ pub unsafe extern "C" fn cmd_list_free(cmdlist: *mut cmd_list) {
     }
 }
 
-pub unsafe extern "C" fn cmd_list_copy(
+pub unsafe fn cmd_list_copy(
     cmdlist: &mut cmd_list,
     argc: c_int,
     argv: *mut *mut c_char,
@@ -759,27 +759,27 @@ pub fn cmd_list_print(cmdlist: &mut cmd_list, escaped: c_int) -> *mut c_char {
     }
 }
 
-pub unsafe extern "C" fn cmd_list_first(cmdlist: *mut cmd_list) -> *mut cmd {
+pub unsafe fn cmd_list_first(cmdlist: *mut cmd_list) -> *mut cmd {
     unsafe { tailq_first((*cmdlist).list) }
 }
 
-pub unsafe extern "C" fn cmd_list_next(cmd: *mut cmd) -> *mut cmd {
+pub unsafe fn cmd_list_next(cmd: *mut cmd) -> *mut cmd {
     unsafe { tailq_next::<_, _, qentry>(cmd) }
 }
 
-pub unsafe extern "C" fn cmd_list_all_have(cmdlist: *mut cmd_list, flag: cmd_flag) -> bool {
+pub unsafe fn cmd_list_all_have(cmdlist: *mut cmd_list, flag: cmd_flag) -> bool {
     unsafe {
         tailq_foreach((*cmdlist).list).all(|cmd| (*(*cmd.as_ptr()).entry).flags.intersects(flag))
     }
 }
 
-pub unsafe extern "C" fn cmd_list_any_have(cmdlist: *mut cmd_list, flag: cmd_flag) -> bool {
+pub unsafe fn cmd_list_any_have(cmdlist: *mut cmd_list, flag: cmd_flag) -> bool {
     unsafe {
         tailq_foreach((*cmdlist).list).any(|cmd| (*(*cmd.as_ptr()).entry).flags.intersects(flag))
     }
 }
 
-pub unsafe extern "C" fn cmd_mouse_at(
+pub unsafe fn cmd_mouse_at(
     wp: *mut window_pane,
     m: *mut mouse_event,
     xp: *mut c_uint,
@@ -827,7 +827,7 @@ pub unsafe extern "C" fn cmd_mouse_at(
     }
 }
 
-pub unsafe extern "C" fn cmd_mouse_window(
+pub unsafe fn cmd_mouse_window(
     m: *mut mouse_event,
     sp: *mut *mut session,
 ) -> Option<NonNull<winlink>> {
@@ -861,7 +861,7 @@ pub unsafe extern "C" fn cmd_mouse_window(
     }
 }
 
-pub unsafe extern "C" fn cmd_mouse_pane(
+pub unsafe fn cmd_mouse_pane(
     m: *mut mouse_event,
     sp: *mut *mut session,
     wlp: *mut *mut winlink,
@@ -886,7 +886,7 @@ pub unsafe extern "C" fn cmd_mouse_pane(
     }
 }
 
-pub unsafe extern "C" fn cmd_template_replace(
+pub unsafe fn cmd_template_replace(
     template: *const c_char,
     s: *const c_char,
     idx: c_int,

--- a/src/colour.rs
+++ b/src/colour.rs
@@ -123,7 +123,7 @@ pub fn colour_force_rgb(c: i32) -> i32 {
     static_mut_refs,
     reason = "TODO need to find a better way to make use of the write macro without invoking ub"
 )]
-pub unsafe extern "C" fn colour_tostring(c: i32) -> *const c_char {
+pub unsafe fn colour_tostring(c: i32) -> *const c_char {
     // TODO this function returns a static buffer
     // this means it's not thread safe and multiple
     // concurrent calls to this function would result in bugs
@@ -308,7 +308,7 @@ pub fn colour_256to16(c: i32) -> i32 {
     table[c as u8 as usize] as i32
 }
 
-pub unsafe extern "C" fn colour_byname(name: *const c_char) -> i32 {
+pub unsafe fn colour_byname(name: *const c_char) -> i32 {
     const COLOURS: [(&CStr, i32); 578] = [
         (c"AliceBlue", 0xf0f8ff),
         (c"AntiqueWhite", 0xfaebd7),
@@ -920,7 +920,7 @@ pub unsafe extern "C" fn colour_byname(name: *const c_char) -> i32 {
     -1
 }
 
-pub unsafe extern "C" fn colour_palette_init(p: *mut colour_palette) {
+pub unsafe fn colour_palette_init(p: *mut colour_palette) {
     unsafe {
         *p = colour_palette {
             fg: 8,
@@ -932,7 +932,7 @@ pub unsafe extern "C" fn colour_palette_init(p: *mut colour_palette) {
 }
 
 /// Clear palette.
-pub unsafe extern "C" fn colour_palette_clear(p: *mut colour_palette) {
+pub unsafe fn colour_palette_clear(p: *mut colour_palette) {
     unsafe {
         if !p.is_null() {
             (*p).fg = 8;
@@ -944,7 +944,7 @@ pub unsafe extern "C" fn colour_palette_clear(p: *mut colour_palette) {
 }
 
 /// Free a palette
-pub unsafe extern "C" fn colour_palette_free(p: *mut colour_palette) {
+pub unsafe fn colour_palette_free(p: *mut colour_palette) {
     if let Some(p) = std::ptr::NonNull::new(p) {
         let p = p.as_ptr();
         unsafe {
@@ -957,7 +957,7 @@ pub unsafe extern "C" fn colour_palette_free(p: *mut colour_palette) {
 }
 
 /// Get a colour from a palette.
-pub unsafe extern "C" fn colour_palette_get(p: *const colour_palette, mut c: i32) -> i32 {
+pub unsafe fn colour_palette_get(p: *const colour_palette, mut c: i32) -> i32 {
     unsafe {
         if p.is_null() {
             return -1;
@@ -981,7 +981,7 @@ pub unsafe extern "C" fn colour_palette_get(p: *const colour_palette, mut c: i32
     }
 }
 
-pub unsafe extern "C" fn colour_palette_set(p: *mut colour_palette, n: i32, c: i32) -> i32 {
+pub unsafe fn colour_palette_set(p: *mut colour_palette, n: i32, c: i32) -> i32 {
     unsafe {
         if p.is_null() || n > 255 {
             return 0;
@@ -1005,7 +1005,7 @@ pub unsafe extern "C" fn colour_palette_set(p: *mut colour_palette, n: i32, c: i
     }
 }
 
-pub unsafe extern "C" fn colour_palette_from_option(p: *mut colour_palette, oo: *mut options) {
+pub unsafe fn colour_palette_from_option(p: *mut colour_palette, oo: *mut options) {
     unsafe {
         if p.is_null() {
             return;
@@ -1041,7 +1041,7 @@ pub unsafe extern "C" fn colour_palette_from_option(p: *mut colour_palette, oo: 
 }
 
 // below has the auto generated code I haven't bothered to translate yet
-pub unsafe extern "C" fn colour_parse_x11(mut p: *const c_char) -> c_int {
+pub unsafe fn colour_parse_x11(mut p: *const c_char) -> c_int {
     unsafe {
         let mut c: f64 = 0.0;
         let mut m: f64 = 0.0;

--- a/src/compat/b64.rs
+++ b/src/compat/b64.rs
@@ -3,7 +3,7 @@ use core::mem::MaybeUninit;
 
 // https://www.rfc-editor.org/rfc/rfc4648
 
-pub unsafe extern "C" fn b64_ntop(
+pub unsafe fn b64_ntop(
     src: *const u8,
     srclength: usize,
     target: *mut c_char,
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn b64_ntop(
 /// converts characters, four at a time, starting at (or after)
 /// src from base - 64 numbers into three 8 bit bytes in the target area.
 /// it returns the number of data bytes stored at the target, or -1 on error.
-pub unsafe extern "C" fn b64_pton(src: *const c_char, target: *mut u8, targsize: usize) -> i32 {
+pub unsafe fn b64_pton(src: *const c_char, target: *mut u8, targsize: usize) -> i32 {
     let srclength: usize = unsafe { libc::strlen(src) };
     let src = unsafe { std::slice::from_raw_parts(src.cast::<u8>(), srclength) };
     let dst = unsafe { std::slice::from_raw_parts_mut(target.cast::<MaybeUninit<u8>>(), targsize) };

--- a/src/compat/fdforkpty.rs
+++ b/src/compat/fdforkpty.rs
@@ -5,7 +5,7 @@ pub extern "C" fn getptmfd() -> c_int {
     c_int::MAX
 }
 
-pub unsafe extern "C" fn fdforkpty(
+pub unsafe fn fdforkpty(
     _ptmfd: c_int,
     master: *mut c_int,
     name: *mut c_char,

--- a/src/compat/getopt.rs
+++ b/src/compat/getopt.rs
@@ -17,7 +17,7 @@ pub static mut BSDoptreset: libc::c_int = 0;
 #[no_mangle]
 pub static mut BSDoptarg: *mut libc::c_char = 0 as *const libc::c_char as *mut libc::c_char;
 #[no_mangle]
-pub unsafe extern "C" fn BSDgetopt(
+pub unsafe fn BSDgetopt(
     mut nargc: libc::c_int,
     mut nargv: *const *mut libc::c_char,
     mut ostr: *const libc::c_char,

--- a/src/compat/getprogname.rs
+++ b/src/compat/getprogname.rs
@@ -2,6 +2,6 @@ unsafe extern "C" {
     static mut program_invocation_short_name: *mut libc::c_char;
 }
 
-pub unsafe extern "C" fn getprogname() -> *const libc::c_char {
+pub unsafe fn getprogname() -> *const libc::c_char {
     unsafe { program_invocation_short_name }
 }

--- a/src/compat/imsg.rs
+++ b/src/compat/imsg.rs
@@ -103,7 +103,7 @@ impl super::queue::Entry<imsg_fd> for imsg_fd {
 
 static mut imsg_fd_overhead: i32 = 0;
 
-pub unsafe extern "C" fn imsg_init(imsgbuf: *mut imsgbuf, fd: c_int) {
+pub unsafe fn imsg_init(imsgbuf: *mut imsgbuf, fd: c_int) {
     unsafe {
         msgbuf_init(&raw mut (*imsgbuf).w);
         memset((&raw mut (*imsgbuf).r).cast(), 0, size_of::<ibuf_read>());
@@ -114,7 +114,7 @@ pub unsafe extern "C" fn imsg_init(imsgbuf: *mut imsgbuf, fd: c_int) {
     }
 }
 
-pub unsafe extern "C" fn imsg_read(imsgbuf: *mut imsgbuf) -> isize {
+pub unsafe fn imsg_read(imsgbuf: *mut imsgbuf) -> isize {
     const BUFSIZE: usize = unsafe { CMSG_SPACE(size_of::<c_int>() as u32) } as usize;
     union cmsgbuf {
         _hdr: cmsghdr,
@@ -198,7 +198,7 @@ pub unsafe extern "C" fn imsg_read(imsgbuf: *mut imsgbuf) -> isize {
     }
 }
 
-pub unsafe extern "C" fn imsg_get(imsgbuf: *mut imsgbuf, imsg: *mut imsg) -> isize {
+pub unsafe fn imsg_get(imsgbuf: *mut imsgbuf, imsg: *mut imsg) -> isize {
     unsafe {
         let mut m = MaybeUninit::<imsg>::uninit();
         #[allow(clippy::shadow_reuse)]
@@ -263,7 +263,7 @@ pub unsafe extern "C" fn imsg_get(imsgbuf: *mut imsgbuf, imsg: *mut imsg) -> isi
     }
 }
 
-pub unsafe extern "C" fn imsg_get_ibuf(imsg: *mut imsg, ibuf: *mut ibuf) -> c_int {
+pub unsafe fn imsg_get_ibuf(imsg: *mut imsg, ibuf: *mut ibuf) -> c_int {
     unsafe {
         if (*imsg).buf.is_null() {
             errno!() = EBADMSG;
@@ -273,7 +273,7 @@ pub unsafe extern "C" fn imsg_get_ibuf(imsg: *mut imsg, ibuf: *mut ibuf) -> c_in
     }
 }
 
-pub unsafe extern "C" fn imsg_get_data(imsg: *mut imsg, data: *mut c_void, len: usize) -> i32 {
+pub unsafe fn imsg_get_data(imsg: *mut imsg, data: *mut c_void, len: usize) -> i32 {
     unsafe {
         if len == 0 {
             errno!() = EINVAL;
@@ -287,15 +287,15 @@ pub unsafe extern "C" fn imsg_get_data(imsg: *mut imsg, data: *mut c_void, len: 
     }
 }
 
-pub unsafe extern "C" fn imsg_get_fd(imsg: *mut imsg) -> i32 {
+pub unsafe fn imsg_get_fd(imsg: *mut imsg) -> i32 {
     unsafe { std::ptr::replace(&raw mut (*imsg).fd, -1) }
 }
 
-pub unsafe extern "C" fn imsg_get_id(imsg: *const imsg) -> u32 {
+pub unsafe fn imsg_get_id(imsg: *const imsg) -> u32 {
     unsafe { (*imsg).hdr.peerid }
 }
 
-pub unsafe extern "C" fn imsg_get_len(imsg: *const imsg) -> usize {
+pub unsafe fn imsg_get_len(imsg: *const imsg) -> usize {
     unsafe {
         if (*imsg).buf.is_null() {
             return 0;
@@ -304,15 +304,15 @@ pub unsafe extern "C" fn imsg_get_len(imsg: *const imsg) -> usize {
     }
 }
 
-pub unsafe extern "C" fn imsg_get_pid(imsg: *const imsg) -> pid_t {
+pub unsafe fn imsg_get_pid(imsg: *const imsg) -> pid_t {
     unsafe { (*imsg).hdr.pid as pid_t }
 }
 
-pub unsafe extern "C" fn imsg_get_type(imsg: *const imsg) -> u32 {
+pub unsafe fn imsg_get_type(imsg: *const imsg) -> u32 {
     unsafe { (*imsg).hdr.type_ }
 }
 
-pub unsafe extern "C" fn imsg_compose(
+pub unsafe fn imsg_compose(
     imsgbuf: *mut imsgbuf,
     type_: u32,
     id: u32,
@@ -338,7 +338,7 @@ pub unsafe extern "C" fn imsg_compose(
     }
 }
 
-pub unsafe extern "C" fn imsg_composev(
+pub unsafe fn imsg_composev(
     imsgbuf: *mut imsgbuf,
     type_: u32,
     id: u32,
@@ -377,7 +377,7 @@ pub unsafe extern "C" fn imsg_composev(
     }
 }
 
-pub unsafe extern "C" fn imsg_compose_ibuf(
+pub unsafe fn imsg_compose_ibuf(
     imsgbuf: *mut imsgbuf,
     type_: u32,
     id: u32,
@@ -426,7 +426,7 @@ pub unsafe extern "C" fn imsg_compose_ibuf(
     }
 }
 
-pub unsafe extern "C" fn imsg_forward(imsgbuf: *mut imsgbuf, msg: *mut imsg) -> c_int {
+pub unsafe fn imsg_forward(imsgbuf: *mut imsgbuf, msg: *mut imsg) -> c_int {
     unsafe {
         let mut len = 0;
 
@@ -461,7 +461,7 @@ pub unsafe extern "C" fn imsg_forward(imsgbuf: *mut imsgbuf, msg: *mut imsg) -> 
     }
 }
 
-pub unsafe extern "C" fn imsg_create(
+pub unsafe fn imsg_create(
     imsgbuf: *mut imsgbuf,
     type_: u32,
     id: u32,
@@ -499,7 +499,7 @@ pub unsafe extern "C" fn imsg_create(
     }
 }
 
-pub unsafe extern "C" fn imsg_add(msg: *mut ibuf, data: *const c_void, datalen: usize) -> i32 {
+pub unsafe fn imsg_add(msg: *mut ibuf, data: *const c_void, datalen: usize) -> i32 {
     unsafe {
         if datalen != 0 && ibuf_add(msg, data, datalen) == -1 {
             ibuf_free(msg);
@@ -509,7 +509,7 @@ pub unsafe extern "C" fn imsg_add(msg: *mut ibuf, data: *const c_void, datalen: 
     }
 }
 
-pub unsafe extern "C" fn imsg_close(imsgbuf: *mut imsgbuf, msg: *mut ibuf) {
+pub unsafe fn imsg_close(imsgbuf: *mut imsgbuf, msg: *mut ibuf) {
     unsafe {
         let hdr: *mut imsg_hdr = (*msg).buf as *mut imsg_hdr;
 
@@ -523,11 +523,11 @@ pub unsafe extern "C" fn imsg_close(imsgbuf: *mut imsgbuf, msg: *mut ibuf) {
     }
 }
 
-pub unsafe extern "C" fn imsg_free(imsg: *mut imsg) {
+pub unsafe fn imsg_free(imsg: *mut imsg) {
     unsafe { ibuf_free((*imsg).buf) }
 }
 
-unsafe extern "C" fn imsg_dequeue_fd(imsgbuf: *mut imsgbuf) -> i32 {
+unsafe fn imsg_dequeue_fd(imsgbuf: *mut imsgbuf) -> i32 {
     unsafe {
         let Some(ifd) = NonNull::new(tailq_first(&raw mut (*imsgbuf).fds)) else {
             return -1;
@@ -543,7 +543,7 @@ unsafe extern "C" fn imsg_dequeue_fd(imsgbuf: *mut imsgbuf) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn imsg_flush(imsgbuf: *mut imsgbuf) -> c_int {
+pub unsafe fn imsg_flush(imsgbuf: *mut imsgbuf) -> c_int {
     unsafe {
         while (*imsgbuf).w.queued != 0 {
             if msgbuf_write(&raw mut (*imsgbuf).w) <= 0 {
@@ -554,7 +554,7 @@ pub unsafe extern "C" fn imsg_flush(imsgbuf: *mut imsgbuf) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn imsg_clear(imsgbuf: *mut imsgbuf) {
+pub unsafe fn imsg_clear(imsgbuf: *mut imsgbuf) {
     unsafe {
         msgbuf_clear(&raw mut (*imsgbuf).w);
 

--- a/src/compat/imsg_buffer.rs
+++ b/src/compat/imsg_buffer.rs
@@ -18,7 +18,7 @@ use super::{freezero, recallocarray};
 
 const IOV_MAX: usize = 1024; // TODO find where IOV_MAX is defined
 
-pub unsafe extern "C" fn ibuf_open(len: usize) -> *mut ibuf {
+pub unsafe fn ibuf_open(len: usize) -> *mut ibuf {
     unsafe {
         if len == 0 {
             errno!() = EINVAL;
@@ -42,7 +42,7 @@ pub unsafe extern "C" fn ibuf_open(len: usize) -> *mut ibuf {
     }
 }
 
-pub unsafe extern "C" fn ibuf_dynamic(len: usize, max: usize) -> *mut ibuf {
+pub unsafe fn ibuf_dynamic(len: usize, max: usize) -> *mut ibuf {
     unsafe {
         if len == 0 || max < len {
             errno!() = EINVAL;
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn ibuf_dynamic(len: usize, max: usize) -> *mut ibuf {
     }
 }
 
-pub unsafe extern "C" fn ibuf_realloc(buf: *mut ibuf, len: usize) -> i32 {
+pub unsafe fn ibuf_realloc(buf: *mut ibuf, len: usize) -> i32 {
     unsafe {
         /* on static buffers max is eq size and so the following fails */
         if len > usize::MAX - (*buf).wpos || (*buf).wpos + len > (*buf).max {
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn ibuf_realloc(buf: *mut ibuf, len: usize) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn ibuf_reserve(buf: *mut ibuf, len: usize) -> *mut c_void {
+pub unsafe fn ibuf_reserve(buf: *mut ibuf, len: usize) -> *mut c_void {
     unsafe {
         if len > usize::MAX - (*buf).wpos || (*buf).max == 0 {
             errno!() = ERANGE;
@@ -103,7 +103,7 @@ pub unsafe extern "C" fn ibuf_reserve(buf: *mut ibuf, len: usize) -> *mut c_void
     }
 }
 
-pub unsafe extern "C" fn ibuf_add(buf: *mut ibuf, data: *const c_void, len: usize) -> i32 {
+pub unsafe fn ibuf_add(buf: *mut ibuf, data: *const c_void, len: usize) -> i32 {
     unsafe {
         let b = ibuf_reserve(buf, len);
         if b.is_null() {
@@ -115,15 +115,15 @@ pub unsafe extern "C" fn ibuf_add(buf: *mut ibuf, data: *const c_void, len: usiz
     }
 }
 
-pub unsafe extern "C" fn ibuf_add_ibuf(buf: *mut ibuf, from: *const ibuf) -> c_int {
+pub unsafe fn ibuf_add_ibuf(buf: *mut ibuf, from: *const ibuf) -> c_int {
     unsafe { ibuf_add(buf, ibuf_data(from), ibuf_size(from)) }
 }
 
-pub unsafe extern "C" fn ibuf_add_buf(buf: *mut ibuf, from: *const ibuf) -> c_int {
+pub unsafe fn ibuf_add_buf(buf: *mut ibuf, from: *const ibuf) -> c_int {
     unsafe { ibuf_add_ibuf(buf, from) }
 }
 
-pub unsafe extern "C" fn ibuf_add_n8(buf: *mut ibuf, value: u64) -> c_int {
+pub unsafe fn ibuf_add_n8(buf: *mut ibuf, value: u64) -> c_int {
     unsafe {
         if value > u8::MAX as u64 {
             errno!() = EINVAL;
@@ -134,7 +134,7 @@ pub unsafe extern "C" fn ibuf_add_n8(buf: *mut ibuf, value: u64) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn ibuf_add_n16(buf: *mut ibuf, value: u64) -> c_int {
+pub unsafe fn ibuf_add_n16(buf: *mut ibuf, value: u64) -> c_int {
     unsafe {
         if value > u16::MAX as u64 {
             errno!() = EINVAL;
@@ -145,7 +145,7 @@ pub unsafe extern "C" fn ibuf_add_n16(buf: *mut ibuf, value: u64) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn ibuf_add_n32(buf: *mut ibuf, value: u64) -> c_int {
+pub unsafe fn ibuf_add_n32(buf: *mut ibuf, value: u64) -> c_int {
     unsafe {
         if value > u32::MAX as u64 {
             errno!() = EINVAL;
@@ -156,14 +156,14 @@ pub unsafe extern "C" fn ibuf_add_n32(buf: *mut ibuf, value: u64) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn ibuf_add_n64(buf: *mut ibuf, value: u64) -> c_int {
+pub unsafe fn ibuf_add_n64(buf: *mut ibuf, value: u64) -> c_int {
     unsafe {
         let v = value.to_be();
         ibuf_add(buf, &raw const v as _, size_of::<u64>())
     }
 }
 
-pub unsafe extern "C" fn ibuf_add_h16(buf: *mut ibuf, value: u64) -> c_int {
+pub unsafe fn ibuf_add_h16(buf: *mut ibuf, value: u64) -> c_int {
     unsafe {
         if value > u16::MAX as u64 {
             errno!() = EINVAL;
@@ -174,7 +174,7 @@ pub unsafe extern "C" fn ibuf_add_h16(buf: *mut ibuf, value: u64) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn ibuf_add_h32(buf: *mut ibuf, value: u64) -> c_int {
+pub unsafe fn ibuf_add_h32(buf: *mut ibuf, value: u64) -> c_int {
     unsafe {
         if value > u32::MAX as u64 {
             errno!() = EINVAL;
@@ -185,11 +185,11 @@ pub unsafe extern "C" fn ibuf_add_h32(buf: *mut ibuf, value: u64) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn ibuf_add_h64(buf: *mut ibuf, value: u64) -> c_int {
+pub unsafe fn ibuf_add_h64(buf: *mut ibuf, value: u64) -> c_int {
     unsafe { ibuf_add(buf, &raw const value as *const c_void, size_of::<u64>()) }
 }
 
-pub unsafe extern "C" fn ibuf_add_zero(buf: *mut ibuf, len: usize) -> c_int {
+pub unsafe fn ibuf_add_zero(buf: *mut ibuf, len: usize) -> c_int {
     unsafe {
         let b: *mut c_void = ibuf_reserve(buf, len);
         if b.is_null() {
@@ -200,7 +200,7 @@ pub unsafe extern "C" fn ibuf_add_zero(buf: *mut ibuf, len: usize) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn ibuf_seek(buf: *mut ibuf, pos: usize, len: usize) -> *mut c_void {
+pub unsafe fn ibuf_seek(buf: *mut ibuf, pos: usize, len: usize) -> *mut c_void {
     unsafe {
         /* only allow seeking between rpos and wpos */
         if ibuf_size(buf) < pos || usize::MAX - pos < len || ibuf_size(buf) < pos + len {
@@ -212,7 +212,7 @@ pub unsafe extern "C" fn ibuf_seek(buf: *mut ibuf, pos: usize, len: usize) -> *m
     }
 }
 
-pub unsafe extern "C" fn ibuf_set(
+pub unsafe fn ibuf_set(
     buf: *mut ibuf,
     pos: usize,
     data: *const c_void,
@@ -229,7 +229,7 @@ pub unsafe extern "C" fn ibuf_set(
     }
 }
 
-pub unsafe extern "C" fn ibuf_set_n8(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
+pub unsafe fn ibuf_set_n8(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
     unsafe {
         if value > u8::MAX as u64 {
             errno!() = EINVAL;
@@ -240,7 +240,7 @@ pub unsafe extern "C" fn ibuf_set_n8(buf: *mut ibuf, pos: usize, value: u64) -> 
     }
 }
 
-pub unsafe extern "C" fn ibuf_set_n16(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
+pub unsafe fn ibuf_set_n16(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
     unsafe {
         if value > u16::MAX as u64 {
             errno!() = EINVAL;
@@ -251,7 +251,7 @@ pub unsafe extern "C" fn ibuf_set_n16(buf: *mut ibuf, pos: usize, value: u64) ->
     }
 }
 
-pub unsafe extern "C" fn ibuf_set_n32(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
+pub unsafe fn ibuf_set_n32(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
     unsafe {
         if value > u32::MAX as u64 {
             errno!() = EINVAL;
@@ -262,14 +262,14 @@ pub unsafe extern "C" fn ibuf_set_n32(buf: *mut ibuf, pos: usize, value: u64) ->
     }
 }
 
-pub unsafe extern "C" fn ibuf_set_n64(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
+pub unsafe fn ibuf_set_n64(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
     unsafe {
         let v = u64::to_be(value);
         ibuf_set(buf, pos, &raw const v as *const c_void, size_of::<u64>())
     }
 }
 
-pub unsafe extern "C" fn ibuf_set_h16(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
+pub unsafe fn ibuf_set_h16(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
     unsafe {
         if value > u16::MAX as u64 {
             errno!() = EINVAL;
@@ -280,7 +280,7 @@ pub unsafe extern "C" fn ibuf_set_h16(buf: *mut ibuf, pos: usize, value: u64) ->
     }
 }
 
-pub unsafe extern "C" fn ibuf_set_h32(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
+pub unsafe fn ibuf_set_h32(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
     unsafe {
         if value > u32::MAX as u64 {
             errno!() = EINVAL;
@@ -291,7 +291,7 @@ pub unsafe extern "C" fn ibuf_set_h32(buf: *mut ibuf, pos: usize, value: u64) ->
     }
 }
 
-pub unsafe extern "C" fn ibuf_set_h64(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
+pub unsafe fn ibuf_set_h64(buf: *mut ibuf, pos: usize, value: u64) -> c_int {
     unsafe {
         ibuf_set(
             buf,
@@ -302,15 +302,15 @@ pub unsafe extern "C" fn ibuf_set_h64(buf: *mut ibuf, pos: usize, value: u64) ->
     }
 }
 
-pub unsafe extern "C" fn ibuf_data(buf: *const ibuf) -> *mut c_void {
+pub unsafe fn ibuf_data(buf: *const ibuf) -> *mut c_void {
     unsafe { (*buf).buf.add((*buf).rpos) as *mut c_void }
 }
 
-pub unsafe extern "C" fn ibuf_size(buf: *const ibuf) -> usize {
+pub unsafe fn ibuf_size(buf: *const ibuf) -> usize {
     unsafe { (*buf).wpos - (*buf).rpos }
 }
 
-pub unsafe extern "C" fn ibuf_left(buf: *const ibuf) -> usize {
+pub unsafe fn ibuf_left(buf: *const ibuf) -> usize {
     unsafe {
         if (*buf).max == 0 {
             return 0;
@@ -319,7 +319,7 @@ pub unsafe extern "C" fn ibuf_left(buf: *const ibuf) -> usize {
     }
 }
 
-pub unsafe extern "C" fn ibuf_truncate(buf: *mut ibuf, len: usize) -> c_int {
+pub unsafe fn ibuf_truncate(buf: *mut ibuf, len: usize) -> c_int {
     unsafe {
         if ibuf_size(buf) >= len {
             (*buf).wpos = (*buf).rpos + len;
@@ -334,19 +334,19 @@ pub unsafe extern "C" fn ibuf_truncate(buf: *mut ibuf, len: usize) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn ibuf_rewind(buf: *mut ibuf) {
+pub unsafe fn ibuf_rewind(buf: *mut ibuf) {
     unsafe {
         (*buf).rpos = 0;
     }
 }
 
-pub unsafe extern "C" fn ibuf_close(msgbuf: *mut msgbuf, buf: *mut ibuf) {
+pub unsafe fn ibuf_close(msgbuf: *mut msgbuf, buf: *mut ibuf) {
     unsafe {
         ibuf_enqueue(msgbuf, buf);
     }
 }
 
-pub unsafe extern "C" fn ibuf_from_buffer(buf: *mut ibuf, data: *mut c_void, len: usize) {
+pub unsafe fn ibuf_from_buffer(buf: *mut ibuf, data: *mut c_void, len: usize) {
     unsafe {
         memset(buf as _, 0, size_of::<ibuf>());
         (*buf).buf = data as _;
@@ -356,13 +356,13 @@ pub unsafe extern "C" fn ibuf_from_buffer(buf: *mut ibuf, data: *mut c_void, len
     }
 }
 
-pub unsafe extern "C" fn ibuf_from_ibuf(buf: *mut ibuf, from: *const ibuf) {
+pub unsafe fn ibuf_from_ibuf(buf: *mut ibuf, from: *const ibuf) {
     unsafe {
         ibuf_from_buffer(buf, ibuf_data(from), ibuf_size(from));
     }
 }
 
-pub unsafe extern "C" fn ibuf_get(buf: *mut ibuf, data: *mut c_void, len: usize) -> c_int {
+pub unsafe fn ibuf_get(buf: *mut ibuf, data: *mut c_void, len: usize) -> c_int {
     unsafe {
         if ibuf_size(buf) < len {
             errno!() = EBADMSG;
@@ -375,7 +375,7 @@ pub unsafe extern "C" fn ibuf_get(buf: *mut ibuf, data: *mut c_void, len: usize)
     }
 }
 
-pub unsafe extern "C" fn ibuf_get_ibuf(buf: *mut ibuf, len: usize, new: *mut ibuf) -> c_int {
+pub unsafe fn ibuf_get_ibuf(buf: *mut ibuf, len: usize, new: *mut ibuf) -> c_int {
     unsafe {
         if ibuf_size(buf) < len {
             errno!() = EBADMSG;
@@ -388,11 +388,11 @@ pub unsafe extern "C" fn ibuf_get_ibuf(buf: *mut ibuf, len: usize, new: *mut ibu
     }
 }
 
-pub unsafe extern "C" fn ibuf_get_n8(buf: *mut ibuf, value: *mut u8) -> c_int {
+pub unsafe fn ibuf_get_n8(buf: *mut ibuf, value: *mut u8) -> c_int {
     unsafe { ibuf_get(buf, value as _, size_of::<u8>()) }
 }
 
-pub unsafe extern "C" fn ibuf_get_n16(buf: *mut ibuf, value: *mut u16) -> c_int {
+pub unsafe fn ibuf_get_n16(buf: *mut ibuf, value: *mut u16) -> c_int {
     unsafe {
         let rv = ibuf_get(buf, value as _, size_of::<u16>());
         *value = u16::from_be(*value);
@@ -400,7 +400,7 @@ pub unsafe extern "C" fn ibuf_get_n16(buf: *mut ibuf, value: *mut u16) -> c_int 
     }
 }
 
-pub unsafe extern "C" fn ibuf_get_n32(buf: *mut ibuf, value: *mut u32) -> c_int {
+pub unsafe fn ibuf_get_n32(buf: *mut ibuf, value: *mut u32) -> c_int {
     unsafe {
         let rv = ibuf_get(buf, value as _, size_of::<u32>());
         *value = u32::from_be(*value);
@@ -408,7 +408,7 @@ pub unsafe extern "C" fn ibuf_get_n32(buf: *mut ibuf, value: *mut u32) -> c_int 
     }
 }
 
-pub unsafe extern "C" fn ibuf_get_n64(buf: *mut ibuf, value: *mut u64) -> c_int {
+pub unsafe fn ibuf_get_n64(buf: *mut ibuf, value: *mut u64) -> c_int {
     unsafe {
         let rv = ibuf_get(buf, value as _, size_of::<u64>());
         *value = u64::from_be(*value);
@@ -416,19 +416,19 @@ pub unsafe extern "C" fn ibuf_get_n64(buf: *mut ibuf, value: *mut u64) -> c_int 
     }
 }
 
-pub unsafe extern "C" fn ibuf_get_h16(buf: *mut ibuf, value: *mut u16) -> c_int {
+pub unsafe fn ibuf_get_h16(buf: *mut ibuf, value: *mut u16) -> c_int {
     unsafe { ibuf_get(buf, value as _, size_of::<u16>()) }
 }
 
-pub unsafe extern "C" fn ibuf_get_h32(buf: *mut ibuf, value: *mut u32) -> c_int {
+pub unsafe fn ibuf_get_h32(buf: *mut ibuf, value: *mut u32) -> c_int {
     unsafe { ibuf_get(buf, value as _, size_of::<u32>()) }
 }
 
-pub unsafe extern "C" fn ibuf_get_h64(buf: *mut ibuf, value: *mut u64) -> c_int {
+pub unsafe fn ibuf_get_h64(buf: *mut ibuf, value: *mut u64) -> c_int {
     unsafe { ibuf_get(buf, value as _, size_of::<u64>()) }
 }
 
-pub unsafe extern "C" fn ibuf_skip(buf: *mut ibuf, len: usize) -> c_int {
+pub unsafe fn ibuf_skip(buf: *mut ibuf, len: usize) -> c_int {
     unsafe {
         if ibuf_size(buf) < len {
             errno!() = EBADMSG;
@@ -440,7 +440,7 @@ pub unsafe extern "C" fn ibuf_skip(buf: *mut ibuf, len: usize) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn ibuf_free(buf: *mut ibuf) {
+pub unsafe fn ibuf_free(buf: *mut ibuf) {
     unsafe {
         if buf.is_null() {
             return;
@@ -457,11 +457,11 @@ pub unsafe extern "C" fn ibuf_free(buf: *mut ibuf) {
     }
 }
 
-pub unsafe extern "C" fn ibuf_fd_avail(buf: *mut ibuf) -> c_int {
+pub unsafe fn ibuf_fd_avail(buf: *mut ibuf) -> c_int {
     unsafe { ((*buf).fd != -1) as c_int }
 }
 
-pub unsafe extern "C" fn ibuf_fd_get(buf: *mut ibuf) -> c_int {
+pub unsafe fn ibuf_fd_get(buf: *mut ibuf) -> c_int {
     unsafe {
         let fd = (*buf).fd;
         (*buf).fd = -1;
@@ -469,7 +469,7 @@ pub unsafe extern "C" fn ibuf_fd_get(buf: *mut ibuf) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn ibuf_fd_set(buf: *mut ibuf, fd: c_int) {
+pub unsafe fn ibuf_fd_set(buf: *mut ibuf, fd: c_int) {
     unsafe {
         if (*buf).max == 0 {
             /* if buf lives on the stack */
@@ -482,7 +482,7 @@ pub unsafe extern "C" fn ibuf_fd_set(buf: *mut ibuf, fd: c_int) {
     }
 }
 
-pub unsafe extern "C" fn ibuf_write(msgbuf: *mut msgbuf) -> c_int {
+pub unsafe fn ibuf_write(msgbuf: *mut msgbuf) -> c_int {
     unsafe {
         let mut i: u32 = 0;
 
@@ -532,7 +532,7 @@ pub unsafe extern "C" fn ibuf_write(msgbuf: *mut msgbuf) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn msgbuf_init(msgbuf: *mut msgbuf) {
+pub unsafe fn msgbuf_init(msgbuf: *mut msgbuf) {
     unsafe {
         (*msgbuf).queued = 0;
         (*msgbuf).fd = -1;
@@ -558,7 +558,7 @@ unsafe fn msgbuf_drain(msgbuf: *mut msgbuf, mut n: usize) {
     }
 }
 
-pub unsafe extern "C" fn msgbuf_clear(msgbuf: *mut msgbuf) {
+pub unsafe fn msgbuf_clear(msgbuf: *mut msgbuf) {
     unsafe {
         let mut buf;
         while {
@@ -570,7 +570,7 @@ pub unsafe extern "C" fn msgbuf_clear(msgbuf: *mut msgbuf) {
     }
 }
 
-pub unsafe extern "C" fn msgbuf_write(msgbuf: *mut msgbuf) -> c_int {
+pub unsafe fn msgbuf_write(msgbuf: *mut msgbuf) -> c_int {
     unsafe {
         let mut iov: [iovec; IOV_MAX] = std::mem::zeroed();
         let mut buf0: *mut ibuf = null_mut();
@@ -641,7 +641,7 @@ pub unsafe extern "C" fn msgbuf_write(msgbuf: *mut msgbuf) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn msgbuf_queuelen(msgbuf: *mut msgbuf) -> u32 {
+pub unsafe fn msgbuf_queuelen(msgbuf: *mut msgbuf) -> u32 {
     unsafe { (*msgbuf).queued }
 }
 

--- a/src/compat/ntohll.rs
+++ b/src/compat/ntohll.rs
@@ -4,14 +4,14 @@ pub type __uint64_t = libc::c_ulong;
 pub type uint32_t = __uint32_t;
 pub type uint64_t = __uint64_t;
 #[inline]
-unsafe extern "C" fn __bswap_32(mut __bsx: __uint32_t) -> __uint32_t {
+unsafe fn __bswap_32(mut __bsx: __uint32_t) -> __uint32_t {
     return (__bsx & 0xff000000 as libc::c_uint) >> 24 as libc::c_int
         | (__bsx & 0xff0000 as libc::c_uint) >> 8 as libc::c_int
         | (__bsx & 0xff00 as libc::c_uint) << 8 as libc::c_int
         | (__bsx & 0xff as libc::c_uint) << 24 as libc::c_int;
 }
 #[no_mangle]
-pub unsafe extern "C" fn ntohll(mut v: uint64_t) -> uint64_t {
+pub unsafe fn ntohll(mut v: uint64_t) -> uint64_t {
     let mut b: uint32_t = 0;
     let mut t: uint32_t = 0;
     b = __bswap_32((v & 0xffffffff as libc::c_uint as libc::c_ulong) as __uint32_t);

--- a/src/compat/unvis.rs
+++ b/src/compat/unvis.rs
@@ -29,7 +29,7 @@
 // TODO refactor
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn unvis(
+pub unsafe fn unvis(
     mut cp: *mut libc::c_char,
     mut c: libc::c_char,
     mut astate: *mut libc::c_int,
@@ -187,7 +187,7 @@ pub unsafe extern "C" fn unvis(
     }
 }
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn strunvis(mut dst: *mut libc::c_char, mut src: *const libc::c_char) -> i32 {
+pub unsafe fn strunvis(mut dst: *mut libc::c_char, mut src: *const libc::c_char) -> i32 {
     unsafe {
         let mut c: libc::c_char = 0;
         let mut start: *mut libc::c_char = dst;
@@ -229,7 +229,7 @@ pub unsafe extern "C" fn strunvis(mut dst: *mut libc::c_char, mut src: *const li
     }
 }
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn strnunvis(
+pub unsafe fn strnunvis(
     mut dst: *mut libc::c_char,
     mut src: *const libc::c_char,
     mut sz: usize,

--- a/src/control.rs
+++ b/src/control.rs
@@ -136,7 +136,7 @@ pub const CONTROL_MAXIMUM_AGE: u64 = 300000;
 pub const CONTROL_IGNORE_FLAGS: client_flag =
     client_flag::CONTROL_NOOUTPUT.union(CLIENT_UNATTACHEDFLAGS);
 
-pub unsafe extern "C" fn control_pane_cmp(
+pub unsafe fn control_pane_cmp(
     cp1: *const control_pane,
     cp2: *const control_pane,
 ) -> Ordering {
@@ -150,7 +150,7 @@ RB_GENERATE!(
     control_pane_cmp
 );
 
-pub unsafe extern "C" fn control_sub_cmp(
+pub unsafe fn control_sub_cmp(
     csub1: *const control_sub,
     csub2: *const control_sub,
 ) -> std::cmp::Ordering {
@@ -164,7 +164,7 @@ RB_GENERATE!(
     control_sub_cmp
 );
 
-pub unsafe extern "C" fn control_sub_pane_cmp(
+pub unsafe fn control_sub_pane_cmp(
     csp1: *const control_sub_pane,
     csp2: *const control_sub_pane,
 ) -> std::cmp::Ordering {
@@ -183,7 +183,7 @@ RB_GENERATE!(
     control_sub_pane_cmp
 );
 
-pub unsafe extern "C" fn control_sub_window_cmp(
+pub unsafe fn control_sub_window_cmp(
     csw1: *const control_sub_window,
     csw2: *const control_sub_window,
 ) -> Ordering {
@@ -202,7 +202,7 @@ RB_GENERATE!(
     control_sub_window_cmp
 );
 
-pub unsafe extern "C" fn control_free_sub(cs: *mut control_state, csub: *mut control_sub) {
+pub unsafe fn control_free_sub(cs: *mut control_state, csub: *mut control_sub) {
     unsafe {
         for csp in rb_foreach(&raw mut (*csub).panes).map(NonNull::as_ptr) {
             rb_remove(&raw mut (*csub).panes, csp);
@@ -221,7 +221,7 @@ pub unsafe extern "C" fn control_free_sub(cs: *mut control_state, csub: *mut con
     }
 }
 
-pub unsafe extern "C" fn control_free_block(cs: *mut control_state, cb: *mut control_block) {
+pub unsafe fn control_free_block(cs: *mut control_state, cb: *mut control_block) {
     unsafe {
         free_((*cb).line);
         tailq_remove::<_, discr_all_entry>(&raw mut (*cs).all_blocks, cb);
@@ -229,7 +229,7 @@ pub unsafe extern "C" fn control_free_block(cs: *mut control_state, cb: *mut con
     }
 }
 
-pub unsafe extern "C" fn control_get_pane(
+pub unsafe fn control_get_pane(
     c: *mut client,
     wp: *mut window_pane,
 ) -> *mut control_pane {
@@ -241,7 +241,7 @@ pub unsafe extern "C" fn control_get_pane(
     }
 }
 
-pub unsafe extern "C" fn control_add_pane(
+pub unsafe fn control_add_pane(
     c: *mut client,
     wp: *mut window_pane,
 ) -> NonNull<control_pane> {
@@ -264,7 +264,7 @@ pub unsafe extern "C" fn control_add_pane(
     }
 }
 
-pub unsafe extern "C" fn control_discard_pane(c: *mut client, cp: *mut control_pane) {
+pub unsafe fn control_discard_pane(c: *mut client, cp: *mut control_pane) {
     unsafe {
         let cs = (*c).control_state;
 
@@ -275,7 +275,7 @@ pub unsafe extern "C" fn control_discard_pane(c: *mut client, cp: *mut control_p
     }
 }
 
-pub unsafe extern "C" fn control_window_pane(
+pub unsafe fn control_window_pane(
     c: *mut client,
     pane: u32,
 ) -> Option<NonNull<window_pane>> {
@@ -291,7 +291,7 @@ pub unsafe extern "C" fn control_window_pane(
     }
 }
 
-pub unsafe extern "C" fn control_reset_offsets(c: *mut client) {
+pub unsafe fn control_reset_offsets(c: *mut client) {
     unsafe {
         let cs = (*c).control_state;
 
@@ -305,7 +305,7 @@ pub unsafe extern "C" fn control_reset_offsets(c: *mut client) {
     }
 }
 
-pub unsafe extern "C" fn control_pane_offset(
+pub unsafe fn control_pane_offset(
     c: *mut client,
     wp: *mut window_pane,
     off: *mut i32,
@@ -332,7 +332,7 @@ pub unsafe extern "C" fn control_pane_offset(
     }
 }
 
-pub unsafe extern "C" fn control_set_pane_on(c: *mut client, wp: *mut window_pane) {
+pub unsafe fn control_set_pane_on(c: *mut client, wp: *mut window_pane) {
     unsafe {
         let cp = control_get_pane(c, wp);
         if !cp.is_null() && (*cp).flags & CONTROL_PANE_OFF != 0 {
@@ -343,14 +343,14 @@ pub unsafe extern "C" fn control_set_pane_on(c: *mut client, wp: *mut window_pan
     }
 }
 
-pub unsafe extern "C" fn control_set_pane_off(c: *mut client, wp: *mut window_pane) {
+pub unsafe fn control_set_pane_off(c: *mut client, wp: *mut window_pane) {
     unsafe {
         let cp = control_add_pane(c, wp);
         (*cp.as_ptr()).flags |= CONTROL_PANE_OFF;
     }
 }
 
-pub unsafe extern "C" fn control_continue_pane(c: *mut client, wp: *mut window_pane) {
+pub unsafe fn control_continue_pane(c: *mut client, wp: *mut window_pane) {
     unsafe {
         let cp = control_get_pane(c, wp);
         if !cp.is_null() && ((*cp).flags & CONTROL_PANE_PAUSED) != 0 {
@@ -362,7 +362,7 @@ pub unsafe extern "C" fn control_continue_pane(c: *mut client, wp: *mut window_p
     }
 }
 
-pub unsafe extern "C" fn control_pause_pane(c: *mut client, wp: *mut window_pane) {
+pub unsafe fn control_pause_pane(c: *mut client, wp: *mut window_pane) {
     unsafe {
         let cp = control_add_pane(c, wp).as_ptr();
         if !(*cp).flags & CONTROL_PANE_PAUSED != 0 {
@@ -429,7 +429,7 @@ pub unsafe fn control_write_(c: *mut client, args: std::fmt::Arguments) {
     }
 }
 
-pub unsafe extern "C" fn control_check_age(
+pub unsafe fn control_check_age(
     c: *mut client,
     wp: *mut window_pane,
     cp: *mut control_pane,
@@ -474,7 +474,7 @@ pub unsafe extern "C" fn control_check_age(
     1
 }
 
-pub unsafe extern "C" fn control_write_output(c: *mut client, wp: *mut window_pane) {
+pub unsafe fn control_write_output(c: *mut client, wp: *mut window_pane) {
     let __func__ = "control_write_output";
     unsafe {
         let cs = (*c).control_state;
@@ -547,7 +547,7 @@ pub unsafe extern "C" fn control_write_output(c: *mut client, wp: *mut window_pa
     }
 }
 
-pub unsafe extern "C" fn control_error(item: *mut cmdq_item, data: *mut c_void) -> cmd_retval {
+pub unsafe fn control_error(item: *mut cmdq_item, data: *mut c_void) -> cmd_retval {
     unsafe {
         let c = cmdq_get_client(item);
         let error = data as *mut c_char;
@@ -561,7 +561,7 @@ pub unsafe extern "C" fn control_error(item: *mut cmdq_item, data: *mut c_void) 
     cmd_retval::CMD_RETURN_NORMAL
 }
 
-pub unsafe extern "C" fn control_error_callback(
+pub unsafe fn control_error_callback(
     _bufev: *mut bufferevent,
     what: i16,
     data: *mut c_void,
@@ -573,7 +573,7 @@ pub unsafe extern "C" fn control_error_callback(
     }
 }
 
-pub unsafe extern "C" fn control_read_callback(bufev: *mut bufferevent, data: *mut c_void) {
+pub unsafe fn control_read_callback(bufev: *mut bufferevent, data: *mut c_void) {
     let __func__ = "control_read_callback";
     let c: *mut client = data.cast();
 
@@ -607,7 +607,7 @@ pub unsafe extern "C" fn control_read_callback(bufev: *mut bufferevent, data: *m
     }
 }
 
-pub unsafe extern "C" fn control_all_done(c: *mut client) -> i32 {
+pub unsafe fn control_all_done(c: *mut client) -> i32 {
     unsafe {
         let cs = (*c).control_state;
 
@@ -618,7 +618,7 @@ pub unsafe extern "C" fn control_all_done(c: *mut client) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn control_flush_all_blocks(c: *mut client) {
+pub unsafe fn control_flush_all_blocks(c: *mut client) {
     let __func__ = "control_flush_all_blocks";
     unsafe {
         let cs = (*c).control_state;
@@ -643,7 +643,7 @@ pub unsafe extern "C" fn control_flush_all_blocks(c: *mut client) {
     }
 }
 
-pub unsafe extern "C" fn control_append_data(
+pub unsafe fn control_append_data(
     c: *mut client,
     cp: *mut control_pane,
     age: u64,
@@ -682,7 +682,7 @@ pub unsafe extern "C" fn control_append_data(
     }
 }
 
-pub unsafe extern "C" fn control_write_data(c: *mut client, message: *mut evbuffer) {
+pub unsafe fn control_write_data(c: *mut client, message: *mut evbuffer) {
     unsafe {
         let cs = (*c).control_state;
 
@@ -699,7 +699,7 @@ pub unsafe extern "C" fn control_write_data(c: *mut client, message: *mut evbuff
     }
 }
 
-pub unsafe extern "C" fn control_write_pending(
+pub unsafe fn control_write_pending(
     c: *mut client,
     cp: *mut control_pane,
     limit: usize,
@@ -775,7 +775,7 @@ pub unsafe extern "C" fn control_write_pending(
     }
 }
 
-pub unsafe extern "C" fn control_write_callback(bufev: *mut bufferevent, data: *mut c_void) {
+pub unsafe fn control_write_callback(bufev: *mut bufferevent, data: *mut c_void) {
     unsafe {
         let c: *mut client = data.cast();
         let cs = (*c).control_state;
@@ -821,7 +821,7 @@ pub unsafe extern "C" fn control_write_callback(bufev: *mut bufferevent, data: *
     }
 }
 
-pub unsafe extern "C" fn control_start(c: *mut client) {
+pub unsafe fn control_start(c: *mut client) {
     unsafe {
         if (*c).flags.intersects(client_flag::CONTROLCONTROL) {
             libc::close((*c).out_fd);
@@ -872,13 +872,13 @@ pub unsafe extern "C" fn control_start(c: *mut client) {
     }
 }
 
-pub unsafe extern "C" fn control_ready(c: *mut client) {
+pub unsafe fn control_ready(c: *mut client) {
     unsafe {
         bufferevent_enable((*(*c).control_state).read_event, EV_READ);
     }
 }
 
-pub unsafe extern "C" fn control_discard(c: *mut client) {
+pub unsafe fn control_discard(c: *mut client) {
     unsafe {
         let cs = (*c).control_state;
         for cp in rb_foreach(&raw mut (*cs).panes) {
@@ -888,7 +888,7 @@ pub unsafe extern "C" fn control_discard(c: *mut client) {
     }
 }
 
-pub unsafe extern "C" fn control_stop(c: *mut client) {
+pub unsafe fn control_stop(c: *mut client) {
     unsafe {
         let cs = (*c).control_state;
         if !(*c).flags.intersects(client_flag::CONTROLCONTROL) {
@@ -914,7 +914,7 @@ pub unsafe extern "C" fn control_stop(c: *mut client) {
     }
 }
 
-pub unsafe extern "C" fn control_check_subs_session(c: *mut client, csub: *mut control_sub) {
+pub unsafe fn control_check_subs_session(c: *mut client, csub: *mut control_sub) {
     unsafe {
         let s = (*c).session;
 
@@ -938,7 +938,7 @@ pub unsafe extern "C" fn control_check_subs_session(c: *mut client, csub: *mut c
     }
 }
 
-pub unsafe extern "C" fn control_check_subs_pane(c: *mut client, csub: *mut control_sub) {
+pub unsafe fn control_check_subs_pane(c: *mut client, csub: *mut control_sub) {
     unsafe {
         let s = (*c).session;
         let mut find: control_sub_pane = zeroed(); //TODO uninit
@@ -989,7 +989,7 @@ pub unsafe extern "C" fn control_check_subs_pane(c: *mut client, csub: *mut cont
     }
 }
 
-pub unsafe extern "C" fn control_check_subs_all_panes(c: *mut client, csub: *mut control_sub) {
+pub unsafe fn control_check_subs_all_panes(c: *mut client, csub: *mut control_sub) {
     unsafe {
         let s = (*c).session;
         let mut find: control_sub_pane = zeroed();
@@ -1033,7 +1033,7 @@ pub unsafe extern "C" fn control_check_subs_all_panes(c: *mut client, csub: *mut
     }
 }
 
-pub unsafe extern "C" fn control_check_subs_window(c: *mut client, csub: *mut control_sub) {
+pub unsafe fn control_check_subs_window(c: *mut client, csub: *mut control_sub) {
     unsafe {
         let s = (*c).session;
         let mut find: control_sub_window = zeroed(); // TODO uninit
@@ -1084,7 +1084,7 @@ pub unsafe extern "C" fn control_check_subs_window(c: *mut client, csub: *mut co
     }
 }
 
-pub unsafe extern "C" fn control_check_subs_all_windows(c: *mut client, csub: *mut control_sub) {
+pub unsafe fn control_check_subs_all_windows(c: *mut client, csub: *mut control_sub) {
     unsafe {
         let s = (*c).session;
         let mut find: control_sub_window = zeroed();
@@ -1126,7 +1126,7 @@ pub unsafe extern "C" fn control_check_subs_all_windows(c: *mut client, csub: *m
     }
 }
 
-pub unsafe extern "C" fn control_check_subs_timer(fd: i32, events: i16, data: *mut c_void) {
+pub unsafe fn control_check_subs_timer(fd: i32, events: i16, data: *mut c_void) {
     unsafe {
         let c: *mut client = data.cast();
         let cs = (*c).control_state;
@@ -1152,7 +1152,7 @@ pub unsafe extern "C" fn control_check_subs_timer(fd: i32, events: i16, data: *m
     }
 }
 
-pub unsafe extern "C" fn control_add_sub(
+pub unsafe fn control_add_sub(
     c: *mut client,
     name: *mut c_char,
     type_: control_sub_type,
@@ -1197,7 +1197,7 @@ pub unsafe extern "C" fn control_add_sub(
     }
 }
 
-pub unsafe extern "C" fn control_remove_sub(c: *mut client, name: *mut c_char) {
+pub unsafe fn control_remove_sub(c: *mut client, name: *mut c_char) {
     unsafe {
         let cs = (*c).control_state;
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -561,7 +561,7 @@ pub unsafe fn control_error(item: *mut cmdq_item, data: *mut c_void) -> cmd_retv
     cmd_retval::CMD_RETURN_NORMAL
 }
 
-pub unsafe fn control_error_callback(
+pub unsafe extern "C" fn control_error_callback(
     _bufev: *mut bufferevent,
     what: i16,
     data: *mut c_void,
@@ -573,7 +573,7 @@ pub unsafe fn control_error_callback(
     }
 }
 
-pub unsafe fn control_read_callback(bufev: *mut bufferevent, data: *mut c_void) {
+pub unsafe extern "C" fn control_read_callback(bufev: *mut bufferevent, data: *mut c_void) {
     let __func__ = "control_read_callback";
     let c: *mut client = data.cast();
 
@@ -775,7 +775,7 @@ pub unsafe fn control_write_pending(
     }
 }
 
-pub unsafe fn control_write_callback(bufev: *mut bufferevent, data: *mut c_void) {
+pub unsafe extern "C" fn control_write_callback(bufev: *mut bufferevent, data: *mut c_void) {
     unsafe {
         let c: *mut client = data.cast();
         let cs = (*c).control_state;
@@ -1126,7 +1126,7 @@ pub unsafe fn control_check_subs_all_windows(c: *mut client, csub: *mut control_
     }
 }
 
-pub unsafe fn control_check_subs_timer(fd: i32, events: i16, data: *mut c_void) {
+pub unsafe extern "C" fn control_check_subs_timer(fd: i32, events: i16, data: *mut c_void) {
     unsafe {
         let c: *mut client = data.cast();
         let cs = (*c).control_state;

--- a/src/control_notify.rs
+++ b/src/control_notify.rs
@@ -23,7 +23,7 @@ macro_rules! CONTROL_SHOULD_NOTIFY_CLIENT {
     };
 }
 
-pub unsafe extern "C" fn control_notify_pane_mode_changed(pane: c_int) {
+pub unsafe fn control_notify_pane_mode_changed(pane: c_int) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             {
@@ -37,7 +37,7 @@ pub unsafe extern "C" fn control_notify_pane_mode_changed(pane: c_int) {
     }
 }
 
-pub unsafe extern "C" fn control_notify_window_layout_changed(w: *mut window) {
+pub unsafe fn control_notify_window_layout_changed(w: *mut window) {
     let template = c"%layout-change #{window_id} #{window_layout} #{window_visible_layout} #{window_raw_flags}".as_ptr();
 
     unsafe {
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn control_notify_window_layout_changed(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn control_notify_window_pane_changed(w: *mut window) {
+pub unsafe fn control_notify_window_pane_changed(w: *mut window) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             {
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn control_notify_window_pane_changed(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn control_notify_window_unlinked(s: *mut session, w: *mut window) {
+pub unsafe fn control_notify_window_unlinked(s: *mut session, w: *mut window) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             {
@@ -108,7 +108,7 @@ pub unsafe extern "C" fn control_notify_window_unlinked(s: *mut session, w: *mut
     }
 }
 
-pub unsafe extern "C" fn control_notify_window_linked(s: *mut session, w: *mut window) {
+pub unsafe fn control_notify_window_linked(s: *mut session, w: *mut window) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             {
@@ -127,7 +127,7 @@ pub unsafe extern "C" fn control_notify_window_linked(s: *mut session, w: *mut w
     }
 }
 
-pub unsafe extern "C" fn control_notify_window_renamed(w: *mut window) {
+pub unsafe fn control_notify_window_renamed(w: *mut window) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             {
@@ -146,7 +146,7 @@ pub unsafe extern "C" fn control_notify_window_renamed(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn control_notify_client_session_changed(cc: *mut client) {
+pub unsafe fn control_notify_client_session_changed(cc: *mut client) {
     unsafe {
         if (*cc).session.is_null() {
             return;
@@ -175,7 +175,7 @@ pub unsafe extern "C" fn control_notify_client_session_changed(cc: *mut client) 
     }
 }
 
-pub unsafe extern "C" fn control_notify_client_detached(cc: *mut client) {
+pub unsafe fn control_notify_client_detached(cc: *mut client) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             {
@@ -187,7 +187,7 @@ pub unsafe extern "C" fn control_notify_client_detached(cc: *mut client) {
     }
 }
 
-pub unsafe extern "C" fn control_notify_session_renamed(s: *mut session) {
+pub unsafe fn control_notify_session_renamed(s: *mut session) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             {
@@ -201,7 +201,7 @@ pub unsafe extern "C" fn control_notify_session_renamed(s: *mut session) {
     }
 }
 
-pub unsafe extern "C" fn control_notify_session_created(_: *mut session) {
+pub unsafe fn control_notify_session_created(_: *mut session) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             {
@@ -215,7 +215,7 @@ pub unsafe extern "C" fn control_notify_session_created(_: *mut session) {
     }
 }
 
-pub unsafe extern "C" fn control_notify_session_closed(_: *mut session) {
+pub unsafe fn control_notify_session_closed(_: *mut session) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             {
@@ -229,7 +229,7 @@ pub unsafe extern "C" fn control_notify_session_closed(_: *mut session) {
     }
 }
 
-pub unsafe extern "C" fn control_notify_session_window_changed(s: *mut session) {
+pub unsafe fn control_notify_session_window_changed(s: *mut session) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             {
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn control_notify_session_window_changed(s: *mut session) 
     }
 }
 
-pub unsafe extern "C" fn control_notify_paste_buffer_changed(name: *const c_char) {
+pub unsafe fn control_notify_paste_buffer_changed(name: *const c_char) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             {
@@ -262,7 +262,7 @@ pub unsafe extern "C" fn control_notify_paste_buffer_changed(name: *const c_char
     }
 }
 
-pub unsafe extern "C" fn control_notify_paste_buffer_deleted(name: *const c_char) {
+pub unsafe fn control_notify_paste_buffer_deleted(name: *const c_char) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             {

--- a/src/environ_.rs
+++ b/src/environ_.rs
@@ -22,7 +22,7 @@ use crate::xmalloc::xcalloc_;
 pub type environ = rb_head<environ_entry>;
 RB_GENERATE!(environ, environ_entry, entry, discr_entry, environ_cmp);
 
-pub unsafe extern "C" fn environ_cmp(
+pub unsafe fn environ_cmp(
     envent1: *const environ_entry,
     envent2: *const environ_entry,
 ) -> std::cmp::Ordering {
@@ -54,15 +54,15 @@ pub unsafe fn environ_free(env: *mut environ) {
     }
 }
 
-pub unsafe extern "C" fn environ_first(env: *mut environ) -> *mut environ_entry {
+pub unsafe fn environ_first(env: *mut environ) -> *mut environ_entry {
     unsafe { rb_min(env) }
 }
 
-pub unsafe extern "C" fn environ_next(envent: *mut environ_entry) -> *mut environ_entry {
+pub unsafe fn environ_next(envent: *mut environ_entry) -> *mut environ_entry {
     unsafe { rb_next(envent) }
 }
 
-pub unsafe extern "C" fn environ_copy(srcenv: *mut environ, dstenv: *mut environ) {
+pub unsafe fn environ_copy(srcenv: *mut environ, dstenv: *mut environ) {
     unsafe {
         for envent in rb_foreach(srcenv).map(NonNull::as_ptr) {
             if let Some(value) = (*envent).value {
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn environ_copy(srcenv: *mut environ, dstenv: *mut environ
     }
 }
 
-pub unsafe extern "C" fn environ_find(
+pub unsafe fn environ_find(
     env: *mut environ,
     name: *const c_char,
 ) -> *mut environ_entry {
@@ -127,7 +127,7 @@ pub unsafe fn environ_set_(
     }
 }
 
-pub unsafe extern "C" fn environ_clear(env: *mut environ, name: *const c_char) {
+pub unsafe fn environ_clear(env: *mut environ, name: *const c_char) {
     unsafe {
         let mut envent = environ_find(env, name);
         if !envent.is_null() {
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn environ_clear(env: *mut environ, name: *const c_char) {
     }
 }
 
-pub unsafe extern "C" fn environ_put(env: *mut environ, var: *const c_char, flags: c_int) {
+pub unsafe fn environ_put(env: *mut environ, var: *const c_char, flags: c_int) {
     unsafe {
         let mut value = libc::strchr(var, b'=' as c_int);
         if value.is_null() {
@@ -159,7 +159,7 @@ pub unsafe extern "C" fn environ_put(env: *mut environ, var: *const c_char, flag
     }
 }
 
-pub unsafe extern "C" fn environ_unset(env: *mut environ, name: *const c_char) {
+pub unsafe fn environ_unset(env: *mut environ, name: *const c_char) {
     unsafe {
         let envent = environ_find(env, name);
         if envent.is_null() {
@@ -172,7 +172,7 @@ pub unsafe extern "C" fn environ_unset(env: *mut environ, name: *const c_char) {
     }
 }
 
-pub unsafe extern "C" fn environ_update(oo: *mut options, src: *mut environ, dst: *mut environ) {
+pub unsafe fn environ_update(oo: *mut options, src: *mut environ, dst: *mut environ) {
     unsafe {
         let mut found: i32 = 0;
 
@@ -204,7 +204,7 @@ pub unsafe extern "C" fn environ_update(oo: *mut options, src: *mut environ, dst
     }
 }
 
-pub unsafe extern "C" fn environ_push(env: *mut environ) {
+pub unsafe fn environ_push(env: *mut environ) {
     unsafe {
         let mut envent: *mut environ_entry;
 
@@ -248,7 +248,7 @@ pub unsafe fn environ_log_(env: *mut environ, args: std::fmt::Arguments) {
     }
 }
 
-pub unsafe extern "C" fn environ_for_session(s: *mut session, no_term: c_int) -> *mut environ {
+pub unsafe fn environ_for_session(s: *mut session, no_term: c_int) -> *mut environ {
     let env: *mut environ = environ_create().as_ptr();
 
     unsafe {

--- a/src/event_.rs
+++ b/src/event_.rs
@@ -33,7 +33,7 @@ pub const EV_WRITE: i16 = 0x04;
 // #define evtimer_set(ev, cb, arg)	event_set((ev), -1, 0, (cb), (arg))
 pub unsafe fn evtimer_set(
     ev: *mut event,
-    cb: Option<unsafe fn(_: c_int, _: c_short, _: *mut c_void)>,
+    cb: Option<unsafe extern "C" fn(_: c_int, _: c_short, _: *mut c_void)>,
     arg: *mut c_void,
 ) {
     unsafe {
@@ -71,7 +71,7 @@ pub unsafe fn signal_add(ev: *mut event, tv: *const timeval) -> i32 {
 pub unsafe fn signal_set(
     ev: *mut event,
     x: i32,
-    cb: Option<unsafe fn(c_int, c_short, *mut c_void)>,
+    cb: Option<unsafe extern "C" fn(c_int, c_short, *mut c_void)>,
     arg: *mut c_void,
 ) {
     unsafe { event_set(ev, x, EV_SIGNAL | EV_PERSIST, cb, arg) }
@@ -159,9 +159,9 @@ pub struct event_base {
     _unused: [u8; 0],
 }
 pub type bufferevent_data_cb =
-    Option<unsafe fn(bev: *mut bufferevent, ctx: *mut c_void)>;
+    Option<unsafe extern "C" fn(bev: *mut bufferevent, ctx: *mut c_void)>;
 pub type bufferevent_event_cb =
-    Option<unsafe fn(bev: *mut bufferevent, what: c_short, ctx: *mut c_void)>;
+    Option<unsafe extern "C" fn(bev: *mut bufferevent, what: c_short, ctx: *mut c_void)>;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct event_callback {
@@ -181,10 +181,10 @@ pub struct event_callback__bindgen_ty_1 {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union event_callback__bindgen_ty_2 {
-    pub evcb_callback: Option<unsafe fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
-    pub evcb_selfcb: Option<unsafe fn(arg1: *mut event_callback, arg2: *mut c_void)>,
-    pub evcb_evfinalize: Option<unsafe fn(arg1: *mut event, arg2: *mut c_void)>,
-    pub evcb_cbfinalize: Option<unsafe fn(arg1: *mut event_callback, arg2: *mut c_void)>,
+    pub evcb_callback: Option<unsafe extern "C" fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
+    pub evcb_selfcb: Option<unsafe extern "C" fn(arg1: *mut event_callback, arg2: *mut c_void)>,
+    pub evcb_evfinalize: Option<unsafe extern "C" fn(arg1: *mut event, arg2: *mut c_void)>,
+    pub evcb_cbfinalize: Option<unsafe extern "C" fn(arg1: *mut event_callback, arg2: *mut c_void)>,
 }
 #[repr(C)]
 pub struct event {
@@ -263,7 +263,7 @@ pub struct bufferevent {
     pub timeout_write: timeval,
     pub enabled: c_short,
 }
-pub type event_log_cb = Option<unsafe fn(severity: c_int, msg: *const c_char)>;
+pub type event_log_cb = Option<unsafe extern "C" fn(severity: c_int, msg: *const c_char)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct bufferevent_ops {
@@ -317,7 +317,7 @@ unsafe extern "C" {
     pub fn event_once(
         arg1: c_int,
         arg2: c_short,
-        arg3: Option<unsafe fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
+        arg3: Option<unsafe extern "C" fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
         arg4: *mut c_void,
         arg5: *const timeval,
     ) -> c_int;
@@ -326,7 +326,7 @@ unsafe extern "C" {
         arg1: *mut event,
         arg2: c_int,
         arg3: c_short,
-        arg4: Option<unsafe fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
+        arg4: Option<unsafe extern "C" fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
         arg5: *mut c_void,
     );
 }
@@ -336,7 +336,7 @@ pub unsafe fn event_set_<T>(
     arg1: *mut event,
     arg2: c_int,
     arg3: c_short,
-    arg4: Option<unsafe fn(arg1: c_int, arg2: c_short, arg3: *mut T)>,
+    arg4: Option<unsafe extern "C" fn(arg1: c_int, arg2: c_short, arg3: *mut T)>,
     arg5: *mut T,
 ) {
     // with this we can start changing the interface of all the event set calls and modify
@@ -347,8 +347,8 @@ pub unsafe fn event_set_<T>(
             arg2,
             arg3,
             std::mem::transmute::<
-                Option<unsafe fn(arg1: c_int, arg2: c_short, arg3: *mut T)>,
-                Option<unsafe fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
+                Option<unsafe extern "C" fn(arg1: c_int, arg2: c_short, arg3: *mut T)>,
+                Option<unsafe extern "C" fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
             >(arg4),
             arg5.cast(),
         )

--- a/src/event_.rs
+++ b/src/event_.rs
@@ -31,9 +31,9 @@ pub const EV_WRITE: i16 = 0x04;
 // /usr/include/event2/event.h
 
 // #define evtimer_set(ev, cb, arg)	event_set((ev), -1, 0, (cb), (arg))
-pub unsafe extern "C" fn evtimer_set(
+pub unsafe fn evtimer_set(
     ev: *mut event,
-    cb: Option<unsafe extern "C" fn(_: c_int, _: c_short, _: *mut c_void)>,
+    cb: Option<unsafe fn(_: c_int, _: c_short, _: *mut c_void)>,
     arg: *mut c_void,
 ) {
     unsafe {
@@ -42,36 +42,36 @@ pub unsafe extern "C" fn evtimer_set(
 }
 
 // #define evtimer_add(ev, tv)		event_add((ev), (tv))
-pub unsafe extern "C" fn evtimer_add(ev: *mut event, tv: *const timeval) -> c_int {
+pub unsafe fn evtimer_add(ev: *mut event, tv: *const timeval) -> c_int {
     unsafe { event_add(ev, tv) }
 }
 
-pub unsafe extern "C" fn evtimer_initialized(ev: *mut event) -> bool {
+pub unsafe fn evtimer_initialized(ev: *mut event) -> bool {
     unsafe { event_initialized(ev) != 0 }
 }
 
 // #define evtimer_del(ev)			event_del(ev)
-pub unsafe extern "C" fn evtimer_del(ev: *mut event) -> c_int {
+pub unsafe fn evtimer_del(ev: *mut event) -> c_int {
     unsafe { event_del(ev) }
 }
 
 // #define evtimer_pending(ev, tv)		event_pending((ev), EV_TIMEOUT, (tv))
-pub unsafe extern "C" fn evtimer_pending(ev: *const event, tv: *mut libc::timeval) -> c_int {
+pub unsafe fn evtimer_pending(ev: *const event, tv: *mut libc::timeval) -> c_int {
     unsafe { event_pending(ev, EV_TIMEOUT, tv) }
 }
 
 // #define signal_add(ev, tv)		event_add((ev), (tv))
 #[inline]
-pub unsafe extern "C" fn signal_add(ev: *mut event, tv: *const timeval) -> i32 {
+pub unsafe fn signal_add(ev: *mut event, tv: *const timeval) -> i32 {
     unsafe { event_add(ev, tv) }
 }
 
 // #define signal_set(ev, x, cb, arg)				 event_set((ev), (x), EV_SIGNAL|EV_PERSIST, (cb), (arg))
 #[inline]
-pub unsafe extern "C" fn signal_set(
+pub unsafe fn signal_set(
     ev: *mut event,
     x: i32,
-    cb: Option<unsafe extern "C" fn(c_int, c_short, *mut c_void)>,
+    cb: Option<unsafe fn(c_int, c_short, *mut c_void)>,
     arg: *mut c_void,
 ) {
     unsafe { event_set(ev, x, EV_SIGNAL | EV_PERSIST, cb, arg) }
@@ -159,9 +159,9 @@ pub struct event_base {
     _unused: [u8; 0],
 }
 pub type bufferevent_data_cb =
-    Option<unsafe extern "C" fn(bev: *mut bufferevent, ctx: *mut c_void)>;
+    Option<unsafe fn(bev: *mut bufferevent, ctx: *mut c_void)>;
 pub type bufferevent_event_cb =
-    Option<unsafe extern "C" fn(bev: *mut bufferevent, what: c_short, ctx: *mut c_void)>;
+    Option<unsafe fn(bev: *mut bufferevent, what: c_short, ctx: *mut c_void)>;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct event_callback {
@@ -181,10 +181,10 @@ pub struct event_callback__bindgen_ty_1 {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union event_callback__bindgen_ty_2 {
-    pub evcb_callback: Option<unsafe extern "C" fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
-    pub evcb_selfcb: Option<unsafe extern "C" fn(arg1: *mut event_callback, arg2: *mut c_void)>,
-    pub evcb_evfinalize: Option<unsafe extern "C" fn(arg1: *mut event, arg2: *mut c_void)>,
-    pub evcb_cbfinalize: Option<unsafe extern "C" fn(arg1: *mut event_callback, arg2: *mut c_void)>,
+    pub evcb_callback: Option<unsafe fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
+    pub evcb_selfcb: Option<unsafe fn(arg1: *mut event_callback, arg2: *mut c_void)>,
+    pub evcb_evfinalize: Option<unsafe fn(arg1: *mut event, arg2: *mut c_void)>,
+    pub evcb_cbfinalize: Option<unsafe fn(arg1: *mut event_callback, arg2: *mut c_void)>,
 }
 #[repr(C)]
 pub struct event {
@@ -263,7 +263,7 @@ pub struct bufferevent {
     pub timeout_write: timeval,
     pub enabled: c_short,
 }
-pub type event_log_cb = Option<unsafe extern "C" fn(severity: c_int, msg: *const c_char)>;
+pub type event_log_cb = Option<unsafe fn(severity: c_int, msg: *const c_char)>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct bufferevent_ops {
@@ -317,7 +317,7 @@ unsafe extern "C" {
     pub fn event_once(
         arg1: c_int,
         arg2: c_short,
-        arg3: Option<unsafe extern "C" fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
+        arg3: Option<unsafe fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
         arg4: *mut c_void,
         arg5: *const timeval,
     ) -> c_int;
@@ -326,7 +326,7 @@ unsafe extern "C" {
         arg1: *mut event,
         arg2: c_int,
         arg3: c_short,
-        arg4: Option<unsafe extern "C" fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
+        arg4: Option<unsafe fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
         arg5: *mut c_void,
     );
 }
@@ -336,7 +336,7 @@ pub unsafe fn event_set_<T>(
     arg1: *mut event,
     arg2: c_int,
     arg3: c_short,
-    arg4: Option<unsafe extern "C" fn(arg1: c_int, arg2: c_short, arg3: *mut T)>,
+    arg4: Option<unsafe fn(arg1: c_int, arg2: c_short, arg3: *mut T)>,
     arg5: *mut T,
 ) {
     // with this we can start changing the interface of all the event set calls and modify
@@ -347,8 +347,8 @@ pub unsafe fn event_set_<T>(
             arg2,
             arg3,
             std::mem::transmute::<
-                Option<unsafe extern "C" fn(arg1: c_int, arg2: c_short, arg3: *mut T)>,
-                Option<unsafe extern "C" fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
+                Option<unsafe fn(arg1: c_int, arg2: c_short, arg3: *mut T)>,
+                Option<unsafe fn(arg1: c_int, arg2: c_short, arg3: *mut c_void)>,
             >(arg4),
             arg5.cast(),
         )

--- a/src/file.rs
+++ b/src/file.rs
@@ -132,7 +132,7 @@ pub unsafe fn file_free(cf: *mut client_file) {
     }
 }
 
-pub unsafe fn file_fire_done_cb(_fd: i32, _events: i16, arg: *mut c_void) {
+pub unsafe extern "C" fn file_fire_done_cb(_fd: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let cf: *mut client_file = arg as _;
         let c: *mut client = (*cf).c;
@@ -503,7 +503,7 @@ pub unsafe fn file_cancel(cf: *mut client_file) {
     }
 }
 
-pub unsafe fn file_push_cb(_fd: i32, _events: i16, arg: *mut c_void) {
+pub unsafe extern "C" fn file_push_cb(_fd: i32, _events: i16, arg: *mut c_void) {
     let cf = arg as *mut client_file;
 
     unsafe {
@@ -590,7 +590,7 @@ pub unsafe fn file_write_left(files: *mut client_files) -> c_int {
     (waiting != 0) as i32
 }
 
-pub unsafe fn file_write_error_callback(
+pub unsafe extern "C" fn file_write_error_callback(
     bev: *mut bufferevent,
     what: i16,
     arg: *mut c_void,
@@ -612,7 +612,7 @@ pub unsafe fn file_write_error_callback(
     }
 }
 
-pub unsafe fn file_write_callback(bev: *mut bufferevent, arg: *mut c_void) {
+pub unsafe extern "C" fn file_write_callback(bev: *mut bufferevent, arg: *mut c_void) {
     unsafe {
         let cf = arg as *mut client_file;
 
@@ -771,7 +771,7 @@ pub unsafe fn file_write_close(files: *mut client_files, imsg: *mut imsg) {
     }
 }
 
-pub unsafe fn file_read_error_callback(
+pub unsafe extern "C" fn file_read_error_callback(
     _bev: *mut bufferevent,
     what: i16,
     arg: *mut c_void,
@@ -800,7 +800,7 @@ pub unsafe fn file_read_error_callback(
     }
 }
 
-pub unsafe fn file_read_callback(bev: *mut bufferevent, arg: *mut c_void) {
+pub unsafe extern "C" fn file_read_callback(bev: *mut bufferevent, arg: *mut c_void) {
     let cf = arg as *mut client_file;
     unsafe {
         let mut msg = xmalloc_::<msg_read_data>();

--- a/src/file.rs
+++ b/src/file.rs
@@ -25,7 +25,7 @@ use libc::{
 
 pub static mut file_next_stream: i32 = 3;
 
-pub unsafe extern "C" fn file_get_path(c: *mut client, file: *const c_char) -> NonNull<c_char> {
+pub unsafe fn file_get_path(c: *mut client, file: *const c_char) -> NonNull<c_char> {
     unsafe {
         if *file == b'/' as c_char {
             xstrdup(file)
@@ -40,14 +40,14 @@ pub unsafe extern "C" fn file_get_path(c: *mut client, file: *const c_char) -> N
     }
 }
 
-pub unsafe extern "C" fn file_cmp(
+pub unsafe fn file_cmp(
     cf1: *const client_file,
     cf2: *const client_file,
 ) -> std::cmp::Ordering {
     unsafe { (*cf1).stream.cmp(&(*cf2).stream) }
 }
 
-pub unsafe extern "C" fn file_create_with_peer(
+pub unsafe fn file_create_with_peer(
     peer: *mut tmuxpeer,
     files: *mut client_files,
     stream: c_int,
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn file_create_with_peer(
     }
 }
 
-pub unsafe extern "C" fn file_create_with_client(
+pub unsafe fn file_create_with_client(
     mut c: *mut client,
     stream: c_int,
     cb: client_file_cb,
@@ -111,7 +111,7 @@ pub unsafe extern "C" fn file_create_with_client(
     }
 }
 
-pub unsafe extern "C" fn file_free(cf: *mut client_file) {
+pub unsafe fn file_free(cf: *mut client_file) {
     unsafe {
         (*cf).references -= 1;
         if (*cf).references != 0 {
@@ -132,7 +132,7 @@ pub unsafe extern "C" fn file_free(cf: *mut client_file) {
     }
 }
 
-pub unsafe extern "C" fn file_fire_done_cb(_fd: i32, _events: i16, arg: *mut c_void) {
+pub unsafe fn file_fire_done_cb(_fd: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let cf: *mut client_file = arg as _;
         let c: *mut client = (*cf).c;
@@ -146,13 +146,13 @@ pub unsafe extern "C" fn file_fire_done_cb(_fd: i32, _events: i16, arg: *mut c_v
     }
 }
 
-pub unsafe extern "C" fn file_fire_done(cf: *mut client_file) {
+pub unsafe fn file_fire_done(cf: *mut client_file) {
     unsafe {
         event_once(-1, EV_TIMEOUT, Some(file_fire_done_cb), cf as _, null_mut());
     }
 }
 
-pub unsafe extern "C" fn file_fire_read(cf: *mut client_file) {
+pub unsafe fn file_fire_read(cf: *mut client_file) {
     unsafe {
         if let Some(cb) = (*cf).cb {
             cb(
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn file_fire_read(cf: *mut client_file) {
     }
 }
 
-pub unsafe extern "C" fn file_can_print(c: *mut client) -> c_int {
+pub unsafe fn file_can_print(c: *mut client) -> c_int {
     unsafe {
         if c.is_null()
             || (*c).flags.intersects(client_flag::ATTACHED)
@@ -223,7 +223,7 @@ pub unsafe fn file_vprint(c: *mut client, args: std::fmt::Arguments) {
     }
 }
 
-pub unsafe extern "C" fn file_print_buffer(c: *mut client, data: *mut c_void, size: usize) {
+pub unsafe fn file_print_buffer(c: *mut client, data: *mut c_void, size: usize) {
     unsafe {
         let cf: *mut client_file = null_mut();
         let mut find: client_file = zeroed();
@@ -300,7 +300,7 @@ pub unsafe fn file_error_(c: *mut client, args: std::fmt::Arguments) {
     }
 }
 
-pub unsafe extern "C" fn file_write(
+pub unsafe fn file_write(
     c: *mut client,
     path: *const c_char,
     flags: c_int,
@@ -391,7 +391,7 @@ pub unsafe extern "C" fn file_write(
     }
 }
 
-pub unsafe extern "C" fn file_read(
+pub unsafe fn file_read(
     c: *mut client,
     path: *const c_char,
     cb: client_file_cb,
@@ -481,7 +481,7 @@ pub unsafe extern "C" fn file_read(
     }
 }
 
-pub unsafe extern "C" fn file_cancel(cf: *mut client_file) {
+pub unsafe fn file_cancel(cf: *mut client_file) {
     unsafe {
         log_debug!("read cancel file {}", (*cf).stream);
 
@@ -503,7 +503,7 @@ pub unsafe extern "C" fn file_cancel(cf: *mut client_file) {
     }
 }
 
-pub unsafe extern "C" fn file_push_cb(_fd: i32, _events: i16, arg: *mut c_void) {
+pub unsafe fn file_push_cb(_fd: i32, _events: i16, arg: *mut c_void) {
     let cf = arg as *mut client_file;
 
     unsafe {
@@ -514,7 +514,7 @@ pub unsafe extern "C" fn file_push_cb(_fd: i32, _events: i16, arg: *mut c_void) 
     }
 }
 
-pub unsafe extern "C" fn file_push(cf: *mut client_file) {
+pub unsafe fn file_push(cf: *mut client_file) {
     unsafe {
         let mut msglen: usize = 0;
         let mut sent: usize = 0;
@@ -570,7 +570,7 @@ pub unsafe extern "C" fn file_push(cf: *mut client_file) {
     }
 }
 
-pub unsafe extern "C" fn file_write_left(files: *mut client_files) -> c_int {
+pub unsafe fn file_write_left(files: *mut client_files) -> c_int {
     let mut left = 0;
     let mut waiting: i32 = 0;
 
@@ -590,7 +590,7 @@ pub unsafe extern "C" fn file_write_left(files: *mut client_files) -> c_int {
     (waiting != 0) as i32
 }
 
-pub unsafe extern "C" fn file_write_error_callback(
+pub unsafe fn file_write_error_callback(
     bev: *mut bufferevent,
     what: i16,
     arg: *mut c_void,
@@ -612,7 +612,7 @@ pub unsafe extern "C" fn file_write_error_callback(
     }
 }
 
-pub unsafe extern "C" fn file_write_callback(bev: *mut bufferevent, arg: *mut c_void) {
+pub unsafe fn file_write_callback(bev: *mut bufferevent, arg: *mut c_void) {
     unsafe {
         let cf = arg as *mut client_file;
 
@@ -631,7 +631,7 @@ pub unsafe extern "C" fn file_write_callback(bev: *mut bufferevent, arg: *mut c_
     }
 }
 
-pub unsafe extern "C" fn file_write_open(
+pub unsafe fn file_write_open(
     files: *mut client_files,
     peer: *mut tmuxpeer,
     imsg: *mut imsg,
@@ -718,7 +718,7 @@ pub unsafe extern "C" fn file_write_open(
     }
 }
 
-pub unsafe extern "C" fn file_write_data(files: *mut client_files, imsg: *mut imsg) {
+pub unsafe fn file_write_data(files: *mut client_files, imsg: *mut imsg) {
     unsafe {
         let msg = (*imsg).data as *mut msg_write_data;
         let msglen = (*imsg).hdr.len as usize - IMSG_HEADER_SIZE;
@@ -741,7 +741,7 @@ pub unsafe extern "C" fn file_write_data(files: *mut client_files, imsg: *mut im
     }
 }
 
-pub unsafe extern "C" fn file_write_close(files: *mut client_files, imsg: *mut imsg) {
+pub unsafe fn file_write_close(files: *mut client_files, imsg: *mut imsg) {
     unsafe {
         let msg = (*imsg).data as *mut msg_write_close;
         let msglen = (*imsg).hdr.len as usize - IMSG_HEADER_SIZE;
@@ -771,7 +771,7 @@ pub unsafe extern "C" fn file_write_close(files: *mut client_files, imsg: *mut i
     }
 }
 
-pub unsafe extern "C" fn file_read_error_callback(
+pub unsafe fn file_read_error_callback(
     _bev: *mut bufferevent,
     what: i16,
     arg: *mut c_void,
@@ -800,7 +800,7 @@ pub unsafe extern "C" fn file_read_error_callback(
     }
 }
 
-pub unsafe extern "C" fn file_read_callback(bev: *mut bufferevent, arg: *mut c_void) {
+pub unsafe fn file_read_callback(bev: *mut bufferevent, arg: *mut c_void) {
     let cf = arg as *mut client_file;
     unsafe {
         let mut msg = xmalloc_::<msg_read_data>();
@@ -835,7 +835,7 @@ pub unsafe extern "C" fn file_read_callback(bev: *mut bufferevent, arg: *mut c_v
     }
 }
 
-pub unsafe extern "C" fn file_read_open(
+pub unsafe fn file_read_open(
     files: *mut client_files,
     peer: *mut tmuxpeer,
     imsg: *mut imsg,
@@ -924,7 +924,7 @@ pub unsafe extern "C" fn file_read_open(
     }
 }
 
-pub unsafe extern "C" fn file_read_cancel(files: *mut client_files, imsg: *mut imsg) {
+pub unsafe fn file_read_cancel(files: *mut client_files, imsg: *mut imsg) {
     unsafe {
         let msg = (*imsg).data as *mut msg_read_cancel;
         let msglen = (*imsg).hdr.len as usize - IMSG_HEADER_SIZE;
@@ -944,7 +944,7 @@ pub unsafe extern "C" fn file_read_cancel(files: *mut client_files, imsg: *mut i
     }
 }
 
-pub unsafe extern "C" fn file_write_ready(files: *mut client_files, imsg: *mut imsg) {
+pub unsafe fn file_write_ready(files: *mut client_files, imsg: *mut imsg) {
     unsafe {
         let msg = (*imsg).data as *mut msg_write_ready;
         let msglen = (*imsg).hdr.len as usize - IMSG_HEADER_SIZE;
@@ -967,7 +967,7 @@ pub unsafe extern "C" fn file_write_ready(files: *mut client_files, imsg: *mut i
     }
 }
 
-pub unsafe extern "C" fn file_read_data(files: *mut client_files, imsg: *mut imsg) {
+pub unsafe fn file_read_data(files: *mut client_files, imsg: *mut imsg) {
     unsafe {
         let msg = (*imsg).data as *mut msg_read_data;
         let msglen = (*imsg).hdr.len as usize - IMSG_HEADER_SIZE;
@@ -996,7 +996,7 @@ pub unsafe extern "C" fn file_read_data(files: *mut client_files, imsg: *mut ims
     }
 }
 
-pub unsafe extern "C" fn file_read_done(files: *mut client_files, imsg: *mut imsg) {
+pub unsafe fn file_read_done(files: *mut client_files, imsg: *mut imsg) {
     unsafe {
         let msg = (*imsg).data as *mut msg_read_done;
         let msglen = (*imsg).hdr.len as usize - IMSG_HEADER_SIZE;

--- a/src/format_draw_.rs
+++ b/src/format_draw_.rs
@@ -60,7 +60,7 @@ unsafe fn format_is_type(fr: *mut format_range, sy: *mut style) -> bool {
 
 // Free a range.
 
-unsafe extern "C" fn format_free_range(frs: *mut format_ranges, fr: *mut format_range) {
+unsafe fn format_free_range(frs: *mut format_ranges, fr: *mut format_range) {
     unsafe {
         tailq_remove(frs, fr);
         free(fr.cast());
@@ -68,7 +68,7 @@ unsafe extern "C" fn format_free_range(frs: *mut format_ranges, fr: *mut format_
 }
 
 /// Fix range positions.
-unsafe extern "C" fn format_update_ranges(
+unsafe fn format_update_ranges(
     frs: *mut format_ranges,
     s: *mut screen,
     offset: u32,
@@ -111,7 +111,7 @@ unsafe extern "C" fn format_update_ranges(
 }
 
 /// Draw a part of the format.
-unsafe extern "C" fn format_draw_put(
+unsafe fn format_draw_put(
     octx: *mut screen_write_ctx,
     ocx: u32,
     ocy: u32,
@@ -131,7 +131,7 @@ unsafe extern "C" fn format_draw_put(
 }
 
 /// Draw list part of format.
-unsafe extern "C" fn format_draw_put_list(
+unsafe fn format_draw_put_list(
     octx: *mut screen_write_ctx,
     ocx: u32,
     ocy: u32,
@@ -183,7 +183,7 @@ unsafe extern "C" fn format_draw_put_list(
 }
 
 /// Draw format with no list.
-unsafe extern "C" fn format_draw_none(
+unsafe fn format_draw_none(
     octx: *mut screen_write_ctx,
     available: u32,
     ocx: u32,
@@ -261,7 +261,7 @@ unsafe extern "C" fn format_draw_none(
 }
 
 /// Draw format with list on the left.
-unsafe extern "C" fn format_draw_left(
+unsafe fn format_draw_left(
     octx: *mut screen_write_ctx,
     available: u32,
     ocx: u32,
@@ -407,7 +407,7 @@ unsafe extern "C" fn format_draw_left(
 
 // Draw format with list in the centre.
 
-unsafe extern "C" fn format_draw_centre(
+unsafe fn format_draw_centre(
     octx: *mut screen_write_ctx,
     available: u32,
     ocx: u32,
@@ -559,7 +559,7 @@ unsafe extern "C" fn format_draw_centre(
 
 /* Draw format with list on the right. */
 
-unsafe extern "C" fn format_draw_right(
+unsafe fn format_draw_right(
     octx: *mut screen_write_ctx,
     available: u32,
     ocx: u32,
@@ -705,7 +705,7 @@ unsafe extern "C" fn format_draw_right(
     }
 }
 
-unsafe extern "C" fn format_draw_absolute_centre(
+unsafe fn format_draw_absolute_centre(
     octx: *mut screen_write_ctx,
     available: u32,
     ocx: u32,
@@ -851,7 +851,7 @@ unsafe extern "C" fn format_draw_absolute_centre(
 
 // Get width and count of any leading #s.
 
-unsafe extern "C" fn format_leading_hashes(
+unsafe fn format_leading_hashes(
     cp: *const c_char,
     n: *mut u32,
     width: *mut u32,
@@ -888,7 +888,7 @@ unsafe extern "C" fn format_leading_hashes(
 }
 
 /// Draw multiple characters.
-unsafe extern "C" fn format_draw_many(
+unsafe fn format_draw_many(
     ctx: *mut screen_write_ctx,
     sy: *mut style,
     ch: c_char,
@@ -1452,7 +1452,7 @@ pub unsafe fn format_draw(
 }
 
 /// Get width, taking #[] into account.
-pub unsafe extern "C" fn format_width(expanded: *const c_char) -> u32 {
+pub unsafe fn format_width(expanded: *const c_char) -> u32 {
     unsafe {
         let mut cp: *const c_char = expanded;
 
@@ -1504,7 +1504,7 @@ pub unsafe extern "C" fn format_width(expanded: *const c_char) -> u32 {
 ///
 /// Note, we copy the whole set of unescaped #s, but only add their escaped size to width.
 /// This is because the format_draw function will actually do the escaping when it runs
-pub unsafe extern "C" fn format_trim_left(expanded: *const c_char, limit: u32) -> *mut c_char {
+pub unsafe fn format_trim_left(expanded: *const c_char, limit: u32) -> *mut c_char {
     unsafe {
         // char *copy, *out;
         // const char *cp = expanded, *end;
@@ -1590,7 +1590,7 @@ pub unsafe extern "C" fn format_trim_left(expanded: *const c_char, limit: u32) -
 
 // Trim on the right, taking #[] into account.
 
-pub unsafe extern "C" fn format_trim_right(expanded: *const c_char, limit: u32) -> *mut c_char {
+pub unsafe fn format_trim_right(expanded: *const c_char, limit: u32) -> *mut c_char {
     unsafe {
         //char *copy, *out;
         //const char *cp = expanded, *end;

--- a/src/grid_.rs
+++ b/src/grid_.rs
@@ -66,7 +66,7 @@ pub static grid_cleared_entry: grid_cell_entry = grid_cell_entry {
 };
 
 /// Store cell in entry.
-pub unsafe extern "C" fn grid_store_cell(gce: *mut grid_cell_entry, gc: *const grid_cell, c: u8) {
+pub unsafe fn grid_store_cell(gce: *mut grid_cell_entry, gc: *const grid_cell, c: u8) {
     unsafe {
         (*gce).flags = (*gc).flags & !grid_flag::CLEARED;
 
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn grid_store_cell(gce: *mut grid_cell_entry, gc: *const g
 }
 
 /// Check if a cell should be an extended cell.
-pub unsafe extern "C" fn grid_need_extended_cell(
+pub unsafe fn grid_need_extended_cell(
     gce: *const grid_cell_entry,
     gc: *const grid_cell,
 ) -> i32 {
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn grid_need_extended_cell(
 }
 
 /// Get an extended cell.
-pub unsafe extern "C" fn grid_get_extended_cell(
+pub unsafe fn grid_get_extended_cell(
     gl: *mut grid_line,
     gce: *mut grid_cell_entry,
     flags: grid_flag,
@@ -132,7 +132,7 @@ pub unsafe extern "C" fn grid_get_extended_cell(
 }
 
 /// Set cell as extended.
-pub unsafe extern "C" fn grid_extended_cell(
+pub unsafe fn grid_extended_cell(
     gl: *mut grid_line,
     gce: *mut grid_cell_entry,
     gc: *const grid_cell,
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn grid_extended_cell(
 }
 
 /// Free up unused extended cells.
-pub unsafe extern "C" fn grid_compact_line(gl: *mut grid_line) {
+pub unsafe fn grid_compact_line(gl: *mut grid_line) {
     unsafe {
         let mut new_extdsize = 0u32;
 
@@ -213,19 +213,19 @@ pub unsafe extern "C" fn grid_compact_line(gl: *mut grid_line) {
 }
 
 /// Get line data.
-pub unsafe extern "C" fn grid_get_line(gd: *mut grid, line: c_uint) -> *mut grid_line {
+pub unsafe fn grid_get_line(gd: *mut grid, line: c_uint) -> *mut grid_line {
     unsafe { (*gd).linedata.add(line as usize) }
 }
 
 /// Adjust number of lines.
-pub unsafe extern "C" fn grid_adjust_lines(gd: *mut grid, lines: c_uint) {
+pub unsafe fn grid_adjust_lines(gd: *mut grid, lines: c_uint) {
     unsafe {
         (*gd).linedata = xreallocarray_((*gd).linedata, lines as usize).as_ptr();
     }
 }
 
 /// Copy default into a cell.
-pub unsafe extern "C" fn grid_clear_cell(gd: *mut grid, px: c_uint, py: c_uint, bg: c_uint) {
+pub unsafe fn grid_clear_cell(gd: *mut grid, px: c_uint, py: c_uint, bg: c_uint) {
     unsafe {
         let gl = (*gd).linedata.add(py as usize);
         let gce = (*gl).celldata.add(px as usize);
@@ -246,7 +246,7 @@ pub unsafe extern "C" fn grid_clear_cell(gd: *mut grid, px: c_uint, py: c_uint, 
 }
 
 /// Check grid y position.
-pub unsafe extern "C" fn grid_check_y(gd: *mut grid, from: *const c_char, py: c_uint) -> c_int {
+pub unsafe fn grid_check_y(gd: *mut grid, from: *const c_char, py: c_uint) -> c_int {
     unsafe {
         if py >= (*gd).hsize as c_uint + (*gd).sy as c_uint {
             log_debug!("{}: y out of range: {}", _s(from), py);
@@ -257,7 +257,7 @@ pub unsafe extern "C" fn grid_check_y(gd: *mut grid, from: *const c_char, py: c_
 }
 
 /// Check if two styles are (visibly) the same.
-pub unsafe extern "C" fn grid_cells_look_equal(
+pub unsafe fn grid_cells_look_equal(
     gc1: *const grid_cell,
     gc2: *const grid_cell,
 ) -> c_int {
@@ -276,7 +276,7 @@ pub unsafe extern "C" fn grid_cells_look_equal(
 }
 
 /// Compare grid cells. Return 1 if equal, 0 if not.
-pub unsafe extern "C" fn grid_cells_equal(gc1: *const grid_cell, gc2: *const grid_cell) -> c_int {
+pub unsafe fn grid_cells_equal(gc1: *const grid_cell, gc2: *const grid_cell) -> c_int {
     unsafe {
         if grid_cells_look_equal(gc1, gc2) == 0 {
             return 0;
@@ -301,7 +301,7 @@ pub unsafe extern "C" fn grid_cells_equal(gc1: *const grid_cell, gc2: *const gri
 }
 
 /// Free one line.
-pub unsafe extern "C" fn grid_free_line(gd: *mut grid, py: c_uint) {
+pub unsafe fn grid_free_line(gd: *mut grid, py: c_uint) {
     unsafe {
         free_((*(*gd).linedata.add(py as usize)).celldata);
         (*(*gd).linedata.add(py as usize)).celldata = null_mut();
@@ -311,7 +311,7 @@ pub unsafe extern "C" fn grid_free_line(gd: *mut grid, py: c_uint) {
 }
 
 /// Free several lines.
-pub unsafe extern "C" fn grid_free_lines(gd: *mut grid, py: c_uint, ny: c_uint) {
+pub unsafe fn grid_free_lines(gd: *mut grid, py: c_uint, ny: c_uint) {
     unsafe {
         for yy in py..(py + ny) {
             grid_free_line(gd, yy);
@@ -320,7 +320,7 @@ pub unsafe extern "C" fn grid_free_lines(gd: *mut grid, py: c_uint, ny: c_uint) 
 }
 
 /// Create a new grid.
-pub unsafe extern "C" fn grid_create(sx: u32, sy: u32, hlimit: u32) -> *mut grid {
+pub unsafe fn grid_create(sx: u32, sy: u32, hlimit: u32) -> *mut grid {
     unsafe {
         let gd = xmalloc_::<grid>().as_ptr();
         (*gd).sx = sx;
@@ -342,7 +342,7 @@ pub unsafe extern "C" fn grid_create(sx: u32, sy: u32, hlimit: u32) -> *mut grid
 }
 
 /// Destroy grid.
-pub unsafe extern "C" fn grid_destroy(gd: *mut grid) {
+pub unsafe fn grid_destroy(gd: *mut grid) {
     unsafe {
         grid_free_lines(gd, 0, (*gd).hsize + (*gd).sy);
         free_((*gd).linedata);
@@ -351,7 +351,7 @@ pub unsafe extern "C" fn grid_destroy(gd: *mut grid) {
 }
 
 /// Compare grids.
-pub unsafe extern "C" fn grid_compare(ga: *mut grid, gb: *mut grid) -> c_int {
+pub unsafe fn grid_compare(ga: *mut grid, gb: *mut grid) -> c_int {
     unsafe {
         if (*ga).sx != (*gb).sx || (*ga).sy != (*gb).sy {
             return 1;
@@ -399,7 +399,7 @@ pub unsafe extern "C" fn grid_compare(ga: *mut grid, gb: *mut grid) -> c_int {
 }
 
 /// Trim lines from the history.
-unsafe extern "C" fn grid_trim_history(gd: *mut grid, ny: c_uint) {
+unsafe fn grid_trim_history(gd: *mut grid, ny: c_uint) {
     unsafe {
         grid_free_lines(gd, 0, ny);
         libc::memmove(
@@ -411,7 +411,7 @@ unsafe extern "C" fn grid_trim_history(gd: *mut grid, ny: c_uint) {
 }
 
 /// Collect lines from the history if at the limit. Free the top (oldest) 10% and shift up.
-pub unsafe extern "C" fn grid_collect_history(gd: *mut grid) {
+pub unsafe fn grid_collect_history(gd: *mut grid) {
     unsafe {
         if (*gd).hsize == 0 || (*gd).hsize < (*gd).hlimit {
             return;
@@ -436,7 +436,7 @@ pub unsafe extern "C" fn grid_collect_history(gd: *mut grid) {
 }
 
 /// Remove lines from the bottom of the history.
-pub unsafe extern "C" fn grid_remove_history(gd: *mut grid, ny: c_uint) {
+pub unsafe fn grid_remove_history(gd: *mut grid, ny: c_uint) {
     unsafe {
         if ny > (*gd).hsize {
             return;
@@ -450,7 +450,7 @@ pub unsafe extern "C" fn grid_remove_history(gd: *mut grid, ny: c_uint) {
 
 /// Scroll the entire visible screen, moving one line into the history. Just
 /// allocate a new line at the bottom and move the history size indicator.
-pub unsafe extern "C" fn grid_scroll_history(gd: *mut grid, bg: c_uint) {
+pub unsafe fn grid_scroll_history(gd: *mut grid, bg: c_uint) {
     unsafe {
         let yy = (*gd).hsize + (*gd).sy;
         (*gd).linedata = xreallocarray_((*gd).linedata, (yy + 1) as usize).as_ptr();
@@ -465,7 +465,7 @@ pub unsafe extern "C" fn grid_scroll_history(gd: *mut grid, bg: c_uint) {
 }
 
 /// Clear the history.
-pub unsafe extern "C" fn grid_clear_history(gd: *mut grid) {
+pub unsafe fn grid_clear_history(gd: *mut grid) {
     unsafe {
         grid_trim_history(gd, (*gd).hsize);
 
@@ -477,7 +477,7 @@ pub unsafe extern "C" fn grid_clear_history(gd: *mut grid) {
 }
 
 /// Scroll a region up, moving the top line into the history.
-pub unsafe extern "C" fn grid_scroll_history_region(
+pub unsafe fn grid_scroll_history_region(
     gd: *mut grid,
     mut upper: c_uint,
     mut lower: c_uint,
@@ -538,7 +538,7 @@ unsafe fn grid_expand_line(gd: *mut grid, py: c_uint, mut sx: c_uint, bg: c_uint
 }
 
 /// Empty a line and set background colour if needed.
-pub unsafe extern "C" fn grid_empty_line(gd: *mut grid, py: c_uint, bg: c_uint) {
+pub unsafe fn grid_empty_line(gd: *mut grid, py: c_uint, bg: c_uint) {
     unsafe {
         (*gd).linedata.add(py as usize).write(zeroed());
         if !COLOUR_DEFAULT(bg as i32) {
@@ -548,7 +548,7 @@ pub unsafe extern "C" fn grid_empty_line(gd: *mut grid, py: c_uint, bg: c_uint) 
 }
 
 /// Peek at grid line.
-pub unsafe extern "C" fn grid_peek_line(gd: *mut grid, py: c_uint) -> *mut grid_line {
+pub unsafe fn grid_peek_line(gd: *mut grid, py: c_uint) -> *mut grid_line {
     unsafe {
         if grid_check_y(gd, c"grid_peek_line".as_ptr(), py) != 0 {
             return null_mut();
@@ -595,7 +595,7 @@ unsafe fn grid_get_cell1(gl: *mut grid_line, px: c_uint, gc: *mut grid_cell) {
 }
 
 /// Get cell for reading.
-pub unsafe extern "C" fn grid_get_cell(gd: *mut grid, px: c_uint, py: c_uint, gc: *mut grid_cell) {
+pub unsafe fn grid_get_cell(gd: *mut grid, px: c_uint, py: c_uint, gc: *mut grid_cell) {
     unsafe {
         if grid_check_y(gd, c"grid_get_cell".as_ptr(), py) != 0
             || px >= (*(*gd).linedata.add(py as usize)).cellsize
@@ -608,7 +608,7 @@ pub unsafe extern "C" fn grid_get_cell(gd: *mut grid, px: c_uint, py: c_uint, gc
 }
 
 /// Set cell at position.
-pub unsafe extern "C" fn grid_set_cell(
+pub unsafe fn grid_set_cell(
     gd: *mut grid,
     px: c_uint,
     py: c_uint,
@@ -636,14 +636,14 @@ pub unsafe extern "C" fn grid_set_cell(
 }
 
 /// Set padding at position.
-pub unsafe extern "C" fn grid_set_padding(gd: *mut grid, px: c_uint, py: c_uint) {
+pub unsafe fn grid_set_padding(gd: *mut grid, px: c_uint, py: c_uint) {
     unsafe {
         grid_set_cell(gd, px, py, &grid_padding_cell);
     }
 }
 
 /// Set cells at position.
-pub unsafe extern "C" fn grid_set_cells(
+pub unsafe fn grid_set_cells(
     gd: *mut grid,
     px: u32,
     py: u32,
@@ -676,7 +676,7 @@ pub unsafe extern "C" fn grid_set_cells(
 }
 
 /// Clear area.
-pub unsafe extern "C" fn grid_clear(
+pub unsafe fn grid_clear(
     gd: *mut grid,
     px: c_uint,
     py: c_uint,
@@ -727,7 +727,7 @@ pub unsafe extern "C" fn grid_clear(
 }
 
 /// Clear lines. This just frees and truncates the lines.
-pub unsafe extern "C" fn grid_clear_lines(gd: *mut grid, py: c_uint, ny: c_uint, bg: c_uint) {
+pub unsafe fn grid_clear_lines(gd: *mut grid, py: c_uint, ny: c_uint, bg: c_uint) {
     unsafe {
         if ny == 0 {
             return;
@@ -751,7 +751,7 @@ pub unsafe extern "C" fn grid_clear_lines(gd: *mut grid, py: c_uint, ny: c_uint,
 }
 
 /// Move a group of lines.
-pub unsafe extern "C" fn grid_move_lines(
+pub unsafe fn grid_move_lines(
     gd: *mut grid,
     dy: c_uint,
     py: c_uint,
@@ -805,7 +805,7 @@ pub unsafe extern "C" fn grid_move_lines(
 }
 
 /// Move a group of cells.
-pub unsafe extern "C" fn grid_move_cells(
+pub unsafe fn grid_move_cells(
     gd: *mut grid,
     dx: c_uint,
     px: c_uint,
@@ -845,7 +845,7 @@ pub unsafe extern "C" fn grid_move_cells(
 }
 
 /// Get ANSI foreground sequence.
-pub unsafe extern "C" fn grid_string_cells_fg(gc: *const grid_cell, values: *mut c_int) -> usize {
+pub unsafe fn grid_string_cells_fg(gc: *const grid_cell, values: *mut c_int) -> usize {
     unsafe {
         let mut n: usize = 0;
 
@@ -890,7 +890,7 @@ pub unsafe extern "C" fn grid_string_cells_fg(gc: *const grid_cell, values: *mut
 }
 
 /// Get ANSI background sequence.
-pub unsafe extern "C" fn grid_string_cells_bg(gc: *const grid_cell, values: *mut c_int) -> usize {
+pub unsafe fn grid_string_cells_bg(gc: *const grid_cell, values: *mut c_int) -> usize {
     unsafe {
         let mut n: usize = 0;
 
@@ -935,7 +935,7 @@ pub unsafe extern "C" fn grid_string_cells_bg(gc: *const grid_cell, values: *mut
 }
 
 /// Get underscore colour sequence.
-pub unsafe extern "C" fn grid_string_cells_us(gc: *const grid_cell, values: *mut c_int) -> usize {
+pub unsafe fn grid_string_cells_us(gc: *const grid_cell, values: *mut c_int) -> usize {
     unsafe {
         let mut n: usize = 0;
         if (*gc).us & COLOUR_FLAG_256 != 0 {
@@ -963,7 +963,7 @@ pub unsafe extern "C" fn grid_string_cells_us(gc: *const grid_cell, values: *mut
 }
 
 /// Add on SGR code.
-pub unsafe extern "C" fn grid_string_cells_add_code(
+pub unsafe fn grid_string_cells_add_code(
     buf: *mut c_char,
     len: usize,
     n: c_uint,
@@ -1013,7 +1013,7 @@ pub unsafe extern "C" fn grid_string_cells_add_code(
     }
 }
 
-pub unsafe extern "C" fn grid_string_cells_add_hyperlink(
+pub unsafe fn grid_string_cells_add_hyperlink(
     buf: *mut c_char,
     len: usize,
     id: *const c_char,
@@ -1054,7 +1054,7 @@ pub unsafe extern "C" fn grid_string_cells_add_hyperlink(
 }
 
 /// Returns ANSI code to set particular attributes (colour, bold and so on) given a current state.
-pub unsafe extern "C" fn grid_string_cells_code(
+pub unsafe fn grid_string_cells_code(
     lastgc: *const grid_cell,
     gc: *const grid_cell,
     buf: *mut c_char,
@@ -1232,7 +1232,7 @@ pub unsafe extern "C" fn grid_string_cells_code(
 }
 
 /// Convert cells into a string.
-pub unsafe extern "C" fn grid_string_cells(
+pub unsafe fn grid_string_cells(
     gd: *mut grid,
     px: c_uint,
     py: c_uint,
@@ -1343,7 +1343,7 @@ pub unsafe extern "C" fn grid_string_cells(
 }
 
 /// Duplicate a set of lines between two grids. Both source and destination should be big enough.
-pub unsafe extern "C" fn grid_duplicate_lines(
+pub unsafe fn grid_duplicate_lines(
     dst: *mut grid,
     mut dy: c_uint,
     src: *mut grid,
@@ -1546,7 +1546,7 @@ unsafe fn grid_reflow_join(
 }
 
 /// Split this line into several new ones
-pub unsafe extern "C" fn grid_reflow_split(
+pub unsafe fn grid_reflow_split(
     target: *mut grid,
     gd: *mut grid,
     sx: u32,
@@ -1621,7 +1621,7 @@ pub unsafe extern "C" fn grid_reflow_split(
 }
 
 /// Reflow lines on grid to new width
-pub unsafe extern "C" fn grid_reflow(gd: *mut grid, sx: u32) {
+pub unsafe fn grid_reflow(gd: *mut grid, sx: u32) {
     unsafe {
         // Create destination grid - just used as container for line data
         let target = grid_create((*gd).sx, 0, 0);
@@ -1691,7 +1691,7 @@ pub unsafe extern "C" fn grid_reflow(gd: *mut grid, sx: u32) {
 }
 
 /// Convert to position based on wrapped lines
-pub unsafe extern "C" fn grid_wrap_position(
+pub unsafe fn grid_wrap_position(
     gd: *mut grid,
     px: u32,
     py: u32,
@@ -1725,7 +1725,7 @@ pub unsafe extern "C" fn grid_wrap_position(
 }
 
 /// Convert position based on wrapped lines back
-pub unsafe extern "C" fn grid_unwrap_position(
+pub unsafe fn grid_unwrap_position(
     gd: *mut grid,
     px: *mut u32,
     py: *mut u32,
@@ -1777,7 +1777,7 @@ pub unsafe extern "C" fn grid_unwrap_position(
 }
 
 /// Get length of line
-pub unsafe extern "C" fn grid_line_length(gd: *mut grid, py: u32) -> u32 {
+pub unsafe fn grid_line_length(gd: *mut grid, py: u32) -> u32 {
     unsafe {
         let mut gc = zeroed();
         let mut px = (*grid_get_line(gd, py)).cellsize;

--- a/src/grid_reader_.rs
+++ b/src/grid_reader_.rs
@@ -13,7 +13,7 @@
 // OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 use crate::*;
 
-pub unsafe extern "C" fn grid_reader_start(gr: *mut grid_reader, gd: *mut grid, cx: u32, cy: u32) {
+pub unsafe fn grid_reader_start(gr: *mut grid_reader, gd: *mut grid, cx: u32, cy: u32) {
     unsafe {
         (*gr).gd = gd;
         (*gr).cx = cx;
@@ -21,18 +21,18 @@ pub unsafe extern "C" fn grid_reader_start(gr: *mut grid_reader, gd: *mut grid, 
     }
 }
 
-pub unsafe extern "C" fn grid_reader_get_cursor(gr: *mut grid_reader, cx: *mut u32, cy: *mut u32) {
+pub unsafe fn grid_reader_get_cursor(gr: *mut grid_reader, cx: *mut u32, cy: *mut u32) {
     unsafe {
         *cx = (*gr).cx;
         *cy = (*gr).cy;
     }
 }
 
-pub unsafe extern "C" fn grid_reader_line_length(gr: *mut grid_reader) -> u32 {
+pub unsafe fn grid_reader_line_length(gr: *mut grid_reader) -> u32 {
     unsafe { grid_line_length((*gr).gd, (*gr).cy) }
 }
 
-pub unsafe extern "C" fn grid_reader_cursor_right(gr: *mut grid_reader, wrap: u32, all: i32) {
+pub unsafe fn grid_reader_cursor_right(gr: *mut grid_reader, wrap: u32, all: i32) {
     unsafe {
         let mut gc = MaybeUninit::<grid_cell>::uninit();
 
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn grid_reader_cursor_right(gr: *mut grid_reader, wrap: u3
     }
 }
 
-pub unsafe extern "C" fn grid_reader_cursor_left(gr: *mut grid_reader, wrap: i32) {
+pub unsafe fn grid_reader_cursor_left(gr: *mut grid_reader, wrap: i32) {
     unsafe {
         let mut gc = MaybeUninit::<grid_cell>::uninit();
 
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn grid_reader_cursor_left(gr: *mut grid_reader, wrap: i32
     }
 }
 
-pub unsafe extern "C" fn grid_reader_cursor_down(gr: *mut grid_reader) {
+pub unsafe fn grid_reader_cursor_down(gr: *mut grid_reader) {
     unsafe {
         let mut gc = MaybeUninit::<grid_cell>::uninit();
         let gc = gc.as_mut_ptr();
@@ -102,7 +102,7 @@ pub unsafe extern "C" fn grid_reader_cursor_down(gr: *mut grid_reader) {
     }
 }
 
-pub unsafe extern "C" fn grid_reader_cursor_up(gr: *mut grid_reader) {
+pub unsafe fn grid_reader_cursor_up(gr: *mut grid_reader) {
     unsafe {
         let mut gc = MaybeUninit::<grid_cell>::uninit();
         let gc = gc.as_mut_ptr();
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn grid_reader_cursor_up(gr: *mut grid_reader) {
     }
 }
 
-pub unsafe extern "C" fn grid_reader_cursor_start_of_line(gr: *mut grid_reader, wrap: i32) {
+pub unsafe fn grid_reader_cursor_start_of_line(gr: *mut grid_reader, wrap: i32) {
     unsafe {
         if wrap != 0 {
             while (*gr).cy > 0
@@ -135,7 +135,7 @@ pub unsafe extern "C" fn grid_reader_cursor_start_of_line(gr: *mut grid_reader, 
     }
 }
 
-pub unsafe extern "C" fn grid_reader_cursor_end_of_line(gr: *mut grid_reader, wrap: i32, all: i32) {
+pub unsafe fn grid_reader_cursor_end_of_line(gr: *mut grid_reader, wrap: i32, all: i32) {
     unsafe {
         if wrap != 0 {
             let yy = (*(*gr).gd).hsize + (*(*gr).gd).sy - 1;
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn grid_reader_cursor_end_of_line(gr: *mut grid_reader, wr
     }
 }
 
-pub unsafe extern "C" fn grid_reader_handle_wrap(
+pub unsafe fn grid_reader_handle_wrap(
     gr: *mut grid_reader,
     xx: *mut u32,
     yy: *mut u32,
@@ -181,7 +181,7 @@ pub unsafe extern "C" fn grid_reader_handle_wrap(
     1
 }
 
-pub unsafe extern "C" fn grid_reader_in_set(gr: *mut grid_reader, set: *const c_char) -> i32 {
+pub unsafe fn grid_reader_in_set(gr: *mut grid_reader, set: *const c_char) -> i32 {
     unsafe {
         let mut gc = MaybeUninit::<grid_cell>::uninit();
         let gc = gc.as_mut_ptr();
@@ -194,7 +194,7 @@ pub unsafe extern "C" fn grid_reader_in_set(gr: *mut grid_reader, set: *const c_
     }
 }
 
-pub unsafe extern "C" fn grid_reader_cursor_next_word(
+pub unsafe fn grid_reader_cursor_next_word(
     gr: *mut grid_reader,
     separators: *const c_char,
 ) {
@@ -245,7 +245,7 @@ pub unsafe extern "C" fn grid_reader_cursor_next_word(
     }
 }
 
-pub unsafe extern "C" fn grid_reader_cursor_next_word_end(
+pub unsafe fn grid_reader_cursor_next_word_end(
     gr: *mut grid_reader,
     separators: *const c_char,
 ) {
@@ -293,7 +293,7 @@ pub unsafe extern "C" fn grid_reader_cursor_next_word_end(
     }
 }
 
-pub unsafe extern "C" fn grid_reader_cursor_previous_word(
+pub unsafe fn grid_reader_cursor_previous_word(
     gr: *mut grid_reader,
     separators: *const c_char,
     already: i32,
@@ -368,7 +368,7 @@ pub unsafe extern "C" fn grid_reader_cursor_previous_word(
     }
 }
 
-pub unsafe extern "C" fn grid_reader_cursor_jump(
+pub unsafe fn grid_reader_cursor_jump(
     gr: *mut grid_reader,
     jc: *const utf8_data,
 ) -> i32 {
@@ -413,7 +413,7 @@ pub unsafe extern "C" fn grid_reader_cursor_jump(
     0
 }
 
-pub unsafe extern "C" fn grid_reader_cursor_jump_back(
+pub unsafe fn grid_reader_cursor_jump_back(
     gr: *mut grid_reader,
     jc: *mut utf8_data,
 ) -> i32 {
@@ -458,7 +458,7 @@ pub unsafe extern "C" fn grid_reader_cursor_jump_back(
     0
 }
 
-pub unsafe extern "C" fn grid_reader_cursor_back_to_indentation(gr: *mut grid_reader) {
+pub unsafe fn grid_reader_cursor_back_to_indentation(gr: *mut grid_reader) {
     unsafe {
         let mut gc = MaybeUninit::<grid_cell>::uninit();
         let gc = gc.as_mut_ptr();

--- a/src/grid_view.rs
+++ b/src/grid_view.rs
@@ -27,25 +27,25 @@ unsafe fn grid_view_y(gd: *mut grid, y: u32) -> u32 {
     unsafe { (*gd).hsize + (y) }
 }
 
-pub unsafe extern "C" fn grid_view_get_cell(gd: *mut grid, px: u32, py: u32, gc: *mut grid_cell) {
+pub unsafe fn grid_view_get_cell(gd: *mut grid, px: u32, py: u32, gc: *mut grid_cell) {
     unsafe {
         grid_get_cell(gd, grid_view_x(gd, px), grid_view_y(gd, py), gc);
     }
 }
 
-pub unsafe extern "C" fn grid_view_set_cell(gd: *mut grid, px: u32, py: u32, gc: *const grid_cell) {
+pub unsafe fn grid_view_set_cell(gd: *mut grid, px: u32, py: u32, gc: *const grid_cell) {
     unsafe {
         grid_set_cell(gd, grid_view_x(gd, px), grid_view_y(gd, py), gc);
     }
 }
 
-pub unsafe extern "C" fn grid_view_set_padding(gd: *mut grid, px: u32, py: u32) {
+pub unsafe fn grid_view_set_padding(gd: *mut grid, px: u32, py: u32) {
     unsafe {
         grid_set_padding(gd, grid_view_x(gd, px), grid_view_y(gd, py));
     }
 }
 
-pub unsafe extern "C" fn grid_view_set_cells(
+pub unsafe fn grid_view_set_cells(
     gd: *mut grid,
     px: u32,
     py: u32,
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn grid_view_set_cells(
     }
 }
 
-pub unsafe extern "C" fn grid_view_clear_history(gd: *mut grid, bg: u32) {
+pub unsafe fn grid_view_clear_history(gd: *mut grid, bg: u32) {
     unsafe {
         let mut last = 0u32;
 
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn grid_view_clear_history(gd: *mut grid, bg: u32) {
     }
 }
 
-pub unsafe extern "C" fn grid_view_clear(
+pub unsafe fn grid_view_clear(
     gd: *mut grid,
     mut px: u32,
     mut py: u32,
@@ -100,7 +100,7 @@ pub unsafe extern "C" fn grid_view_clear(
     }
 }
 
-pub unsafe extern "C" fn grid_view_scroll_region_up(
+pub unsafe fn grid_view_scroll_region_up(
     gd: *mut grid,
     mut rupper: u32,
     mut rlower: u32,
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn grid_view_scroll_region_up(
     }
 }
 
-pub unsafe extern "C" fn grid_view_scroll_region_down(
+pub unsafe fn grid_view_scroll_region_down(
     gd: *mut grid,
     mut rupper: u32,
     mut rlower: u32,
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn grid_view_scroll_region_down(
     }
 }
 
-pub unsafe extern "C" fn grid_view_insert_lines(gd: *mut grid, mut py: u32, ny: u32, bg: u32) {
+pub unsafe fn grid_view_insert_lines(gd: *mut grid, mut py: u32, ny: u32, bg: u32) {
     unsafe {
         py = grid_view_y(gd, py);
 
@@ -149,7 +149,7 @@ pub unsafe extern "C" fn grid_view_insert_lines(gd: *mut grid, mut py: u32, ny: 
 }
 
 /// Insert lines in region.
-pub unsafe extern "C" fn grid_view_insert_lines_region(
+pub unsafe fn grid_view_insert_lines_region(
     gd: *mut grid,
     mut rlower: u32,
     mut py: u32,
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn grid_view_insert_lines_region(
 }
 
 /// Delete lines.
-pub unsafe extern "C" fn grid_view_delete_lines(gd: *mut grid, mut py: u32, ny: u32, bg: u32) {
+pub unsafe fn grid_view_delete_lines(gd: *mut grid, mut py: u32, ny: u32, bg: u32) {
     unsafe {
         py = grid_view_y(gd, py);
 
@@ -195,7 +195,7 @@ pub unsafe extern "C" fn grid_view_delete_lines(gd: *mut grid, mut py: u32, ny: 
 }
 
 /// Delete lines inside scroll region.
-pub unsafe extern "C" fn grid_view_delete_lines_region(
+pub unsafe fn grid_view_delete_lines_region(
     gd: *mut grid,
     mut rlower: u32,
     mut py: u32,
@@ -215,7 +215,7 @@ pub unsafe extern "C" fn grid_view_delete_lines_region(
 }
 
 /// Insert characters.
-pub unsafe extern "C" fn grid_view_insert_cells(
+pub unsafe fn grid_view_insert_cells(
     gd: *mut grid,
     mut px: u32,
     mut py: u32,
@@ -237,7 +237,7 @@ pub unsafe extern "C" fn grid_view_insert_cells(
 }
 
 /// Delete characters.
-pub unsafe extern "C" fn grid_view_delete_cells(
+pub unsafe fn grid_view_delete_cells(
     gd: *mut grid,
     mut px: u32,
     mut py: u32,
@@ -256,7 +256,7 @@ pub unsafe extern "C" fn grid_view_delete_cells(
 }
 
 /// Convert cells into a string.
-pub unsafe extern "C" fn grid_view_string_cells(
+pub unsafe fn grid_view_string_cells(
     gd: *mut grid,
     mut px: u32,
     mut py: u32,

--- a/src/hyperlinks_.rs
+++ b/src/hyperlinks_.rs
@@ -59,7 +59,7 @@ pub struct hyperlinks {
     pub references: u32,
 }
 
-unsafe extern "C" fn hyperlinks_by_uri_cmp(
+unsafe fn hyperlinks_by_uri_cmp(
     left: *const hyperlinks_uri,
     right: *const hyperlinks_uri,
 ) -> std::cmp::Ordering {
@@ -87,7 +87,7 @@ RB_GENERATE!(
     hyperlinks_by_uri_cmp
 );
 
-unsafe extern "C" fn hyperlinks_by_inner_cmp(
+unsafe fn hyperlinks_by_inner_cmp(
     left: *const hyperlinks_uri,
     right: *const hyperlinks_uri,
 ) -> Ordering {
@@ -102,7 +102,7 @@ RB_GENERATE!(
     hyperlinks_by_inner_cmp
 );
 
-unsafe extern "C" fn hyperlinks_remove(hlu: *mut hyperlinks_uri) {
+unsafe fn hyperlinks_remove(hlu: *mut hyperlinks_uri) {
     unsafe {
         let hl = (*hlu).tree;
 
@@ -119,7 +119,7 @@ unsafe extern "C" fn hyperlinks_remove(hlu: *mut hyperlinks_uri) {
     }
 }
 
-pub unsafe extern "C" fn hyperlinks_put(
+pub unsafe fn hyperlinks_put(
     hl: *mut hyperlinks,
     uri_in: *const c_char,
     mut internal_id_in: *const c_char,
@@ -189,7 +189,7 @@ pub unsafe extern "C" fn hyperlinks_put(
     }
 }
 
-pub unsafe extern "C" fn hyperlinks_get(
+pub unsafe fn hyperlinks_get(
     hl: *mut hyperlinks,
     inner: u32,
     uri_out: *mut *const c_char,
@@ -216,7 +216,7 @@ pub unsafe extern "C" fn hyperlinks_get(
     }
 }
 
-pub unsafe extern "C" fn hyperlinks_init() -> *mut hyperlinks {
+pub unsafe fn hyperlinks_init() -> *mut hyperlinks {
     unsafe {
         let hl = xcalloc_::<hyperlinks>(1).as_ptr();
         (*hl).next_inner = 1;
@@ -227,14 +227,14 @@ pub unsafe extern "C" fn hyperlinks_init() -> *mut hyperlinks {
     }
 }
 
-pub unsafe extern "C" fn hyperlinks_copy(hl: *mut hyperlinks) -> *mut hyperlinks {
+pub unsafe fn hyperlinks_copy(hl: *mut hyperlinks) -> *mut hyperlinks {
     unsafe {
         (*hl).references += 1;
     }
     hl
 }
 
-pub unsafe extern "C" fn hyperlinks_reset(hl: *mut hyperlinks) {
+pub unsafe fn hyperlinks_reset(hl: *mut hyperlinks) {
     unsafe {
         for hlu in rb_foreach::<_, discr_by_inner_entry>(&raw mut (*hl).by_inner) {
             hyperlinks_remove(hlu.as_ptr());
@@ -242,7 +242,7 @@ pub unsafe extern "C" fn hyperlinks_reset(hl: *mut hyperlinks) {
     }
 }
 
-pub unsafe extern "C" fn hyperlinks_free(hl: *mut hyperlinks) {
+pub unsafe fn hyperlinks_free(hl: *mut hyperlinks) {
     unsafe {
         (*hl).references -= 1;
         if (*hl).references == 0 {

--- a/src/image_.rs
+++ b/src/image_.rs
@@ -21,7 +21,7 @@ static mut all_images: images = TAILQ_HEAD_INITIALIZER!(all_images);
 
 static mut all_images_count: u32 = 0;
 
-unsafe extern "C" fn image_free(im: NonNull<image>) {
+unsafe fn image_free(im: NonNull<image>) {
     unsafe {
         let im = im.as_ptr();
         let mut s = (*im).s;
@@ -36,7 +36,7 @@ unsafe extern "C" fn image_free(im: NonNull<image>) {
     }
 }
 
-pub unsafe extern "C" fn image_free_all(s: *mut screen) -> i32 {
+pub unsafe fn image_free_all(s: *mut screen) -> i32 {
     unsafe {
         let mut redraw = !tailq_empty(&raw mut (*s).images);
 
@@ -49,7 +49,7 @@ pub unsafe extern "C" fn image_free_all(s: *mut screen) -> i32 {
 
 /// Create text placeholder for an image.
 
-pub unsafe extern "C" fn image_fallback(ret: *mut *mut c_char, sx: u32, sy: u32) {
+pub unsafe fn image_fallback(ret: *mut *mut c_char, sx: u32, sy: u32) {
     unsafe {
         let mut label: *mut c_char = format_nul!("SIXEL IMAGE ({}x{})\r\n", sx, sy);
 
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn image_fallback(ret: *mut *mut c_char, sx: u32, sy: u32)
     }
 }
 
-pub unsafe extern "C" fn image_store(s: *mut screen, si: *mut sixel_image) -> *mut image {
+pub unsafe fn image_store(s: *mut screen, si: *mut sixel_image) -> *mut image {
     unsafe {
         let mut im = xcalloc1::<image>() as *mut image;
         (*im).s = s;
@@ -110,7 +110,7 @@ pub unsafe extern "C" fn image_store(s: *mut screen, si: *mut sixel_image) -> *m
     }
 }
 
-pub unsafe extern "C" fn image_check_line(s: *mut screen, py: u32, ny: u32) -> bool {
+pub unsafe fn image_check_line(s: *mut screen, py: u32, ny: u32) -> bool {
     unsafe {
         let mut redraw = false;
 
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn image_check_line(s: *mut screen, py: u32, ny: u32) -> b
     }
 }
 
-pub unsafe extern "C" fn image_check_area(
+pub unsafe fn image_check_area(
     s: *mut screen,
     px: u32,
     py: u32,
@@ -148,7 +148,7 @@ pub unsafe extern "C" fn image_check_area(
     }
 }
 
-pub unsafe extern "C" fn image_scroll_up(s: *mut screen, lines: u32) -> i32 {
+pub unsafe fn image_scroll_up(s: *mut screen, lines: u32) -> i32 {
     unsafe {
         let mut redraw = false;
 

--- a/src/image_sixel.rs
+++ b/src/image_sixel.rs
@@ -43,7 +43,7 @@ pub struct sixel_image {
     lines: *mut sixel_line,
 }
 
-unsafe extern "C" fn sixel_parse_expand_lines(si: *mut sixel_image, y: u32) -> i32 {
+unsafe fn sixel_parse_expand_lines(si: *mut sixel_image, y: u32) -> i32 {
     unsafe {
         if y <= (*si).y {
             return 0;
@@ -57,7 +57,7 @@ unsafe extern "C" fn sixel_parse_expand_lines(si: *mut sixel_image, y: u32) -> i
     }
 }
 
-unsafe extern "C" fn sixel_parse_expand_line(
+unsafe fn sixel_parse_expand_line(
     si: *mut sixel_image,
     sl: *mut sixel_line,
     x: u32,
@@ -78,7 +78,7 @@ unsafe extern "C" fn sixel_parse_expand_line(
     }
 }
 
-unsafe extern "C" fn sixel_get_pixel(si: *mut sixel_image, x: u32, y: u32) -> u32 {
+unsafe fn sixel_get_pixel(si: *mut sixel_image, x: u32, y: u32) -> u32 {
     unsafe {
         if y >= (*si).y {
             return 0;
@@ -91,7 +91,7 @@ unsafe extern "C" fn sixel_get_pixel(si: *mut sixel_image, x: u32, y: u32) -> u3
     }
 }
 
-unsafe extern "C" fn sixel_set_pixel(si: *mut sixel_image, x: u32, y: u32, c: u32) -> i32 {
+unsafe fn sixel_set_pixel(si: *mut sixel_image, x: u32, y: u32, c: u32) -> i32 {
     unsafe {
         if sixel_parse_expand_lines(si, y + 1) != 0 {
             return 1;
@@ -106,7 +106,7 @@ unsafe extern "C" fn sixel_set_pixel(si: *mut sixel_image, x: u32, y: u32, c: u3
     }
 }
 
-unsafe extern "C" fn sixel_parse_write(si: *mut sixel_image, ch: u32) -> i32 {
+unsafe fn sixel_parse_write(si: *mut sixel_image, ch: u32) -> i32 {
     if sixel_parse_expand_lines(si, (*si).dy + 6) != 0 {
         return 1;
     }
@@ -124,7 +124,7 @@ unsafe extern "C" fn sixel_parse_write(si: *mut sixel_image, ch: u32) -> i32 {
     return 0;
 }
 
-unsafe extern "C" fn sixel_parse_attributes(
+unsafe fn sixel_parse_attributes(
     si: *mut sixel_image,
     cp: *const c_char,
     end: *const c_char,
@@ -178,7 +178,7 @@ unsafe extern "C" fn sixel_parse_attributes(
     }
 }
 
-unsafe extern "C" fn sixel_parse_colour(
+unsafe fn sixel_parse_colour(
     si: *mut sixel_image,
     cp: *const c_char,
     end: *const c_char,
@@ -239,7 +239,7 @@ unsafe extern "C" fn sixel_parse_colour(
     }
 }
 
-unsafe extern "C" fn sixel_parse_repeat(
+unsafe fn sixel_parse_repeat(
     si: *mut sixel_image,
     cp: *const c_char,
     end: *const c_char,
@@ -295,7 +295,7 @@ unsafe extern "C" fn sixel_parse_repeat(
     }
 }
 
-pub unsafe extern "C" fn sixel_parse(
+pub unsafe fn sixel_parse(
     buf: *const c_char,
     len: usize,
     xpixel: u32,
@@ -373,7 +373,7 @@ pub unsafe extern "C" fn sixel_parse(
     }
 }
 
-pub unsafe extern "C" fn sixel_free(si: *mut sixel_image) {
+pub unsafe fn sixel_free(si: *mut sixel_image) {
     unsafe {
         for y in 0..(*si).y {
             free_((*(*si).lines.add(y as usize)).data);
@@ -385,7 +385,7 @@ pub unsafe extern "C" fn sixel_free(si: *mut sixel_image) {
     }
 }
 
-unsafe extern "C" fn sixel_log(si: *mut sixel_image) {
+unsafe fn sixel_log(si: *mut sixel_image) {
     unsafe {
         let mut s: [c_char; SIXEL_WIDTH_LIMIT as usize + 1] = [0; SIXEL_WIDTH_LIMIT as usize + 1];
         let mut cx: u32 = 0;
@@ -416,7 +416,7 @@ unsafe extern "C" fn sixel_log(si: *mut sixel_image) {
     }
 }
 
-pub unsafe extern "C" fn sixel_size_in_cells(si: *mut sixel_image, x: *mut u32, y: *mut u32) {
+pub unsafe fn sixel_size_in_cells(si: *mut sixel_image, x: *mut u32, y: *mut u32) {
     unsafe {
         if (((*si).x % (*si).xpixel) == 0) {
             *x = ((*si).x / (*si).xpixel);
@@ -431,7 +431,7 @@ pub unsafe extern "C" fn sixel_size_in_cells(si: *mut sixel_image, x: *mut u32, 
     }
 }
 
-pub unsafe extern "C" fn sixel_scale(
+pub unsafe fn sixel_scale(
     si: *mut sixel_image,
     mut xpixel: u32,
     mut ypixel: u32,
@@ -505,7 +505,7 @@ pub unsafe extern "C" fn sixel_scale(
     }
 }
 
-unsafe extern "C" fn sixel_print_add(
+unsafe fn sixel_print_add(
     buf: *mut *mut c_char,
     len: *mut usize,
     used: *mut usize,
@@ -522,7 +522,7 @@ unsafe extern "C" fn sixel_print_add(
     }
 }
 
-unsafe extern "C" fn sixel_print_repeat(
+unsafe fn sixel_print_repeat(
     buf: *mut *mut c_char,
     len: *mut usize,
     used: *mut usize,
@@ -553,7 +553,7 @@ unsafe extern "C" fn sixel_print_repeat(
     }
 }
 
-unsafe extern "C" fn sixel_print(
+unsafe fn sixel_print(
     si: *mut sixel_image,
     map: *mut sixel_image,
     size: *mut usize,
@@ -712,7 +712,7 @@ unsafe extern "C" fn sixel_print(
     }
 }
 
-unsafe extern "C" fn sixel_to_screen(si: *mut sixel_image) -> *mut screen {
+unsafe fn sixel_to_screen(si: *mut sixel_image) -> *mut screen {
     unsafe {
         let mut ctx: screen_write_ctx = zeroed();
         let mut gc: grid_cell = zeroed();

--- a/src/input.rs
+++ b/src/input.rs
@@ -873,7 +873,7 @@ unsafe extern "C" fn input_table_compare(key: *const c_void, value: *const c_voi
 /// Timer
 ///
 /// if this expires then have been waiting for a terminator for too long, so reset to ground.
-unsafe fn input_timer_callback(_fd: i32, events: i16, arg: *mut c_void) {
+unsafe extern "C" fn input_timer_callback(_fd: i32, events: i16, arg: *mut c_void) {
     unsafe {
         let ictx: *mut input_ctx = arg as *mut input_ctx;
 

--- a/src/input_keys.rs
+++ b/src/input_keys.rs
@@ -41,7 +41,7 @@ impl input_key_entry {
 }
 
 /// Input key comparison function.
-pub unsafe extern "C" fn input_key_cmp(
+pub unsafe fn input_key_cmp(
     ike1: *const input_key_entry,
     ike2: *const input_key_entry,
 ) -> Ordering {
@@ -172,7 +172,7 @@ static input_key_modifiers: [key_code; 9] = [
 ];
 
 /// Look for key in tree.
-pub unsafe extern "C" fn input_key_get(key: key_code) -> *mut input_key_entry {
+pub unsafe fn input_key_get(key: key_code) -> *mut input_key_entry {
     unsafe {
         let mut entry = MaybeUninit::<input_key_entry>::uninit();
         (*entry.as_mut_ptr()).key = key;
@@ -180,7 +180,7 @@ pub unsafe extern "C" fn input_key_get(key: key_code) -> *mut input_key_entry {
     }
 }
 
-pub unsafe extern "C" fn input_key_split2(c: u32, dst: *mut u8) -> usize {
+pub unsafe fn input_key_split2(c: u32, dst: *mut u8) -> usize {
     unsafe {
         if c > 0x7f {
             *dst = (c >> 6) as u8 | 0xc0;
@@ -227,7 +227,7 @@ pub unsafe extern "C-unwind" fn input_key_build() {
 }
 
 /// Translate a key code into an output key sequence for a pane.
-pub unsafe extern "C" fn input_key_pane(
+pub unsafe fn input_key_pane(
     wp: *mut window_pane,
     key: key_code,
     m: *mut mouse_event,
@@ -247,7 +247,7 @@ pub unsafe extern "C" fn input_key_pane(
     }
 }
 
-pub unsafe extern "C" fn input_key_write(
+pub unsafe fn input_key_write(
     from: *const c_char,
     bev: *mut bufferevent,
     data: *const c_char,
@@ -259,7 +259,7 @@ pub unsafe extern "C" fn input_key_write(
     }
 }
 
-pub unsafe extern "C" fn input_key_extended(bev: *mut bufferevent, mut key: key_code) -> i32 {
+pub unsafe fn input_key_extended(bev: *mut bufferevent, mut key: key_code) -> i32 {
     let __func__ = c"input_key_extended".as_ptr();
     unsafe {
         let sizeof_tmp = 64;
@@ -334,7 +334,7 @@ static standard_map: [SyncCharPtr; 2] = [
 /// Outputs the key in the "standard" mode. This is by far the most
 /// complicated output mode, with a lot of remapping in order to
 /// emulate quirks of terminals that today can be only found in museums.
-pub unsafe extern "C" fn input_key_vt10x(bev: *mut bufferevent, mut key: key_code) -> i32 {
+pub unsafe fn input_key_vt10x(bev: *mut bufferevent, mut key: key_code) -> i32 {
     let __func__ = c"input_key_vt10x".as_ptr();
     unsafe {
         let mut ud: utf8_data = zeroed(); // TODO use uninit
@@ -395,7 +395,7 @@ pub unsafe extern "C" fn input_key_vt10x(bev: *mut bufferevent, mut key: key_cod
 }
 
 /// Pick keys that are reported as vt10x keys in modifyOtherKeys=1 mode.
-pub unsafe extern "C" fn input_key_mode1(bev: *mut bufferevent, key: key_code) -> i32 {
+pub unsafe fn input_key_mode1(bev: *mut bufferevent, key: key_code) -> i32 {
     unsafe {
         log_debug!("{}: key in {}", "input_key_mode1", key);
 
@@ -422,7 +422,7 @@ pub unsafe extern "C" fn input_key_mode1(bev: *mut bufferevent, key: key_code) -
 }
 
 /// Translate a key code into an output key sequence.
-pub unsafe extern "C" fn input_key(
+pub unsafe fn input_key(
     s: *mut screen,
     bev: *mut bufferevent,
     mut key: key_code,
@@ -573,7 +573,7 @@ pub unsafe extern "C" fn input_key(
 }
 
 /// Get mouse event string.
-pub unsafe extern "C" fn input_key_get_mouse(
+pub unsafe fn input_key_get_mouse(
     s: *mut screen,
     m: *mut mouse_event,
     x: u32,
@@ -687,7 +687,7 @@ pub unsafe extern "C" fn input_key_get_mouse(
 }
 
 /// Translate mouse and output.
-pub unsafe extern "C" fn input_key_mouse(wp: *mut window_pane, m: *mut mouse_event) {
+pub unsafe fn input_key_mouse(wp: *mut window_pane, m: *mut mouse_event) {
     let __func__ = c"input_key_mouse".as_ptr();
     unsafe {
         let s = (*wp).screen;

--- a/src/job_.rs
+++ b/src/job_.rs
@@ -364,7 +364,7 @@ pub unsafe fn job_resize(job: *mut job, sx: c_uint, sy: c_uint) {
     }
 }
 
-unsafe fn job_read_callback(bufev: *mut bufferevent, data: *mut libc::c_void) {
+unsafe extern "C" fn job_read_callback(bufev: *mut bufferevent, data: *mut libc::c_void) {
     let job = data as *mut job;
 
     unsafe {
@@ -373,7 +373,7 @@ unsafe fn job_read_callback(bufev: *mut bufferevent, data: *mut libc::c_void) {
         }
     }
 }
-unsafe fn job_write_callback(bufev: *mut bufferevent, data: *mut libc::c_void) {
+unsafe extern "C" fn job_write_callback(bufev: *mut bufferevent, data: *mut libc::c_void) {
     unsafe {
         let job = data as *mut job;
         let len = EVBUFFER_LENGTH(EVBUFFER_OUTPUT((*job).event));
@@ -393,7 +393,7 @@ unsafe fn job_write_callback(bufev: *mut bufferevent, data: *mut libc::c_void) {
     }
 }
 
-unsafe fn job_error_callback(
+unsafe extern "C" fn job_error_callback(
     bufev: *mut bufferevent,
     events: libc::c_short,
     data: *mut libc::c_void,

--- a/src/key_bindings_.rs
+++ b/src/key_bindings_.rs
@@ -99,21 +99,21 @@ RB_GENERATE!(
 RB_GENERATE!(key_tables, key_table, entry, discr_entry, key_table_cmp);
 static mut key_tables: key_tables = rb_initializer();
 
-pub unsafe extern "C" fn key_table_cmp(
+pub unsafe fn key_table_cmp(
     table1: *const key_table,
     table2: *const key_table,
 ) -> Ordering {
     unsafe { i32_to_ordering(strcmp((*table1).name, (*table2).name)) }
 }
 
-pub unsafe extern "C" fn key_bindings_cmp(
+pub unsafe fn key_bindings_cmp(
     bd1: *const key_binding,
     bd2: *const key_binding,
 ) -> Ordering {
     unsafe { (*bd1).key.cmp(&(*bd2).key) }
 }
 
-pub unsafe extern "C" fn key_bindings_free(bd: *mut key_binding) {
+pub unsafe fn key_bindings_free(bd: *mut key_binding) {
     unsafe {
         cmd_list_free((*bd).cmdlist);
         free_((*bd).note);
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn key_bindings_free(bd: *mut key_binding) {
     }
 }
 
-pub unsafe extern "C" fn key_bindings_get_table(
+pub unsafe fn key_bindings_get_table(
     name: *const c_char,
     create: i32,
 ) -> *mut key_table {
@@ -148,15 +148,15 @@ pub unsafe extern "C" fn key_bindings_get_table(
     }
 }
 
-pub unsafe extern "C" fn key_bindings_first_table() -> *mut key_table {
+pub unsafe fn key_bindings_first_table() -> *mut key_table {
     unsafe { rb_min(&raw mut key_tables) }
 }
 
-pub unsafe extern "C" fn key_bindings_next_table(table: *mut key_table) -> *mut key_table {
+pub unsafe fn key_bindings_next_table(table: *mut key_table) -> *mut key_table {
     unsafe { rb_next(table) }
 }
 
-pub unsafe extern "C" fn key_bindings_unref_table(table: *mut key_table) {
+pub unsafe fn key_bindings_unref_table(table: *mut key_table) {
     unsafe {
         (*table).references -= 1;
         if (*table).references != 0 {
@@ -177,7 +177,7 @@ pub unsafe extern "C" fn key_bindings_unref_table(table: *mut key_table) {
     }
 }
 
-pub unsafe extern "C" fn key_bindings_get(
+pub unsafe fn key_bindings_get(
     table: NonNull<key_table>,
     key: key_code,
 ) -> *mut key_binding {
@@ -190,7 +190,7 @@ pub unsafe extern "C" fn key_bindings_get(
     }
 }
 
-pub unsafe extern "C" fn key_bindings_get_default(
+pub unsafe fn key_bindings_get_default(
     table: *mut key_table,
     key: key_code,
 ) -> *mut key_binding {
@@ -203,18 +203,18 @@ pub unsafe extern "C" fn key_bindings_get_default(
     }
 }
 
-pub unsafe extern "C" fn key_bindings_first(table: *mut key_table) -> *mut key_binding {
+pub unsafe fn key_bindings_first(table: *mut key_table) -> *mut key_binding {
     unsafe { rb_min(&raw mut (*table).key_bindings) }
 }
 
-pub unsafe extern "C" fn key_bindings_next(
+pub unsafe fn key_bindings_next(
     _table: *mut key_table,
     bd: *mut key_binding,
 ) -> *mut key_binding {
     unsafe { rb_next(bd) }
 }
 
-pub unsafe extern "C" fn key_bindings_add(
+pub unsafe fn key_bindings_add(
     name: *const c_char,
     key: key_code,
     note: *const c_char,
@@ -265,7 +265,7 @@ pub unsafe extern "C" fn key_bindings_add(
     }
 }
 
-pub unsafe extern "C" fn key_bindings_remove(name: *const c_char, key: key_code) {
+pub unsafe fn key_bindings_remove(name: *const c_char, key: key_code) {
     unsafe {
         let Some(table) = NonNull::new(key_bindings_get_table(name, 0)) else {
             return;
@@ -295,7 +295,7 @@ pub unsafe extern "C" fn key_bindings_remove(name: *const c_char, key: key_code)
     }
 }
 
-pub unsafe extern "C" fn key_bindings_reset(name: *const c_char, key: key_code) {
+pub unsafe fn key_bindings_reset(name: *const c_char, key: key_code) {
     unsafe {
         let Some(table) = NonNull::new(key_bindings_get_table(name, 0)) else {
             return;
@@ -326,7 +326,7 @@ pub unsafe extern "C" fn key_bindings_reset(name: *const c_char, key: key_code) 
     }
 }
 
-pub unsafe extern "C" fn key_bindings_remove_table(name: *const c_char) {
+pub unsafe fn key_bindings_remove_table(name: *const c_char) {
     unsafe {
         let table = key_bindings_get_table(name, 0);
         if !table.is_null() {
@@ -341,7 +341,7 @@ pub unsafe extern "C" fn key_bindings_remove_table(name: *const c_char) {
     }
 }
 
-pub unsafe extern "C" fn key_bindings_reset_table(name: *const c_char) {
+pub unsafe fn key_bindings_reset_table(name: *const c_char) {
     unsafe {
         let table = key_bindings_get_table(name, 0);
         if table.is_null() {
@@ -357,7 +357,7 @@ pub unsafe extern "C" fn key_bindings_reset_table(name: *const c_char) {
     }
 }
 
-pub unsafe extern "C" fn key_bindings_init_done(
+pub unsafe fn key_bindings_init_done(
     _item: *mut cmdq_item,
     data: *mut c_void,
 ) -> cmd_retval {
@@ -380,7 +380,7 @@ pub unsafe extern "C" fn key_bindings_init_done(
     cmd_retval::CMD_RETURN_NORMAL
 }
 
-pub unsafe extern "C" fn key_bindings_init() {
+pub unsafe fn key_bindings_init() {
     #[rustfmt::skip]
     static defaults: [&str; 262] = [
         // Prefix keys.
@@ -684,7 +684,7 @@ pub unsafe extern "C" fn key_bindings_init() {
     }
 }
 
-pub unsafe extern "C" fn key_bindings_read_only(
+pub unsafe fn key_bindings_read_only(
     item: *mut cmdq_item,
     data: *mut c_void,
 ) -> cmd_retval {
@@ -694,7 +694,7 @@ pub unsafe extern "C" fn key_bindings_read_only(
     cmd_retval::CMD_RETURN_ERROR
 }
 
-pub unsafe extern "C" fn key_bindings_dispatch(
+pub unsafe fn key_bindings_dispatch(
     bd: *mut key_binding,
     item: *mut cmdq_item,
     c: *mut client,

--- a/src/key_string.rs
+++ b/src/key_string.rs
@@ -235,7 +235,7 @@ static key_string_table: [key_string_table_entry; 469] = const {
 };
 
 /// Find key string in table.
-pub unsafe extern "C" fn key_string_search_table(string: *const c_char) -> key_code {
+pub unsafe fn key_string_search_table(string: *const c_char) -> key_code {
     unsafe {
         for key_string in &key_string_table {
             if strcasecmp(string, key_string.string) == 0 {
@@ -253,7 +253,7 @@ pub unsafe extern "C" fn key_string_search_table(string: *const c_char) -> key_c
 }
 
 /// Find modifiers.
-pub unsafe extern "C" fn key_string_get_modifiers(string: *mut *const c_char) -> key_code {
+pub unsafe fn key_string_get_modifiers(string: *mut *const c_char) -> key_code {
     unsafe {
         let mut modifiers: key_code = 0;
 
@@ -285,7 +285,7 @@ const MB_LEN_MAX: usize = 16;
 
 /* Lookup a string and convert to a key value. */
 
-pub unsafe extern "C" fn key_string_lookup_string(mut string: *const c_char) -> key_code {
+pub unsafe fn key_string_lookup_string(mut string: *const c_char) -> key_code {
     unsafe {
         let mut key: key_code = 0;
         let mut modifiers: key_code = 0;
@@ -387,7 +387,7 @@ pub unsafe extern "C" fn key_string_lookup_string(mut string: *const c_char) -> 
 }
 
 /// Convert a key code into string format, with prefix if necessary.
-pub unsafe extern "C" fn key_string_lookup_key(
+pub unsafe fn key_string_lookup_key(
     mut key: key_code,
     with_flags: i32,
 ) -> *const c_char {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -19,7 +19,7 @@ use crate::compat::queue::{
     tailq_insert_tail, tailq_last, tailq_prev, tailq_remove, tailq_replace,
 };
 
-pub unsafe extern "C" fn layout_create_cell(lcparent: *mut layout_cell) -> *mut layout_cell {
+pub unsafe fn layout_create_cell(lcparent: *mut layout_cell) -> *mut layout_cell {
     unsafe {
         let lc = xmalloc_::<layout_cell>().as_ptr();
         (*lc).type_ = layout_type::LAYOUT_WINDOWPANE;
@@ -39,7 +39,7 @@ pub unsafe extern "C" fn layout_create_cell(lcparent: *mut layout_cell) -> *mut 
     }
 }
 
-pub unsafe extern "C" fn layout_free_cell(lc: *mut layout_cell) {
+pub unsafe fn layout_free_cell(lc: *mut layout_cell) {
     unsafe {
         match (*lc).type_ {
             layout_type::LAYOUT_LEFTRIGHT | layout_type::LAYOUT_TOPBOTTOM => {
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn layout_free_cell(lc: *mut layout_cell) {
     }
 }
 
-pub unsafe extern "C" fn layout_print_cell(lc: *mut layout_cell, hdr: *const c_char, n: u32) {
+pub unsafe fn layout_print_cell(lc: *mut layout_cell, hdr: *const c_char, n: u32) {
     unsafe {
         let type_str = match (*lc).type_ {
             layout_type::LAYOUT_LEFTRIGHT => c"LEFTRIGHT",
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn layout_print_cell(lc: *mut layout_cell, hdr: *const c_c
     }
 }
 
-pub unsafe extern "C" fn layout_search_by_border(
+pub unsafe fn layout_search_by_border(
     lc: *mut layout_cell,
     x: u32,
     y: u32,
@@ -140,7 +140,7 @@ pub unsafe extern "C" fn layout_search_by_border(
     }
 }
 
-pub unsafe extern "C" fn layout_set_size(
+pub unsafe fn layout_set_size(
     lc: *mut layout_cell,
     sx: u32,
     sy: u32,
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn layout_set_size(
     }
 }
 
-pub unsafe extern "C" fn layout_make_leaf(lc: *mut layout_cell, wp: *mut window_pane) {
+pub unsafe fn layout_make_leaf(lc: *mut layout_cell, wp: *mut window_pane) {
     unsafe {
         (*lc).type_ = layout_type::LAYOUT_WINDOWPANE;
         tailq_init(&raw mut (*lc).cells);
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn layout_make_leaf(lc: *mut layout_cell, wp: *mut window_
     }
 }
 
-pub unsafe extern "C" fn layout_make_node(lc: *mut layout_cell, type_: layout_type) {
+pub unsafe fn layout_make_node(lc: *mut layout_cell, type_: layout_type) {
     unsafe {
         if type_ == layout_type::LAYOUT_WINDOWPANE {
             fatalx(c"bad layout type");
@@ -209,7 +209,7 @@ unsafe fn layout_fix_offsets1(lc: *mut layout_cell) {
 }
 
 /// Update cell offsets based on their sizes.
-pub unsafe extern "C" fn layout_fix_offsets(w: *mut window) {
+pub unsafe fn layout_fix_offsets(w: *mut window) {
     unsafe {
         let lc = (*w).layout_root;
         (*lc).xoff = 0;
@@ -265,7 +265,7 @@ unsafe fn layout_add_border(w: *mut window, lc: *mut layout_cell, status: pane_s
 }
 
 /// Update pane offsets and sizes based on their cells.
-pub unsafe extern "C" fn layout_fix_panes(w: *mut window, skip: *mut window_pane) {
+pub unsafe fn layout_fix_panes(w: *mut window, skip: *mut window_pane) {
     unsafe {
         let status: pane_status =
             pane_status::try_from(options_get_number_((*w).options, c"pane-border-status") as i32)
@@ -294,7 +294,7 @@ pub unsafe extern "C" fn layout_fix_panes(w: *mut window, skip: *mut window_pane
 }
 
 /// Count the number of available cells in a layout.
-pub unsafe extern "C" fn layout_count_cells(lc: *mut layout_cell) -> u32 {
+pub unsafe fn layout_count_cells(lc: *mut layout_cell) -> u32 {
     unsafe {
         match (*lc).type_ {
             layout_type::LAYOUT_WINDOWPANE => 1,
@@ -310,7 +310,7 @@ pub unsafe extern "C" fn layout_count_cells(lc: *mut layout_cell) -> u32 {
 }
 
 /// Calculate how much size is available to be removed from a cell.
-pub unsafe extern "C" fn layout_resize_check(
+pub unsafe fn layout_resize_check(
     w: *mut window,
     lc: *mut layout_cell,
     type_: layout_type,
@@ -365,7 +365,7 @@ pub unsafe extern "C" fn layout_resize_check(
 
 /// Adjust cell size evenly, including altering its children. This function
 /// expects the change to have already been bounded to the space available.
-pub unsafe extern "C" fn layout_resize_adjust(
+pub unsafe fn layout_resize_adjust(
     w: *mut window,
     lc: *mut layout_cell,
     type_: layout_type,
@@ -414,7 +414,7 @@ pub unsafe extern "C" fn layout_resize_adjust(
 }
 
 /// Destroy a cell and redistribute the space.
-pub unsafe extern "C" fn layout_destroy_cell(
+pub unsafe fn layout_destroy_cell(
     w: *mut window,
     lc: *mut layout_cell,
     lcroot: *mut *mut layout_cell,
@@ -469,7 +469,7 @@ pub unsafe extern "C" fn layout_destroy_cell(
     }
 }
 
-pub unsafe extern "C" fn layout_init(w: *mut window, wp: *mut window_pane) {
+pub unsafe fn layout_init(w: *mut window, wp: *mut window_pane) {
     unsafe {
         let lc = layout_create_cell(std::ptr::null_mut());
         (*w).layout_root = lc;
@@ -479,14 +479,14 @@ pub unsafe extern "C" fn layout_init(w: *mut window, wp: *mut window_pane) {
     }
 }
 
-pub unsafe extern "C" fn layout_free(w: *mut window) {
+pub unsafe fn layout_free(w: *mut window) {
     unsafe {
         layout_free_cell((*w).layout_root);
     }
 }
 
 /// Resize the entire layout after window resize.
-pub unsafe extern "C" fn layout_resize(w: *mut window, sx: c_uint, sy: c_uint) {
+pub unsafe fn layout_resize(w: *mut window, sx: c_uint, sy: c_uint) {
     unsafe {
         let lc = (*w).layout_root;
 
@@ -543,7 +543,7 @@ pub unsafe extern "C" fn layout_resize(w: *mut window, sx: c_uint, sy: c_uint) {
 }
 
 /// Resize a pane to an absolute size.
-pub unsafe extern "C" fn layout_resize_pane_to(
+pub unsafe fn layout_resize_pane_to(
     wp: *mut window_pane,
     type_: layout_type,
     new_size: u32,
@@ -580,7 +580,7 @@ pub unsafe extern "C" fn layout_resize_pane_to(
     }
 }
 
-pub unsafe extern "C" fn layout_resize_layout(
+pub unsafe fn layout_resize_layout(
     w: *mut window,
     lc: *mut layout_cell,
     type_: layout_type,
@@ -614,7 +614,7 @@ pub unsafe extern "C" fn layout_resize_layout(
     }
 }
 
-pub unsafe extern "C" fn layout_resize_pane(
+pub unsafe fn layout_resize_pane(
     wp: *mut window_pane,
     type_: layout_type,
     change: c_int,
@@ -644,7 +644,7 @@ pub unsafe extern "C" fn layout_resize_pane(
 }
 
 /// Helper function to grow pane.
-pub unsafe extern "C" fn layout_resize_pane_grow(
+pub unsafe fn layout_resize_pane_grow(
     w: *mut window,
     lc: *mut layout_cell,
     type_: layout_type,
@@ -693,7 +693,7 @@ pub unsafe extern "C" fn layout_resize_pane_grow(
 }
 
 /// Helper function to shrink pane.
-pub unsafe extern "C" fn layout_resize_pane_shrink(
+pub unsafe fn layout_resize_pane_shrink(
     w: *mut window,
     lc: *mut layout_cell,
     type_: layout_type,
@@ -735,7 +735,7 @@ pub unsafe extern "C" fn layout_resize_pane_shrink(
 }
 
 /// Assign window pane to newly split cell.
-pub unsafe extern "C" fn layout_assign_pane(
+pub unsafe fn layout_assign_pane(
     lc: *mut layout_cell,
     wp: *mut window_pane,
     do_not_resize: c_int,
@@ -751,7 +751,7 @@ pub unsafe extern "C" fn layout_assign_pane(
 }
 
 /// Calculate the new pane size for resized parent.
-pub unsafe extern "C" fn layout_new_pane_size(
+pub unsafe fn layout_new_pane_size(
     w: *mut window,
     previous: u32,
     lc: *mut layout_cell,
@@ -797,7 +797,7 @@ pub unsafe extern "C" fn layout_new_pane_size(
 }
 
 /// Check if the cell and all its children can be resized to a specific size.
-pub unsafe extern "C" fn layout_set_size_check(
+pub unsafe fn layout_set_size_check(
     w: *mut window,
     lc: *mut layout_cell,
     type_: layout_type,
@@ -875,7 +875,7 @@ pub unsafe extern "C" fn layout_set_size_check(
 
 // unsafe extern "C" { pub fn layout_resize_child_cells(w: *mut window, lc: *mut layout_cell); }
 /// Resize all child cells to fit within the current cell.
-pub unsafe extern "C" fn layout_resize_child_cells(w: *mut window, lc: *mut layout_cell) {
+pub unsafe fn layout_resize_child_cells(w: *mut window, lc: *mut layout_cell) {
     unsafe {
         if (*lc).type_ == layout_type::LAYOUT_WINDOWPANE {
             return;
@@ -943,7 +943,7 @@ pub unsafe extern "C" fn layout_resize_child_cells(w: *mut window, lc: *mut layo
 
 /// Split a pane into two. size is a hint, or -1 for default half/half
 /// split. This must be followed by layout_assign_pane before much else happens!
-pub unsafe extern "C" fn layout_split_pane(
+pub unsafe fn layout_split_pane(
     wp: *mut window_pane,
     type_: layout_type,
     size: i32,
@@ -1128,7 +1128,7 @@ pub unsafe extern "C" fn layout_split_pane(
 }
 
 /// Destroy the cell associated with a pane.
-pub unsafe extern "C" fn layout_close_pane(wp: *mut window_pane) {
+pub unsafe fn layout_close_pane(wp: *mut window_pane) {
     unsafe {
         let w = (*wp).window;
 
@@ -1145,7 +1145,7 @@ pub unsafe extern "C" fn layout_close_pane(wp: *mut window_pane) {
 }
 
 /// Spread cells evenly within a parent cell
-pub unsafe extern "C" fn layout_spread_cell(w: *mut window, parent: *mut layout_cell) -> c_int {
+pub unsafe fn layout_spread_cell(w: *mut window, parent: *mut layout_cell) -> c_int {
     unsafe {
         // Count number of cells
         let number = tailq_foreach(&raw mut (*parent).cells).count() as u32;
@@ -1216,7 +1216,7 @@ pub unsafe extern "C" fn layout_spread_cell(w: *mut window, parent: *mut layout_
 }
 
 /// Spread out a pane and its parent cells
-pub unsafe extern "C" fn layout_spread_out(wp: *mut window_pane) {
+pub unsafe fn layout_spread_out(wp: *mut window_pane) {
     unsafe {
         let mut parent = (*wp).layout_cell;
         if parent.is_null() {

--- a/src/layout_custom.rs
+++ b/src/layout_custom.rs
@@ -20,7 +20,7 @@ use crate::compat::{
     strlcat,
 };
 
-pub unsafe extern "C" fn layout_find_bottomright(mut lc: *mut layout_cell) -> *mut layout_cell {
+pub unsafe fn layout_find_bottomright(mut lc: *mut layout_cell) -> *mut layout_cell {
     unsafe {
         if (*lc).type_ == layout_type::LAYOUT_WINDOWPANE {
             return lc;
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn layout_find_bottomright(mut lc: *mut layout_cell) -> *m
     }
 }
 
-pub unsafe extern "C" fn layout_checksum(mut layout: *const c_char) -> u16 {
+pub unsafe fn layout_checksum(mut layout: *const c_char) -> u16 {
     unsafe {
         let mut csum = 0u16;
         while *layout != b'\0' as _ {
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn layout_checksum(mut layout: *const c_char) -> u16 {
 }
 
 /// Dump layout as a string.
-pub unsafe extern "C" fn layout_dump(root: *mut layout_cell) -> *mut c_char {
+pub unsafe fn layout_dump(root: *mut layout_cell) -> *mut c_char {
     unsafe {
         let mut layout: MaybeUninit<[c_char; 8192]> = MaybeUninit::<[c_char; 8192]>::uninit();
         let layout = layout.as_mut_ptr() as *mut i8;
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn layout_dump(root: *mut layout_cell) -> *mut c_char {
     }
 }
 
-pub unsafe extern "C" fn layout_append(lc: *mut layout_cell, buf: *mut c_char, len: usize) -> i32 {
+pub unsafe fn layout_append(lc: *mut layout_cell, buf: *mut c_char, len: usize) -> i32 {
     unsafe {
         let sizeof_tmp = 64;
         let mut tmp = MaybeUninit::<[c_char; 64]>::uninit();
@@ -130,7 +130,7 @@ pub unsafe extern "C" fn layout_append(lc: *mut layout_cell, buf: *mut c_char, l
 }
 
 /// Check layout sizes fit.
-pub unsafe extern "C" fn layout_check(lc: *mut layout_cell) -> i32 {
+pub unsafe fn layout_check(lc: *mut layout_cell) -> i32 {
     unsafe {
         let mut n = 0u32;
 
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn layout_check(lc: *mut layout_cell) -> i32 {
     1
 }
 
-pub unsafe extern "C" fn layout_parse(
+pub unsafe fn layout_parse(
     w: *mut window,
     mut layout: *const c_char,
     cause: *mut *mut c_char,
@@ -290,7 +290,7 @@ pub unsafe extern "C" fn layout_parse(
 
 /* Assign panes into cells. */
 
-unsafe extern "C" fn layout_assign(wp: *mut *mut window_pane, lc: *mut layout_cell) {
+unsafe fn layout_assign(wp: *mut *mut window_pane, lc: *mut layout_cell) {
     unsafe {
         match (*lc).type_ {
             layout_type::LAYOUT_WINDOWPANE => {
@@ -308,7 +308,7 @@ unsafe extern "C" fn layout_assign(wp: *mut *mut window_pane, lc: *mut layout_ce
 
 /* Construct a cell from all or part of a layout tree. */
 
-unsafe extern "C" fn layout_construct(
+unsafe fn layout_construct(
     lcparent: *mut layout_cell,
     layout: *mut *const c_char,
 ) -> *mut layout_cell {

--- a/src/layout_set.rs
+++ b/src/layout_set.rs
@@ -17,10 +17,10 @@ use crate::compat::queue::{tailq_first, tailq_foreach, tailq_insert_tail, tailq_
 
 struct layout_sets_entry {
     name: SyncCharPtr,
-    arrange: Option<unsafe extern "C" fn(*mut window)>,
+    arrange: Option<unsafe fn(*mut window)>,
 }
 impl layout_sets_entry {
-    const fn new(name: &'static CStr, arrange: unsafe extern "C" fn(*mut window)) -> Self {
+    const fn new(name: &'static CStr, arrange: unsafe fn(*mut window)) -> Self {
         Self {
             name: SyncCharPtr::new(name),
             arrange: Some(arrange),
@@ -39,7 +39,7 @@ static layout_sets: [layout_sets_entry; layout_sets_len] = [
     layout_sets_entry::new(c"tiled", layout_set_tiled),
 ];
 
-pub unsafe extern "C" fn layout_set_lookup(name: *const c_char) -> i32 {
+pub unsafe fn layout_set_lookup(name: *const c_char) -> i32 {
     unsafe {
         let mut matched: i32 = -1;
 
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn layout_set_lookup(name: *const c_char) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn layout_set_select(w: *mut window, mut layout: u32) -> u32 {
+pub unsafe fn layout_set_select(w: *mut window, mut layout: u32) -> u32 {
     unsafe {
         if layout > layout_sets_len as u32 - 1 {
             layout = layout_sets_len as u32 - 1;
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn layout_set_select(w: *mut window, mut layout: u32) -> u
     }
 }
 
-pub unsafe extern "C" fn layout_set_next(w: *mut window) -> u32 {
+pub unsafe fn layout_set_next(w: *mut window) -> u32 {
     unsafe {
         let mut layout: u32 = 0;
 
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn layout_set_next(w: *mut window) -> u32 {
     }
 }
 
-pub unsafe extern "C" fn layout_set_previous(w: *mut window) -> u32 {
+pub unsafe fn layout_set_previous(w: *mut window) -> u32 {
     unsafe {
         let mut layout: u32 = 0;
 
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn layout_set_previous(w: *mut window) -> u32 {
     }
 }
 
-pub unsafe extern "C" fn layout_set_even(w: *mut window, type_: layout_type) {
+pub unsafe fn layout_set_even(w: *mut window, type_: layout_type) {
     let __func__ = c"layout_set_even".as_ptr();
     unsafe {
         // struct window_pane *wp;
@@ -183,19 +183,19 @@ pub unsafe extern "C" fn layout_set_even(w: *mut window, type_: layout_type) {
     }
 }
 
-unsafe extern "C" fn layout_set_even_h(w: *mut window) {
+unsafe fn layout_set_even_h(w: *mut window) {
     unsafe {
         layout_set_even(w, layout_type::LAYOUT_LEFTRIGHT);
     }
 }
 
-unsafe extern "C" fn layout_set_even_v(w: *mut window) {
+unsafe fn layout_set_even_v(w: *mut window) {
     unsafe {
         layout_set_even(w, layout_type::LAYOUT_TOPBOTTOM);
     }
 }
 
-pub unsafe extern "C" fn layout_set_main_h(w: *mut window) {
+pub unsafe fn layout_set_main_h(w: *mut window) {
     let __func__ = c"layout_set_main_h".as_ptr();
     unsafe {
         // struct window_pane *wp;
@@ -302,7 +302,7 @@ pub unsafe extern "C" fn layout_set_main_h(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn layout_set_main_h_mirrored(w: *mut window) {
+pub unsafe fn layout_set_main_h_mirrored(w: *mut window) {
     let __func__ = c"layout_set_main_h_mirrored".as_ptr();
     unsafe {
         let mut otherh: u32;
@@ -404,7 +404,7 @@ pub unsafe extern "C" fn layout_set_main_h_mirrored(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn layout_set_main_v(w: *mut window) {
+pub unsafe fn layout_set_main_v(w: *mut window) {
     let __func__ = c"layout_set_main_v".as_ptr();
     let mut cause = null_mut();
 
@@ -507,7 +507,7 @@ pub unsafe extern "C" fn layout_set_main_v(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn layout_set_main_v_mirrored(w: *mut window) {
+pub unsafe fn layout_set_main_v_mirrored(w: *mut window) {
     let __func__ = c"layout_set_main_v_mirrored".as_ptr();
     unsafe {
         let mut cause: *mut c_char = null_mut();
@@ -609,7 +609,7 @@ pub unsafe extern "C" fn layout_set_main_v_mirrored(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn layout_set_tiled(w: *mut window) {
+pub unsafe fn layout_set_tiled(w: *mut window) {
     let __func__ = c"layout_set_tiled".as_ptr();
 
     unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1058,7 +1058,7 @@ struct screen {
 const SCREEN_WRITE_SYNC: i32 = 0x1;
 
 // Screen write context.
-type screen_write_init_ctx_cb = Option<unsafe extern "C" fn(*mut screen_write_ctx, *mut tty_ctx)>;
+type screen_write_init_ctx_cb = Option<unsafe fn(*mut screen_write_ctx, *mut tty_ctx)>;
 #[repr(C)]
 struct screen_write_ctx {
     wp: *mut window_pane,
@@ -1189,7 +1189,7 @@ struct menu {
     count: u32,
     width: u32,
 }
-type menu_choice_cb = Option<unsafe extern "C" fn(*mut menu, u32, key_code, *mut c_void)>;
+type menu_choice_cb = Option<unsafe fn(*mut menu, u32, key_code, *mut c_void)>;
 
 // Window mode. Windows can be in several modes and this is used to call the
 // right function to handle input and output.
@@ -1199,17 +1199,17 @@ struct window_mode {
     default_format: SyncCharPtr,
 
     init: Option<
-        unsafe extern "C" fn(
+        unsafe fn(
             NonNull<window_mode_entry>,
             *mut cmd_find_state,
             *mut args,
         ) -> *mut screen,
     >,
-    free: Option<unsafe extern "C" fn(NonNull<window_mode_entry>)>,
-    resize: Option<unsafe extern "C" fn(NonNull<window_mode_entry>, u32, u32)>,
-    update: Option<unsafe extern "C" fn(NonNull<window_mode_entry>)>,
+    free: Option<unsafe fn(NonNull<window_mode_entry>)>,
+    resize: Option<unsafe fn(NonNull<window_mode_entry>, u32, u32)>,
+    update: Option<unsafe fn(NonNull<window_mode_entry>)>,
     key: Option<
-        unsafe extern "C" fn(
+        unsafe fn(
             NonNull<window_mode_entry>,
             *mut client,
             *mut session,
@@ -1219,9 +1219,9 @@ struct window_mode {
         ),
     >,
 
-    key_table: Option<unsafe extern "C" fn(*mut window_mode_entry) -> *const c_char>,
+    key_table: Option<unsafe fn(*mut window_mode_entry) -> *const c_char>,
     command: Option<
-        unsafe extern "C" fn(
+        unsafe fn(
             NonNull<window_mode_entry>,
             *mut client,
             *mut session,
@@ -1230,7 +1230,7 @@ struct window_mode {
             *mut mouse_event,
         ),
     >,
-    formats: Option<unsafe extern "C" fn(*mut window_mode_entry, *mut format_tree)>,
+    formats: Option<unsafe fn(*mut window_mode_entry, *mut format_tree)>,
 }
 
 impl window_mode {
@@ -1823,15 +1823,15 @@ struct tty {
     mouse_last_y: u32,
     mouse_last_b: u32,
     mouse_drag_flag: i32,
-    mouse_drag_update: Option<unsafe extern "C" fn(*mut client, *mut mouse_event)>,
-    mouse_drag_release: Option<unsafe extern "C" fn(*mut client, *mut mouse_event)>,
+    mouse_drag_update: Option<unsafe fn(*mut client, *mut mouse_event)>,
+    mouse_drag_release: Option<unsafe fn(*mut client, *mut mouse_event)>,
 
     key_timer: event,
     key_tree: *mut tty_key,
 }
 
-type tty_ctx_redraw_cb = Option<unsafe extern "C" fn(*const tty_ctx)>;
-type tty_ctx_set_client_cb = Option<unsafe extern "C" fn(*mut tty_ctx, *mut client) -> i32>;
+type tty_ctx_redraw_cb = Option<unsafe fn(*const tty_ctx)>;
+type tty_ctx_set_client_cb = Option<unsafe fn(*mut tty_ctx, *mut client) -> i32>;
 
 #[repr(C)]
 struct tty_ctx {
@@ -1937,7 +1937,7 @@ enum args_parse_type {
 }
 
 type args_parse_cb =
-    Option<unsafe extern "C" fn(*mut args, u32, *mut *mut c_char) -> args_parse_type>;
+    Option<unsafe fn(*mut args, u32, *mut *mut c_char) -> args_parse_type>;
 #[repr(C)]
 struct args_parse {
     template: *const c_char,
@@ -2080,7 +2080,7 @@ bitflags::bitflags! {
 }
 
 // Command queue callback.
-type cmdq_cb = Option<unsafe extern "C" fn(*mut cmdq_item, *mut c_void) -> cmd_retval>;
+type cmdq_cb = Option<unsafe fn(*mut cmdq_item, *mut c_void) -> cmd_retval>;
 
 // Command definition flag.
 #[repr(C)]
@@ -2128,7 +2128,7 @@ struct cmd_entry {
 
     flags: cmd_flag,
 
-    exec: Option<unsafe extern "C" fn(*mut cmd, *mut cmdq_item) -> cmd_retval>,
+    exec: Option<unsafe fn(*mut cmd, *mut cmdq_item) -> cmd_retval>,
 }
 
 /* Status line. */
@@ -2164,7 +2164,7 @@ enum prompt_type {
 
 /* File in client. */
 type client_file_cb =
-    Option<unsafe extern "C" fn(*mut client, *mut c_char, i32, i32, *mut evbuffer, *mut c_void)>;
+    Option<unsafe fn(*mut client, *mut c_char, i32, i32, *mut evbuffer, *mut c_void)>;
 #[repr(C)]
 struct client_file {
     c: *mut client,
@@ -2219,17 +2219,17 @@ struct overlay_ranges {
 }
 
 type prompt_input_cb =
-    Option<unsafe extern "C" fn(*mut client, NonNull<c_void>, *const c_char, i32) -> i32>;
-type prompt_free_cb = Option<unsafe extern "C" fn(NonNull<c_void>)>;
+    Option<unsafe fn(*mut client, NonNull<c_void>, *const c_char, i32) -> i32>;
+type prompt_free_cb = Option<unsafe fn(NonNull<c_void>)>;
 type overlay_check_cb =
-    Option<unsafe extern "C" fn(*mut client, *mut c_void, u32, u32, u32, *mut overlay_ranges)>;
+    Option<unsafe fn(*mut client, *mut c_void, u32, u32, u32, *mut overlay_ranges)>;
 type overlay_mode_cb =
-    Option<unsafe extern "C" fn(*mut client, *mut c_void, *mut u32, *mut u32) -> *mut screen>;
+    Option<unsafe fn(*mut client, *mut c_void, *mut u32, *mut u32) -> *mut screen>;
 type overlay_draw_cb =
-    Option<unsafe extern "C" fn(*mut client, *mut c_void, *mut screen_redraw_ctx)>;
-type overlay_key_cb = Option<unsafe extern "C" fn(*mut client, *mut c_void, *mut key_event) -> i32>;
-type overlay_free_cb = Option<unsafe extern "C" fn(*mut client, *mut c_void)>;
-type overlay_resize_cb = Option<unsafe extern "C" fn(*mut client, *mut c_void)>;
+    Option<unsafe fn(*mut client, *mut c_void, *mut screen_redraw_ctx)>;
+type overlay_key_cb = Option<unsafe fn(*mut client, *mut c_void, *mut key_event) -> i32>;
+type overlay_free_cb = Option<unsafe fn(*mut client, *mut c_void)>;
+type overlay_resize_cb = Option<unsafe fn(*mut client, *mut c_void)>;
 
 bitflags::bitflags! {
     #[repr(transparent)]

--- a/src/log.rs
+++ b/src/log.rs
@@ -42,7 +42,7 @@ static log_level: AtomicI32 = AtomicI32::new(0);
 
 const DEFAULT_ORDERING: Ordering = Ordering::SeqCst;
 
-unsafe extern "C" fn log_event_cb(_severity: c_int, msg: *const c_char) {
+unsafe fn log_event_cb(_severity: c_int, msg: *const c_char) {
     unsafe { log_debug!("{}", _s(msg)) }
 }
 
@@ -50,7 +50,7 @@ pub fn log_add_level() {
     log_level.fetch_add(1, DEFAULT_ORDERING);
 }
 
-pub extern "C" fn log_get_level() -> i32 {
+pub fn log_get_level() -> i32 {
     log_level.load(DEFAULT_ORDERING)
 }
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -42,7 +42,7 @@ static log_level: AtomicI32 = AtomicI32::new(0);
 
 const DEFAULT_ORDERING: Ordering = Ordering::SeqCst;
 
-unsafe fn log_event_cb(_severity: c_int, msg: *const c_char) {
+unsafe extern "C" fn log_event_cb(_severity: c_int, msg: *const c_char) {
     unsafe { log_debug!("{}", _s(msg)) }
 }
 

--- a/src/menu_.rs
+++ b/src/menu_.rs
@@ -37,7 +37,7 @@ pub struct menu_data {
     pub data: *mut c_void,
 }
 
-pub unsafe extern "C" fn menu_add_items(
+pub unsafe fn menu_add_items(
     menu: *mut menu,
     items: *const menu_item,
     qitem: *mut cmdq_item,
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn menu_add_items(
     }
 }
 
-pub unsafe extern "C" fn menu_add_item(
+pub unsafe fn menu_add_item(
     menu: *mut menu,
     item: *const menu_item,
     qitem: *mut cmdq_item,
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn menu_add_item(
     }
 }
 
-pub unsafe extern "C" fn menu_create(title: *const c_char) -> *mut menu {
+pub unsafe fn menu_create(title: *const c_char) -> *mut menu {
     unsafe {
         let menu = xcalloc1::<menu>() as *mut menu;
         (*menu).title = xstrdup(title).as_ptr();
@@ -172,7 +172,7 @@ pub unsafe extern "C" fn menu_create(title: *const c_char) -> *mut menu {
     }
 }
 
-pub unsafe extern "C" fn menu_free(menu: *mut menu) {
+pub unsafe fn menu_free(menu: *mut menu) {
     unsafe {
         for i in 0..(*menu).count {
             // TODO consider making the struct hold mut pointer
@@ -186,7 +186,7 @@ pub unsafe extern "C" fn menu_free(menu: *mut menu) {
     }
 }
 
-pub unsafe extern "C" fn menu_mode_cb(
+pub unsafe fn menu_mode_cb(
     _c: *mut client,
     data: *mut c_void,
     cx: *mut u32,
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn menu_mode_cb(
     }
 }
 
-pub unsafe extern "C" fn menu_check_cb(
+pub unsafe fn menu_check_cb(
     _c: *mut client,
     data: *mut c_void,
     px: u32,
@@ -231,7 +231,7 @@ pub unsafe extern "C" fn menu_check_cb(
     }
 }
 
-pub unsafe extern "C" fn menu_draw_cb(
+pub unsafe fn menu_draw_cb(
     c: *mut client,
     data: *mut c_void,
     _rctx: *mut screen_redraw_ctx,
@@ -288,7 +288,7 @@ pub unsafe extern "C" fn menu_draw_cb(
     }
 }
 
-pub unsafe extern "C" fn menu_free_cb(_c: *mut client, data: *mut c_void) {
+pub unsafe fn menu_free_cb(_c: *mut client, data: *mut c_void) {
     unsafe {
         let md = data as *mut menu_data;
 
@@ -306,7 +306,7 @@ pub unsafe extern "C" fn menu_free_cb(_c: *mut client, data: *mut c_void) {
     }
 }
 
-pub unsafe extern "C" fn menu_key_cb(
+pub unsafe fn menu_key_cb(
     c: *mut client,
     data: *mut c_void,
     mut event: *mut key_event,
@@ -620,7 +620,7 @@ pub unsafe fn menu_set_style(
     }
 }
 
-pub unsafe extern "C" fn menu_prepare(
+pub unsafe fn menu_prepare(
     menu: *mut menu,
     flags: i32,
     mut starting_choice: i32,
@@ -734,7 +734,7 @@ pub unsafe extern "C" fn menu_prepare(
     }
 }
 
-pub unsafe extern "C" fn menu_display(
+pub unsafe fn menu_display(
     menu: *mut menu,
     flags: i32,
     starting_choice: i32,

--- a/src/mode_tree.rs
+++ b/src/mode_tree.rs
@@ -26,7 +26,7 @@ use crate::compat::{
 };
 
 pub type mode_tree_build_cb = Option<
-    unsafe extern "C" fn(
+    unsafe fn(
         _: NonNull<c_void>,
         _: *mut mode_tree_sort_criteria,
         _: *mut u64,
@@ -34,7 +34,7 @@ pub type mode_tree_build_cb = Option<
     ),
 >;
 pub type mode_tree_draw_cb = Option<
-    unsafe extern "C" fn(
+    unsafe fn(
         _: *mut c_void,
         _: Option<NonNull<c_void>>,
         _: *mut screen_write_ctx,
@@ -43,14 +43,14 @@ pub type mode_tree_draw_cb = Option<
     ),
 >;
 pub type mode_tree_search_cb =
-    Option<unsafe extern "C" fn(_: *mut c_void, _: NonNull<c_void>, _: *const c_char) -> bool>;
+    Option<unsafe fn(_: *mut c_void, _: NonNull<c_void>, _: *const c_char) -> bool>;
 pub type mode_tree_menu_cb =
-    Option<unsafe extern "C" fn(_: NonNull<c_void>, _: *mut client, _: key_code)>;
-pub type mode_tree_height_cb = Option<unsafe extern "C" fn(_: *mut c_void, _: c_uint) -> c_uint>;
+    Option<unsafe fn(_: NonNull<c_void>, _: *mut client, _: key_code)>;
+pub type mode_tree_height_cb = Option<unsafe fn(_: *mut c_void, _: c_uint) -> c_uint>;
 pub type mode_tree_key_cb =
-    Option<unsafe extern "C" fn(_: NonNull<c_void>, _: NonNull<c_void>, _: c_uint) -> key_code>;
+    Option<unsafe fn(_: NonNull<c_void>, _: NonNull<c_void>, _: c_uint) -> key_code>;
 pub type mode_tree_each_cb = Option<
-    unsafe extern "C" fn(_: NonNull<c_void>, _: NonNull<c_void>, _: *mut client, _: key_code),
+    unsafe fn(_: NonNull<c_void>, _: NonNull<c_void>, _: *mut client, _: key_code),
 >;
 
 #[repr(C)]
@@ -154,7 +154,7 @@ static mode_tree_menu_items: [menu_item; 5] = [
     menu_item::new(None, KEYC_NONE, null_mut()),
 ];
 
-unsafe extern "C" fn mode_tree_find_item(
+unsafe fn mode_tree_find_item(
     mtl: *mut mode_tree_list,
     tag: u64,
 ) -> *mut mode_tree_item {
@@ -172,7 +172,7 @@ unsafe extern "C" fn mode_tree_find_item(
     }
 }
 
-unsafe extern "C" fn mode_tree_free_item(mti: *mut mode_tree_item) {
+unsafe fn mode_tree_free_item(mti: *mut mode_tree_item) {
     unsafe {
         mode_tree_free_items(&raw mut (*mti).children);
 
@@ -184,7 +184,7 @@ unsafe extern "C" fn mode_tree_free_item(mti: *mut mode_tree_item) {
     }
 }
 
-unsafe extern "C" fn mode_tree_free_items(mtl: *mut mode_tree_list) {
+unsafe fn mode_tree_free_items(mtl: *mut mode_tree_list) {
     unsafe {
         for mti in tailq_foreach(mtl).map(NonNull::as_ptr) {
             tailq_remove(mtl, mti);
@@ -193,7 +193,7 @@ unsafe extern "C" fn mode_tree_free_items(mtl: *mut mode_tree_list) {
     }
 }
 
-unsafe extern "C" fn mode_tree_check_selected(mtd: *mut mode_tree_data) {
+unsafe fn mode_tree_check_selected(mtd: *mut mode_tree_data) {
     unsafe {
         /*
          * If the current line would now be off screen reset the offset to the
@@ -205,7 +205,7 @@ unsafe extern "C" fn mode_tree_check_selected(mtd: *mut mode_tree_data) {
     }
 }
 
-unsafe extern "C" fn mode_tree_clear_lines(mtd: *mut mode_tree_data) {
+unsafe fn mode_tree_clear_lines(mtd: *mut mode_tree_data) {
     unsafe {
         free_((*mtd).line_list);
         (*mtd).line_list = null_mut();
@@ -213,7 +213,7 @@ unsafe extern "C" fn mode_tree_clear_lines(mtd: *mut mode_tree_data) {
     }
 }
 
-unsafe extern "C" fn mode_tree_build_lines(
+unsafe fn mode_tree_build_lines(
     mtd: *mut mode_tree_data,
     mtl: *mut mode_tree_list,
     depth: u32,
@@ -275,7 +275,7 @@ unsafe extern "C" fn mode_tree_build_lines(
     }
 }
 
-unsafe extern "C" fn mode_tree_clear_tagged(mtl: *mut mode_tree_list) {
+unsafe fn mode_tree_clear_tagged(mtl: *mut mode_tree_list) {
     unsafe {
         for mti in tailq_foreach(mtl).map(NonNull::as_ptr) {
             (*mti).tagged = 0;
@@ -284,7 +284,7 @@ unsafe extern "C" fn mode_tree_clear_tagged(mtl: *mut mode_tree_list) {
     }
 }
 
-pub unsafe extern "C" fn mode_tree_up(mtd: *mut mode_tree_data, wrap: i32) {
+pub unsafe fn mode_tree_up(mtd: *mut mode_tree_data, wrap: i32) {
     unsafe {
         if (*mtd).current == 0 {
             if wrap != 0 {
@@ -302,7 +302,7 @@ pub unsafe extern "C" fn mode_tree_up(mtd: *mut mode_tree_data, wrap: i32) {
     }
 }
 
-pub unsafe extern "C" fn mode_tree_down(mtd: *mut mode_tree_data, wrap: i32) -> i32 {
+pub unsafe fn mode_tree_down(mtd: *mut mode_tree_data, wrap: i32) -> i32 {
     unsafe {
         if (*mtd).current == (*mtd).line_size - 1 {
             if wrap != 0 {
@@ -322,16 +322,16 @@ pub unsafe extern "C" fn mode_tree_down(mtd: *mut mode_tree_data, wrap: i32) -> 
     }
 }
 
-pub unsafe extern "C" fn mode_tree_get_current(mtd: *mut mode_tree_data) -> NonNull<c_void> {
+pub unsafe fn mode_tree_get_current(mtd: *mut mode_tree_data) -> NonNull<c_void> {
     NonNull::new(unsafe { (*(*(*mtd).line_list.add((*mtd).current as usize)).item).itemdata })
         .unwrap()
 }
 
-pub unsafe extern "C" fn mode_tree_get_current_name(mtd: *mut mode_tree_data) -> *const c_char {
+pub unsafe fn mode_tree_get_current_name(mtd: *mut mode_tree_data) -> *const c_char {
     unsafe { (*(*(*mtd).line_list.add((*mtd).current as usize)).item).name }
 }
 
-pub unsafe extern "C" fn mode_tree_expand_current(mtd: *mut mode_tree_data) {
+pub unsafe fn mode_tree_expand_current(mtd: *mut mode_tree_data) {
     unsafe {
         if (*(*(*mtd).line_list.add((*mtd).current as usize)).item).expanded == 0 {
             (*(*(*mtd).line_list.add((*mtd).current as usize)).item).expanded = 1;
@@ -340,7 +340,7 @@ pub unsafe extern "C" fn mode_tree_expand_current(mtd: *mut mode_tree_data) {
     }
 }
 
-pub unsafe extern "C" fn mode_tree_collapse_current(mtd: *mut mode_tree_data) {
+pub unsafe fn mode_tree_collapse_current(mtd: *mut mode_tree_data) {
     unsafe {
         if ((*(*(*mtd).line_list.add((*mtd).current as usize)).item).expanded) != 0 {
             (*(*(*mtd).line_list.add((*mtd).current as usize)).item).expanded = 0;
@@ -349,7 +349,7 @@ pub unsafe extern "C" fn mode_tree_collapse_current(mtd: *mut mode_tree_data) {
     }
 }
 
-pub unsafe extern "C" fn mode_tree_get_tag(
+pub unsafe fn mode_tree_get_tag(
     mtd: *mut mode_tree_data,
     tag: u64,
     found: *mut u32,
@@ -371,7 +371,7 @@ pub unsafe extern "C" fn mode_tree_get_tag(
     }
 }
 
-pub unsafe extern "C" fn mode_tree_expand(mtd: *mut mode_tree_data, tag: u64) {
+pub unsafe fn mode_tree_expand(mtd: *mut mode_tree_data, tag: u64) {
     unsafe {
         let mut found: u32 = 0;
         if mode_tree_get_tag(mtd, tag, &raw mut found) == 0 {
@@ -384,7 +384,7 @@ pub unsafe extern "C" fn mode_tree_expand(mtd: *mut mode_tree_data, tag: u64) {
     }
 }
 
-pub unsafe extern "C" fn mode_tree_set_current(mtd: *mut mode_tree_data, tag: u64) -> i32 {
+pub unsafe fn mode_tree_set_current(mtd: *mut mode_tree_data, tag: u64) -> i32 {
     unsafe {
         let mut found: u32 = 0;
 
@@ -403,7 +403,7 @@ pub unsafe extern "C" fn mode_tree_set_current(mtd: *mut mode_tree_data, tag: u6
     }
 }
 
-pub unsafe extern "C" fn mode_tree_count_tagged(mtd: *mut mode_tree_data) -> u32 {
+pub unsafe fn mode_tree_count_tagged(mtd: *mut mode_tree_data) -> u32 {
     unsafe {
         let mut tagged: u32 = 0;
         for i in 0..(*mtd).line_size {
@@ -416,7 +416,7 @@ pub unsafe extern "C" fn mode_tree_count_tagged(mtd: *mut mode_tree_data) -> u32
     }
 }
 
-pub unsafe extern "C" fn mode_tree_each_tagged(
+pub unsafe fn mode_tree_each_tagged(
     mtd: *mut mode_tree_data,
     cb: mode_tree_each_cb,
     c: *mut client,
@@ -449,7 +449,7 @@ pub unsafe extern "C" fn mode_tree_each_tagged(
     }
 }
 
-pub unsafe extern "C" fn mode_tree_start(
+pub unsafe fn mode_tree_start(
     wp: *mut window_pane,
     args: *mut args,
     buildcb: mode_tree_build_cb,
@@ -518,7 +518,7 @@ pub unsafe extern "C" fn mode_tree_start(
     }
 }
 
-pub unsafe extern "C" fn mode_tree_zoom(mtd: *mut mode_tree_data, args: *mut args) {
+pub unsafe fn mode_tree_zoom(mtd: *mut mode_tree_data, args: *mut args) {
     unsafe {
         let wp: *mut window_pane = (*mtd).wp;
 
@@ -533,7 +533,7 @@ pub unsafe extern "C" fn mode_tree_zoom(mtd: *mut mode_tree_data, args: *mut arg
     }
 }
 
-pub unsafe extern "C" fn mode_tree_set_height(mtd: *mut mode_tree_data) {
+pub unsafe fn mode_tree_set_height(mtd: *mut mode_tree_data) {
     unsafe {
         let s: *mut screen = &raw mut (*mtd).screen;
 
@@ -557,7 +557,7 @@ pub unsafe extern "C" fn mode_tree_set_height(mtd: *mut mode_tree_data) {
     }
 }
 
-pub unsafe extern "C" fn mode_tree_build(mtd: *mut mode_tree_data) {
+pub unsafe fn mode_tree_build(mtd: *mut mode_tree_data) {
     unsafe {
         let s = &raw mut (*mtd).screen;
 
@@ -607,7 +607,7 @@ pub unsafe extern "C" fn mode_tree_build(mtd: *mut mode_tree_data) {
     }
 }
 
-pub unsafe extern "C" fn mode_tree_remove_ref(mtd: *mut mode_tree_data) {
+pub unsafe fn mode_tree_remove_ref(mtd: *mut mode_tree_data) {
     unsafe {
         (*mtd).references -= 1;
         if (*mtd).references == 0 {
@@ -616,7 +616,7 @@ pub unsafe extern "C" fn mode_tree_remove_ref(mtd: *mut mode_tree_data) {
     }
 }
 
-pub unsafe extern "C" fn mode_tree_free(mtd: *mut mode_tree_data) {
+pub unsafe fn mode_tree_free(mtd: *mut mode_tree_data) {
     unsafe {
         let wp = (*mtd).wp;
 
@@ -636,7 +636,7 @@ pub unsafe extern "C" fn mode_tree_free(mtd: *mut mode_tree_data) {
     }
 }
 
-pub unsafe extern "C" fn mode_tree_resize(mtd: *mut mode_tree_data, sx: u32, sy: u32) {
+pub unsafe fn mode_tree_resize(mtd: *mut mode_tree_data, sx: u32, sy: u32) {
     unsafe {
         let s: *mut screen = &raw mut (*mtd).screen;
 
@@ -649,7 +649,7 @@ pub unsafe extern "C" fn mode_tree_resize(mtd: *mut mode_tree_data, sx: u32, sy:
     }
 }
 
-pub unsafe extern "C" fn mode_tree_add(
+pub unsafe fn mode_tree_add(
     mtd: *mut mode_tree_data,
     parent: *mut mode_tree_item,
     itemdata: *mut c_void,
@@ -695,19 +695,19 @@ pub unsafe extern "C" fn mode_tree_add(
     }
 }
 
-pub unsafe extern "C" fn mode_tree_draw_as_parent(mti: *mut mode_tree_item) {
+pub unsafe fn mode_tree_draw_as_parent(mti: *mut mode_tree_item) {
     unsafe {
         (*mti).draw_as_parent = 1;
     }
 }
 
-pub unsafe extern "C" fn mode_tree_no_tag(mti: *mut mode_tree_item) {
+pub unsafe fn mode_tree_no_tag(mti: *mut mode_tree_item) {
     unsafe {
         (*mti).no_tag = 1;
     }
 }
 
-pub unsafe extern "C" fn mode_tree_remove(mtd: *mut mode_tree_data, mti: *mut mode_tree_item) {
+pub unsafe fn mode_tree_remove(mtd: *mut mode_tree_data, mti: *mut mode_tree_item) {
     unsafe {
         let parent: *mut mode_tree_item = (*mti).parent;
 
@@ -720,7 +720,7 @@ pub unsafe extern "C" fn mode_tree_remove(mtd: *mut mode_tree_data, mti: *mut mo
     }
 }
 
-pub unsafe extern "C" fn mode_tree_draw(mtd: *mut mode_tree_data) {
+pub unsafe fn mode_tree_draw(mtd: *mut mode_tree_data) {
     unsafe {
         let wp = (*mtd).wp;
         let s = &raw mut (*mtd).screen;
@@ -954,7 +954,7 @@ pub unsafe extern "C" fn mode_tree_draw(mtd: *mut mode_tree_data) {
     }
 }
 
-pub unsafe extern "C" fn mode_tree_search_backward(
+pub unsafe fn mode_tree_search_backward(
     mtd: *mut mode_tree_data,
 ) -> *mut mode_tree_item {
     unsafe {
@@ -1008,7 +1008,7 @@ pub unsafe extern "C" fn mode_tree_search_backward(
     }
 }
 
-pub unsafe extern "C" fn mode_tree_search_forward(mtd: *mut mode_tree_data) -> *mut mode_tree_item {
+pub unsafe fn mode_tree_search_forward(mtd: *mut mode_tree_data) -> *mut mode_tree_item {
     unsafe {
         if (*mtd).search.is_null() {
             return null_mut();
@@ -1059,7 +1059,7 @@ pub unsafe extern "C" fn mode_tree_search_forward(mtd: *mut mode_tree_data) -> *
     }
 }
 
-pub unsafe extern "C" fn mode_tree_search_set(mtd: *mut mode_tree_data) {
+pub unsafe fn mode_tree_search_set(mtd: *mut mode_tree_data) {
     unsafe {
         let mti = if (*mtd).search_dir == mode_tree_search_dir::MODE_TREE_SEARCH_FORWARD {
             mode_tree_search_forward(mtd)
@@ -1084,7 +1084,7 @@ pub unsafe extern "C" fn mode_tree_search_set(mtd: *mut mode_tree_data) {
     }
 }
 
-pub unsafe extern "C" fn mode_tree_search_callback(
+pub unsafe fn mode_tree_search_callback(
     _c: *mut client,
     data: NonNull<c_void>,
     s: *const c_char,
@@ -1109,13 +1109,13 @@ pub unsafe extern "C" fn mode_tree_search_callback(
     }
 }
 
-pub unsafe extern "C" fn mode_tree_search_free(data: NonNull<c_void>) {
+pub unsafe fn mode_tree_search_free(data: NonNull<c_void>) {
     unsafe {
         mode_tree_remove_ref(data.cast().as_ptr());
     }
 }
 
-pub unsafe extern "C" fn mode_tree_filter_callback(
+pub unsafe fn mode_tree_filter_callback(
     _c: *mut client,
     data: NonNull<c_void>,
     s: *const c_char,
@@ -1145,13 +1145,13 @@ pub unsafe extern "C" fn mode_tree_filter_callback(
     }
 }
 
-pub unsafe extern "C" fn mode_tree_filter_free(data: NonNull<c_void>) {
+pub unsafe fn mode_tree_filter_free(data: NonNull<c_void>) {
     unsafe {
         mode_tree_remove_ref(data.cast().as_ptr());
     }
 }
 
-pub unsafe extern "C" fn mode_tree_menu_callback(
+pub unsafe fn mode_tree_menu_callback(
     _menu: *mut menu,
     _idx: u32,
     key: key_code,
@@ -1178,7 +1178,7 @@ pub unsafe extern "C" fn mode_tree_menu_callback(
     }
 }
 
-pub unsafe extern "C" fn mode_tree_display_menu(
+pub unsafe fn mode_tree_display_menu(
     mtd: *mut mode_tree_data,
     c: *mut client,
     mut x: u32,
@@ -1241,7 +1241,7 @@ pub unsafe extern "C" fn mode_tree_display_menu(
     }
 }
 
-pub unsafe extern "C" fn mode_tree_key(
+pub unsafe fn mode_tree_key(
     mtd: *mut mode_tree_data,
     c: *mut client,
     key: *mut key_code,
@@ -1548,7 +1548,7 @@ pub unsafe extern "C" fn mode_tree_key(
     }
 }
 
-pub unsafe extern "C" fn mode_tree_run_command(
+pub unsafe fn mode_tree_run_command(
     c: *mut client,
     fs: *mut cmd_find_state,
     template: *const c_char,

--- a/src/names.rs
+++ b/src/names.rs
@@ -16,7 +16,7 @@ use ::libc::{gettimeofday, memcpy, strchr, strcmp, strcspn, strlen, strncmp};
 use crate::event_::{event_add, event_initialized};
 use crate::*;
 
-pub unsafe fn name_time_callback(_fd: c_int, _events: c_short, arg: *mut c_void) {
+pub unsafe extern "C" fn name_time_callback(_fd: c_int, _events: c_short, arg: *mut c_void) {
     let w = arg as *mut window;
     unsafe {
         log_debug!("@{} timer expired", (*w).id);

--- a/src/names.rs
+++ b/src/names.rs
@@ -16,14 +16,14 @@ use ::libc::{gettimeofday, memcpy, strchr, strcmp, strcspn, strlen, strncmp};
 use crate::event_::{event_add, event_initialized};
 use crate::*;
 
-pub unsafe extern "C" fn name_time_callback(_fd: c_int, _events: c_short, arg: *mut c_void) {
+pub unsafe fn name_time_callback(_fd: c_int, _events: c_short, arg: *mut c_void) {
     let w = arg as *mut window;
     unsafe {
         log_debug!("@{} timer expired", (*w).id);
     }
 }
 
-pub unsafe extern "C" fn name_time_expired(w: *mut window, tv: *mut timeval) -> c_int {
+pub unsafe fn name_time_expired(w: *mut window, tv: *mut timeval) -> c_int {
     unsafe {
         let mut offset: MaybeUninit<timeval> = MaybeUninit::<timeval>::uninit();
 
@@ -101,7 +101,7 @@ pub unsafe fn check_window_name(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn default_window_name(w: *mut window) -> *mut c_char {
+pub unsafe fn default_window_name(w: *mut window) -> *mut c_char {
     unsafe {
         if (*w).active.is_null() {
             return xstrdup(c"".as_ptr()).cast().as_ptr();
@@ -118,7 +118,7 @@ pub unsafe extern "C" fn default_window_name(w: *mut window) -> *mut c_char {
     }
 }
 
-unsafe extern "C" fn format_window_name(w: *mut window) -> *const c_char {
+unsafe fn format_window_name(w: *mut window) -> *const c_char {
     unsafe {
         let ft = format_create(
             null_mut(),

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -26,7 +26,7 @@ pub struct notify_entry {
     pub pbname: *mut c_char,
 }
 
-pub unsafe extern "C" fn notify_insert_one_hook(
+pub unsafe fn notify_insert_one_hook(
     item: *mut cmdq_item,
     ne: *mut notify_entry,
     cmdlist: *mut cmd_list,
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn notify_insert_one_hook(
     }
 }
 
-pub unsafe extern "C" fn notify_insert_hook(mut item: *mut cmdq_item, ne: *mut notify_entry) {
+pub unsafe fn notify_insert_hook(mut item: *mut cmdq_item, ne: *mut notify_entry) {
     let __func__ = "notify_insert_hook";
     unsafe {
         log_debug!("{}: inserting hook {}", __func__, _s((*ne).name));
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn notify_insert_hook(mut item: *mut cmdq_item, ne: *mut n
 // notify_callback
 // notify_add
 
-pub unsafe extern "C" fn notify_callback(item: *mut cmdq_item, data: *mut c_void) -> cmd_retval {
+pub unsafe fn notify_callback(item: *mut cmdq_item, data: *mut c_void) -> cmd_retval {
     let __func__ = c"notify_callback".as_ptr();
     unsafe {
         let ne = data as *mut notify_entry;
@@ -279,7 +279,7 @@ pub unsafe fn notify_add(
     }
 }
 
-pub unsafe extern "C" fn notify_hook(item: *mut cmdq_item, name: *mut c_char) {
+pub unsafe fn notify_hook(item: *mut cmdq_item, name: *mut c_char) {
     let __func__ = c"notify_hook".as_ptr();
     unsafe {
         let target = cmdq_get_target(item);
@@ -404,7 +404,7 @@ pub unsafe fn notify_pane(name: &'static CStr, wp: *mut window_pane) {
     }
 }
 
-pub unsafe extern "C" fn notify_paste_buffer(pbname: *const c_char, deleted: i32) {
+pub unsafe fn notify_paste_buffer(pbname: *const c_char, deleted: i32) {
     unsafe {
         let mut fs: cmd_find_state = zeroed();
 

--- a/src/options_.rs
+++ b/src/options_.rs
@@ -37,7 +37,7 @@ pub struct options_array_item {
     pub entry: rb_entry<options_array_item>,
 }
 
-pub unsafe extern "C" fn options_array_cmp(
+pub unsafe fn options_array_cmp(
     a1: *const options_array_item,
     a2: *const options_array_item,
 ) -> Ordering {
@@ -109,14 +109,14 @@ pub fn OPTIONS_IS_ARRAY(o: *const options_entry) -> bool {
 
 RB_GENERATE!(options_tree, options_entry, entry, discr_entry, options_cmp);
 
-pub unsafe extern "C" fn options_cmp(
+pub unsafe fn options_cmp(
     lhs: *const options_entry,
     rhs: *const options_entry,
 ) -> Ordering {
     unsafe { i32_to_ordering(libc::strcmp((*lhs).name, (*rhs).name)) }
 }
 
-pub unsafe extern "C" fn options_map_name(name: *const c_char) -> *const c_char {
+pub unsafe fn options_map_name(name: *const c_char) -> *const c_char {
     unsafe {
         let mut map = &raw const options_other_names as *const options_name_map;
         while !(*map).from.is_null() {
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn options_map_name(name: *const c_char) -> *const c_char 
     }
 }
 
-pub unsafe extern "C" fn options_parent_table_entry(
+pub unsafe fn options_parent_table_entry(
     oo: *mut options,
     s: *const c_char,
 ) -> *const options_table_entry {
@@ -147,7 +147,7 @@ pub unsafe extern "C" fn options_parent_table_entry(
     }
 }
 
-pub unsafe extern "C" fn options_value_free(o: *const options_entry, ov: *mut options_value) {
+pub unsafe fn options_value_free(o: *const options_entry, ov: *mut options_value) {
     unsafe {
         if OPTIONS_IS_STRING(o) {
             free_((*ov).string);
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn options_value_free(o: *const options_entry, ov: *mut op
     }
 }
 
-pub unsafe extern "C" fn options_value_to_string(
+pub unsafe fn options_value_to_string(
     o: *mut options_entry,
     ov: *mut options_value,
     numeric: i32,
@@ -211,7 +211,7 @@ pub unsafe extern "C" fn options_value_to_string(
     }
 }
 
-pub unsafe extern "C" fn options_create(parent: *mut options) -> *mut options {
+pub unsafe fn options_create(parent: *mut options) -> *mut options {
     unsafe {
         let oo = xcalloc1::<options>() as *mut options;
         rb_init(&raw mut (*oo).tree);
@@ -220,7 +220,7 @@ pub unsafe extern "C" fn options_create(parent: *mut options) -> *mut options {
     }
 }
 
-pub unsafe extern "C" fn options_free(oo: *mut options) {
+pub unsafe fn options_free(oo: *mut options) {
     unsafe {
         for o in rb_foreach(&raw mut (*oo).tree) {
             options_remove(o.as_ptr());
@@ -229,25 +229,25 @@ pub unsafe extern "C" fn options_free(oo: *mut options) {
     }
 }
 
-pub unsafe extern "C" fn options_get_parent(oo: *mut options) -> *mut options {
+pub unsafe fn options_get_parent(oo: *mut options) -> *mut options {
     unsafe { (*oo).parent }
 }
 
-pub unsafe extern "C" fn options_set_parent(oo: *mut options, parent: *mut options) {
+pub unsafe fn options_set_parent(oo: *mut options, parent: *mut options) {
     unsafe {
         (*oo).parent = parent;
     }
 }
 
-pub unsafe extern "C" fn options_first(oo: *mut options) -> *mut options_entry {
+pub unsafe fn options_first(oo: *mut options) -> *mut options_entry {
     unsafe { rb_min(&raw mut (*oo).tree) }
 }
 
-pub unsafe extern "C" fn options_next(o: *mut options_entry) -> *mut options_entry {
+pub unsafe fn options_next(o: *mut options_entry) -> *mut options_entry {
     unsafe { rb_next(o) }
 }
 
-pub unsafe extern "C" fn options_get_only(
+pub unsafe fn options_get_only(
     oo: *mut options,
     name: *const c_char,
 ) -> *mut options_entry {
@@ -267,7 +267,7 @@ pub unsafe extern "C" fn options_get_only(
     }
 }
 
-pub unsafe extern "C" fn options_get(
+pub unsafe fn options_get(
     mut oo: *mut options,
     name: *const c_char,
 ) -> *mut options_entry {
@@ -300,7 +300,7 @@ pub unsafe fn options_get_(mut oo: *mut options, name: &CStr) -> *mut options_en
     }
 }
 
-pub unsafe extern "C" fn options_empty(
+pub unsafe fn options_empty(
     oo: *mut options,
     oe: *const options_table_entry,
 ) -> *mut options_entry {
@@ -315,7 +315,7 @@ pub unsafe extern "C" fn options_empty(
     }
 }
 
-pub unsafe extern "C" fn options_default(
+pub unsafe fn options_default(
     oo: *mut options,
     oe: *const options_table_entry,
 ) -> *mut options_entry {
@@ -348,7 +348,7 @@ pub unsafe extern "C" fn options_default(
     }
 }
 
-pub unsafe extern "C" fn options_default_to_string(
+pub unsafe fn options_default_to_string(
     oe: *const options_table_entry,
 ) -> NonNull<c_char> {
     unsafe {
@@ -392,7 +392,7 @@ unsafe fn options_add(oo: *mut options, name: *const c_char) -> *mut options_ent
     }
 }
 
-pub unsafe extern "C" fn options_remove(o: *mut options_entry) {
+pub unsafe fn options_remove(o: *mut options_entry) {
     unsafe {
         let oo = (*o).owner;
 
@@ -407,15 +407,15 @@ pub unsafe extern "C" fn options_remove(o: *mut options_entry) {
     }
 }
 
-pub unsafe extern "C" fn options_name(o: *mut options_entry) -> *const c_char {
+pub unsafe fn options_name(o: *mut options_entry) -> *const c_char {
     unsafe { (*o).name }
 }
 
-pub unsafe extern "C" fn options_owner(o: *mut options_entry) -> *mut options {
+pub unsafe fn options_owner(o: *mut options_entry) -> *mut options {
     unsafe { (*o).owner }
 }
 
-pub unsafe extern "C" fn options_table_entry(o: *mut options_entry) -> *const options_table_entry {
+pub unsafe fn options_table_entry(o: *mut options_entry) -> *const options_table_entry {
     unsafe { (*o).tableentry }
 }
 
@@ -446,7 +446,7 @@ unsafe fn options_array_free(o: *mut options_entry, a: *mut options_array_item) 
     }
 }
 
-pub unsafe extern "C" fn options_array_clear(o: *mut options_entry) {
+pub unsafe fn options_array_clear(o: *mut options_entry) {
     unsafe {
         if options_is_array(o) == 0 {
             return;
@@ -461,7 +461,7 @@ pub unsafe extern "C" fn options_array_clear(o: *mut options_entry) {
     }
 }
 
-pub unsafe extern "C" fn options_array_get(o: *mut options_entry, idx: u32) -> *mut options_value {
+pub unsafe fn options_array_get(o: *mut options_entry, idx: u32) -> *mut options_value {
     unsafe {
         if options_is_array(o) == 0 {
             return null_mut();
@@ -474,7 +474,7 @@ pub unsafe extern "C" fn options_array_get(o: *mut options_entry, idx: u32) -> *
     }
 }
 
-pub unsafe extern "C" fn options_array_set(
+pub unsafe fn options_array_set(
     o: *mut options_entry,
     idx: u32,
     value: *const c_char,
@@ -562,7 +562,7 @@ pub unsafe extern "C" fn options_array_set(
     }
 }
 
-pub unsafe extern "C" fn options_array_assign(
+pub unsafe fn options_array_assign(
     o: *mut options_entry,
     s: *const c_char,
     cause: *mut *mut c_char,
@@ -616,7 +616,7 @@ pub unsafe extern "C" fn options_array_assign(
     }
 }
 
-pub unsafe extern "C" fn options_array_first(o: *mut options_entry) -> *mut options_array_item {
+pub unsafe fn options_array_first(o: *mut options_entry) -> *mut options_array_item {
     unsafe {
         if !OPTIONS_IS_ARRAY(o) {
             return null_mut();
@@ -625,29 +625,29 @@ pub unsafe extern "C" fn options_array_first(o: *mut options_entry) -> *mut opti
     }
 }
 
-pub unsafe extern "C" fn options_array_next(a: *mut options_array_item) -> *mut options_array_item {
+pub unsafe fn options_array_next(a: *mut options_array_item) -> *mut options_array_item {
     unsafe { rb_next(a) }
 }
 
-pub unsafe extern "C" fn options_array_item_index(a: *mut options_array_item) -> u32 {
+pub unsafe fn options_array_item_index(a: *mut options_array_item) -> u32 {
     unsafe { (*a).index }
 }
 
-pub unsafe extern "C" fn options_array_item_value(
+pub unsafe fn options_array_item_value(
     a: *mut options_array_item,
 ) -> *mut options_value {
     unsafe { &raw mut (*a).value }
 }
 
-pub unsafe extern "C" fn options_is_array(o: *mut options_entry) -> i32 {
+pub unsafe fn options_is_array(o: *mut options_entry) -> i32 {
     unsafe { OPTIONS_IS_ARRAY(o) as i32 }
 }
 
-pub unsafe extern "C" fn options_is_string(o: *mut options_entry) -> i32 {
+pub unsafe fn options_is_string(o: *mut options_entry) -> i32 {
     unsafe { OPTIONS_IS_STRING(o) as i32 }
 }
 
-pub unsafe extern "C" fn options_to_string(
+pub unsafe fn options_to_string(
     o: *mut options_entry,
     idx: i32,
     numeric: i32,
@@ -696,7 +696,7 @@ pub unsafe extern "C" fn options_to_string(
     }
 }
 
-pub unsafe extern "C" fn options_parse(name: *const c_char, idx: *mut i32) -> *mut c_char {
+pub unsafe fn options_parse(name: *const c_char, idx: *mut i32) -> *mut c_char {
     unsafe {
         if *name == 0 {
             return null_mut();
@@ -728,7 +728,7 @@ pub unsafe extern "C" fn options_parse(name: *const c_char, idx: *mut i32) -> *m
     }
 }
 
-pub unsafe extern "C" fn options_parse_get(
+pub unsafe fn options_parse_get(
     oo: *mut options,
     s: *const c_char,
     idx: *mut i32,
@@ -751,7 +751,7 @@ pub unsafe extern "C" fn options_parse_get(
     }
 }
 
-pub unsafe extern "C" fn options_match(
+pub unsafe fn options_match(
     s: *const c_char,
     idx: *mut i32,
     ambiguous: *mut i32,
@@ -799,7 +799,7 @@ pub unsafe extern "C" fn options_match(
     }
 }
 
-pub unsafe extern "C" fn options_match_get(
+pub unsafe fn options_match_get(
     oo: *mut options,
     s: *const c_char,
     idx: *mut i32,
@@ -824,7 +824,7 @@ pub unsafe extern "C" fn options_match_get(
     }
 }
 
-pub unsafe extern "C" fn options_get_string(
+pub unsafe fn options_get_string(
     oo: *mut options,
     name: *const c_char,
 ) -> *const c_char {
@@ -853,7 +853,7 @@ pub unsafe fn options_get_string_(oo: *mut options, name: &CStr) -> *const c_cha
     }
 }
 
-pub unsafe extern "C" fn options_get_number(oo: *mut options, name: *const c_char) -> i64 {
+pub unsafe fn options_get_number(oo: *mut options, name: *const c_char) -> i64 {
     unsafe {
         let o = options_get(oo, name);
         if o.is_null() {
@@ -933,7 +933,7 @@ pub unsafe fn options_set_string_(
     }
 }
 
-pub unsafe extern "C" fn options_set_number(
+pub unsafe fn options_set_number(
     oo: *mut options,
     name: *const c_char,
     value: i64,
@@ -959,7 +959,7 @@ pub unsafe extern "C" fn options_set_number(
     }
 }
 
-pub unsafe extern "C" fn options_scope_from_name(
+pub unsafe fn options_scope_from_name(
     args: *mut args,
     window: i32,
     name: *const c_char,
@@ -1054,7 +1054,7 @@ pub unsafe extern "C" fn options_scope_from_name(
     }
 }
 
-pub unsafe extern "C" fn options_scope_from_flags(
+pub unsafe fn options_scope_from_flags(
     args: *mut args,
     window: i32,
     fs: *mut cmd_find_state,
@@ -1117,7 +1117,7 @@ pub unsafe extern "C" fn options_scope_from_flags(
     }
 }
 
-pub unsafe extern "C" fn options_string_to_style(
+pub unsafe fn options_string_to_style(
     oo: *mut options,
     name: *const c_char,
     ft: *mut format_tree,
@@ -1214,7 +1214,7 @@ unsafe fn options_from_string_flag(
     }
 }
 
-pub unsafe extern "C" fn options_find_choice(
+pub unsafe fn options_find_choice(
     oe: *const options_table_entry,
     value: *const c_char,
     cause: *mut *mut c_char,
@@ -1265,7 +1265,7 @@ unsafe fn options_from_string_choice(
     }
 }
 
-pub unsafe extern "C" fn options_from_string(
+pub unsafe fn options_from_string(
     oo: *mut options,
     oe: *const options_table_entry,
     name: *const c_char,
@@ -1360,7 +1360,7 @@ pub unsafe extern "C" fn options_from_string(
     }
 }
 
-pub unsafe extern "C" fn options_push_changes(name: *const c_char) {
+pub unsafe fn options_push_changes(name: *const c_char) {
     let __func__ = c"options_push_changes".as_ptr();
     unsafe {
         let mut loop_: *mut client;
@@ -1453,7 +1453,7 @@ pub unsafe extern "C" fn options_push_changes(name: *const c_char) {
     }
 }
 
-pub unsafe extern "C" fn options_remove_or_default(
+pub unsafe fn options_remove_or_default(
     o: *mut options_entry,
     idx: i32,
     cause: *mut *mut c_char,

--- a/src/osdep.rs
+++ b/src/osdep.rs
@@ -18,7 +18,7 @@ use crate::*;
 
 // this is for osdep-linux.c
 
-pub unsafe extern "C" fn osdep_get_name(fd: i32, tty: *const c_char) -> *mut c_char {
+pub unsafe fn osdep_get_name(fd: i32, tty: *const c_char) -> *mut c_char {
     unsafe {
         let pgrp = tcgetpgrp(fd);
         if pgrp == -1 {
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn osdep_get_name(fd: i32, tty: *const c_char) -> *mut c_c
     }
 }
 
-pub unsafe extern "C" fn osdep_get_cwd(fd: i32) -> *const c_char {
+pub unsafe fn osdep_get_cwd(fd: i32) -> *const c_char {
     const MAXPATHLEN: usize = libc::PATH_MAX as usize;
     static mut target_buffer: [c_char; MAXPATHLEN + 1] = [0; MAXPATHLEN + 1];
     unsafe {
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn osdep_get_cwd(fd: i32) -> *const c_char {
     }
 }
 
-pub unsafe extern "C" fn osdep_event_init() -> *mut event_base {
+pub unsafe fn osdep_event_init() -> *mut event_base {
     unsafe {
         // On Linux, epoll doesn't work on /dev/null (yes, really).
         libc::setenv(c"EVENT_NOEPOLL".as_ptr(), c"1".as_ptr(), 1);

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -75,19 +75,19 @@ fn paste_cmp_times(a: *const paste_buffer, b: *const paste_buffer) -> Ordering {
     }
 }
 
-pub unsafe extern "C" fn paste_buffer_name(pb: NonNull<paste_buffer>) -> *const c_char {
+pub unsafe fn paste_buffer_name(pb: NonNull<paste_buffer>) -> *const c_char {
     unsafe { (*pb.as_ptr()).name }
 }
 
-pub unsafe extern "C" fn paste_buffer_order(pb: NonNull<paste_buffer>) -> u32 {
+pub unsafe fn paste_buffer_order(pb: NonNull<paste_buffer>) -> u32 {
     unsafe { (*pb.as_ptr()).order }
 }
 
-pub unsafe extern "C" fn paste_buffer_created(pb: NonNull<paste_buffer>) -> time_t {
+pub unsafe fn paste_buffer_created(pb: NonNull<paste_buffer>) -> time_t {
     unsafe { (*pb.as_ptr()).created }
 }
 
-pub unsafe extern "C" fn paste_buffer_data(
+pub unsafe fn paste_buffer_data(
     pb: *mut paste_buffer,
     size: *mut usize,
 ) -> *const c_char {
@@ -106,7 +106,7 @@ pub unsafe fn paste_buffer_data_(pb: NonNull<paste_buffer>, size: &mut usize) ->
     }
 }
 
-pub unsafe extern "C" fn paste_walk(pb: *mut paste_buffer) -> *mut paste_buffer {
+pub unsafe fn paste_walk(pb: *mut paste_buffer) -> *mut paste_buffer {
     unsafe {
         if pb.is_null() {
             return rb_min::<_, discr_time_entry>(&raw mut paste_by_time);
@@ -115,11 +115,11 @@ pub unsafe extern "C" fn paste_walk(pb: *mut paste_buffer) -> *mut paste_buffer 
     }
 }
 
-pub unsafe extern "C" fn paste_is_empty() -> i32 {
+pub unsafe fn paste_is_empty() -> i32 {
     unsafe { rb_root(&raw mut paste_by_time).is_null() as i32 }
 }
 
-pub unsafe extern "C" fn paste_get_top(name: *mut *const c_char) -> *mut paste_buffer {
+pub unsafe fn paste_get_top(name: *mut *const c_char) -> *mut paste_buffer {
     unsafe {
         let mut pb = rb_min::<_, discr_time_entry>(&raw mut paste_by_time);
         while !pb.is_null() && (*pb).automatic == 0 {
@@ -136,7 +136,7 @@ pub unsafe extern "C" fn paste_get_top(name: *mut *const c_char) -> *mut paste_b
     }
 }
 
-pub unsafe extern "C" fn paste_get_name(name: *const c_char) -> *mut paste_buffer {
+pub unsafe fn paste_get_name(name: *const c_char) -> *mut paste_buffer {
     unsafe {
         let mut pbfind = MaybeUninit::<paste_buffer>::uninit();
 
@@ -149,7 +149,7 @@ pub unsafe extern "C" fn paste_get_name(name: *const c_char) -> *mut paste_buffe
     }
 }
 
-pub unsafe extern "C" fn paste_free(pb: NonNull<paste_buffer>) {
+pub unsafe fn paste_free(pb: NonNull<paste_buffer>) {
     unsafe {
         let pb = pb.as_ptr();
         notify_paste_buffer((*pb).name, 1);
@@ -166,7 +166,7 @@ pub unsafe extern "C" fn paste_free(pb: NonNull<paste_buffer>) {
     }
 }
 
-pub unsafe extern "C" fn paste_add(mut prefix: *const c_char, data: *mut c_char, size: usize) {
+pub unsafe fn paste_add(mut prefix: *const c_char, data: *mut c_char, size: usize) {
     unsafe {
         if prefix.is_null() {
             prefix = c"buffer".as_ptr();
@@ -217,7 +217,7 @@ pub unsafe extern "C" fn paste_add(mut prefix: *const c_char, data: *mut c_char,
     }
 }
 
-pub unsafe extern "C" fn paste_rename(
+pub unsafe fn paste_rename(
     oldname: *const c_char,
     newname: *const c_char,
     cause: *mut *mut c_char,
@@ -270,7 +270,7 @@ pub unsafe extern "C" fn paste_rename(
     0
 }
 
-pub unsafe extern "C" fn paste_set(
+pub unsafe fn paste_set(
     data: *mut c_char,
     size: usize,
     name: *const c_char,
@@ -332,7 +332,7 @@ pub unsafe fn paste_replace(pb: NonNull<paste_buffer>, data: *mut c_char, size: 
     }
 }
 
-pub unsafe extern "C" fn paste_make_sample(pb: *mut paste_buffer) -> *mut c_char {
+pub unsafe fn paste_make_sample(pb: *mut paste_buffer) -> *mut c_char {
     unsafe {
         let width = 200;
 

--- a/src/popup.rs
+++ b/src/popup.rs
@@ -13,9 +13,9 @@
 // OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 use crate::*;
 
-pub type popup_close_cb = Option<unsafe extern "C" fn(_: i32, _: *mut c_void)>;
+pub type popup_close_cb = Option<unsafe fn(_: i32, _: *mut c_void)>;
 pub type popup_finish_edit_cb =
-    Option<unsafe extern "C" fn(_: *mut c_char, _: usize, _: *mut c_void)>;
+    Option<unsafe fn(_: *mut c_char, _: usize, _: *mut c_void)>;
 
 #[repr(i32)]
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -103,7 +103,7 @@ static mut popup_internal_menu_items: [menu_item; 5] = [
 
 // #[cfg(disabled)]
 
-pub unsafe extern "C" fn popup_redraw_cb(ttyctx: *const tty_ctx) {
+pub unsafe fn popup_redraw_cb(ttyctx: *const tty_ctx) {
     unsafe {
         let pd = (*ttyctx).arg.cast::<popup_data>();
         (*(*pd).c).flags |= client_flag::REDRAWOVERLAY;
@@ -112,7 +112,7 @@ pub unsafe extern "C" fn popup_redraw_cb(ttyctx: *const tty_ctx) {
 
 // #[cfg(disabled)]
 
-pub unsafe extern "C" fn popup_set_client_cb(ttyctx: *mut tty_ctx, c: *mut client) -> i32 {
+pub unsafe fn popup_set_client_cb(ttyctx: *mut tty_ctx, c: *mut client) -> i32 {
     unsafe {
         let pd = (*ttyctx).arg.cast::<popup_data>();
 
@@ -147,7 +147,7 @@ pub unsafe extern "C" fn popup_set_client_cb(ttyctx: *mut tty_ctx, c: *mut clien
 
 // #[cfg(disabled)]
 
-pub unsafe extern "C" fn popup_init_ctx_cb(ctx: *mut screen_write_ctx, ttyctx: *mut tty_ctx) {
+pub unsafe fn popup_init_ctx_cb(ctx: *mut screen_write_ctx, ttyctx: *mut tty_ctx) {
     unsafe {
         let pd = (*ctx).arg.cast::<popup_data>();
 
@@ -161,7 +161,7 @@ pub unsafe extern "C" fn popup_init_ctx_cb(ctx: *mut screen_write_ctx, ttyctx: *
 
 // #[cfg(disabled)]
 
-pub unsafe extern "C" fn popup_mode_cb(
+pub unsafe fn popup_mode_cb(
     c: *mut client,
     data: *mut c_void,
     cx: *mut u32,
@@ -186,7 +186,7 @@ pub unsafe extern "C" fn popup_mode_cb(
 }
 
 /// Return parts of the input range which are not obstructed by the popup.
-pub unsafe extern "C" fn popup_check_cb(
+pub unsafe fn popup_check_cb(
     c: *mut client,
     data: *mut c_void,
     px: u32,
@@ -246,7 +246,7 @@ pub unsafe extern "C" fn popup_check_cb(
 
 // #[cfg(disabled)]
 
-pub unsafe extern "C" fn popup_draw_cb(
+pub unsafe fn popup_draw_cb(
     c: *mut client,
     data: *mut c_void,
     rctx: *mut screen_redraw_ctx,
@@ -334,7 +334,7 @@ pub unsafe extern "C" fn popup_draw_cb(
 
 // #[cfg(disabled)]
 
-pub extern "C" fn popup_free_cb(c: *mut client, data: *mut c_void) {
+pub fn popup_free_cb(c: *mut client, data: *mut c_void) {
     unsafe {
         let pd = data as *mut popup_data;
         let item = (*pd).item;
@@ -371,7 +371,7 @@ pub extern "C" fn popup_free_cb(c: *mut client, data: *mut c_void) {
 
 // #[cfg(disabled)]
 
-pub extern "C" fn popup_resize_cb(_c: *mut client, data: *mut c_void) {
+pub fn popup_resize_cb(_c: *mut client, data: *mut c_void) {
     unsafe {
         let pd = data as *mut popup_data;
         if pd.is_null() {
@@ -417,7 +417,7 @@ pub extern "C" fn popup_resize_cb(_c: *mut client, data: *mut c_void) {
 
 //#[cfg(disabled)]
 
-pub extern "C" fn popup_make_pane(pd: *mut popup_data, type_: layout_type) {
+pub fn popup_make_pane(pd: *mut popup_data, type_: layout_type) {
     unsafe {
         let c = (*pd).c;
         let s = (*c).session;
@@ -461,7 +461,7 @@ pub extern "C" fn popup_make_pane(pd: *mut popup_data, type_: layout_type) {
 
 // #[cfg(disabled)]
 
-pub extern "C" fn popup_menu_done(
+pub fn popup_menu_done(
     _menu: *mut menu,
     _choice: u32,
     key: key_code,
@@ -505,7 +505,7 @@ pub extern "C" fn popup_menu_done(
 
 // #[cfg(disabled)]
 
-pub unsafe extern "C" fn popup_handle_drag(
+pub unsafe fn popup_handle_drag(
     c: *mut client,
     pd: *mut popup_data,
     m: *mut mouse_event,
@@ -577,7 +577,7 @@ pub unsafe extern "C" fn popup_handle_drag(
 
 // #[cfg(disabled)]
 
-pub unsafe extern "C" fn popup_key_cb(
+pub unsafe fn popup_key_cb(
     c: *mut client,
     data: *mut c_void,
     event: *mut key_event,
@@ -742,7 +742,7 @@ pub unsafe extern "C" fn popup_key_cb(
 
 // #[cfg(disabled)]
 
-pub unsafe extern "C" fn popup_job_update_cb(job: *mut job) {
+pub unsafe fn popup_job_update_cb(job: *mut job) {
     unsafe {
         let pd = job_get_data(job) as *mut popup_data;
         let evb = (*job_get_event(job)).input;
@@ -778,7 +778,7 @@ pub unsafe extern "C" fn popup_job_update_cb(job: *mut job) {
 }
 
 // #[cfg(disabled)]
-pub unsafe extern "C" fn popup_job_complete_cb(job: *mut job) {
+pub unsafe fn popup_job_complete_cb(job: *mut job) {
     unsafe {
         let pd = job_get_data(job) as *mut popup_data;
         let status = job_get_status((*pd).job);
@@ -802,7 +802,7 @@ pub unsafe extern "C" fn popup_job_complete_cb(job: *mut job) {
 
 // #[cfg(disabled)]
 
-pub unsafe extern "C" fn popup_display(
+pub unsafe fn popup_display(
     flags: c_int,
     mut lines: box_lines,
     item: *mut cmdq_item,
@@ -955,7 +955,7 @@ pub unsafe extern "C" fn popup_display(
 
 // #[cfg(disabled)]
 
-pub unsafe extern "C" fn popup_editor_free(pe: *mut popup_editor) {
+pub unsafe fn popup_editor_free(pe: *mut popup_editor) {
     unsafe {
         unlink((*pe).path);
         free_((*pe).path);
@@ -965,7 +965,7 @@ pub unsafe extern "C" fn popup_editor_free(pe: *mut popup_editor) {
 
 // #[cfg(disabled)]
 
-pub unsafe extern "C" fn popup_editor_close_cb(status: i32, arg: *mut c_void) {
+pub unsafe fn popup_editor_close_cb(status: i32, arg: *mut c_void) {
     unsafe {
         let pe = arg as *mut popup_editor;
         let mut buf: *mut c_char = null_mut();
@@ -1005,7 +1005,7 @@ pub unsafe extern "C" fn popup_editor_close_cb(status: i32, arg: *mut c_void) {
 
 // #[cfg(disabled)]
 
-pub unsafe extern "C" fn popup_editor(
+pub unsafe fn popup_editor(
     c: *mut client,
     buf: *const c_char,
     len: usize,

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -70,7 +70,7 @@ pub struct tmuxpeer {
     pub entry: tailq_entry<tmuxpeer>,
 }
 
-pub unsafe fn proc_event_cb(_fd: i32, events: i16, arg: *mut c_void) {
+pub unsafe extern "C" fn proc_event_cb(_fd: i32, events: i16, arg: *mut c_void) {
     unsafe {
         let peer = arg as *mut tmuxpeer;
         let mut imsg: MaybeUninit<imsg> = MaybeUninit::<imsg>::uninit();
@@ -125,7 +125,7 @@ pub unsafe fn proc_event_cb(_fd: i32, events: i16, arg: *mut c_void) {
     }
 }
 
-pub unsafe fn proc_signal_cb(signo: i32, _events: i16, arg: *mut c_void) {
+pub unsafe extern "C" fn proc_signal_cb(signo: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let tp = arg as *mut tmuxproc;
 

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -18,7 +18,7 @@ use libc::sscanf;
 
 use crate::compat::{queue::tailq_foreach, tree::rb_foreach};
 
-pub unsafe extern "C" fn resize_window(
+pub unsafe fn resize_window(
     w: *mut window,
     mut sx: u32,
     mut sy: u32,
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn resize_window(
     }
 }
 
-pub unsafe extern "C" fn ignore_client_size(c: *mut client) -> i32 {
+pub unsafe fn ignore_client_size(c: *mut client) -> i32 {
     unsafe {
         if (*c).session.is_null() {
             return 1;
@@ -107,7 +107,7 @@ pub unsafe extern "C" fn ignore_client_size(c: *mut client) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn clients_with_window(w: *mut window) -> u32 {
+pub unsafe fn clients_with_window(w: *mut window) -> u32 {
     let mut n = 0u32;
     unsafe {
         for loop_ in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
@@ -123,14 +123,14 @@ pub unsafe extern "C" fn clients_with_window(w: *mut window) -> u32 {
     n
 }
 
-pub unsafe extern "C" fn clients_calculate_size(
+pub unsafe fn clients_calculate_size(
     type_: window_size_option,
     current: i32,
     c: *mut client,
     s: *mut session,
     w: *mut window,
     skip_client: Option<
-        unsafe extern "C" fn(
+        unsafe fn(
             *mut client,
             window_size_option,
             i32,
@@ -328,7 +328,7 @@ pub unsafe extern "C" fn clients_calculate_size(
     }
 }
 
-pub unsafe extern "C" fn default_window_size_skip_client(
+pub unsafe fn default_window_size_skip_client(
     loop_: *mut client,
     type_: window_size_option,
     current: i32,
@@ -435,7 +435,7 @@ pub unsafe fn default_window_size(
     }
 }
 
-pub unsafe extern "C" fn recalculate_size_skip_client(
+pub unsafe fn recalculate_size_skip_client(
     loop_: *mut client,
     type_: window_size_option,
     current: i32,
@@ -459,7 +459,7 @@ pub unsafe extern "C" fn recalculate_size_skip_client(
     }
 }
 
-pub unsafe extern "C" fn recalculate_size(w: *mut window, now: i32) {
+pub unsafe fn recalculate_size(w: *mut window, now: i32) {
     let __func__ = "recalculate_size";
 
     unsafe {
@@ -545,13 +545,13 @@ pub unsafe extern "C" fn recalculate_size(w: *mut window, now: i32) {
     }
 }
 
-pub unsafe extern "C" fn recalculate_sizes() {
+pub unsafe fn recalculate_sizes() {
     unsafe {
         recalculate_sizes_now(0);
     }
 }
 
-pub unsafe extern "C" fn recalculate_sizes_now(now: i32) {
+pub unsafe fn recalculate_sizes_now(now: i32) {
     unsafe {
         // struct session *s;
         // struct client *c;

--- a/src/screen_.rs
+++ b/src/screen_.rs
@@ -67,7 +67,7 @@ pub unsafe fn screen_free_titles(s: *mut screen) {
 }
 
 /// Create a new screen.
-pub unsafe extern "C" fn screen_init(s: *mut screen, sx: u32, sy: u32, hlimit: u32) {
+pub unsafe fn screen_init(s: *mut screen, sx: u32, sy: u32, hlimit: u32) {
     unsafe {
         (*s).grid = grid_create(sx, sy, hlimit);
         (*s).saved_grid = null_mut();
@@ -96,7 +96,7 @@ pub unsafe extern "C" fn screen_init(s: *mut screen, sx: u32, sy: u32, hlimit: u
 }
 
 /// Reinitialise screen.
-pub unsafe extern "C" fn screen_reinit(s: *mut screen) {
+pub unsafe fn screen_reinit(s: *mut screen) {
     unsafe {
         (*s).cx = 0;
         (*s).cy = 0;
@@ -132,7 +132,7 @@ pub unsafe extern "C" fn screen_reinit(s: *mut screen) {
 }
 
 /// Reset hyperlinks of a screen.
-pub unsafe extern "C" fn screen_reset_hyperlinks(s: *mut screen) {
+pub unsafe fn screen_reset_hyperlinks(s: *mut screen) {
     unsafe {
         if (*s).hyperlinks.is_null() {
             (*s).hyperlinks = hyperlinks_init();
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn screen_reset_hyperlinks(s: *mut screen) {
 }
 
 /// Destroy a screen.
-pub unsafe extern "C" fn screen_free(s: *mut screen) {
+pub unsafe fn screen_free(s: *mut screen) {
     unsafe {
         free_((*s).sel);
         free_((*s).tabs);
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn screen_free(s: *mut screen) {
 }
 
 /// Reset tabs to default, eight spaces apart.
-pub unsafe extern "C" fn screen_reset_tabs(s: *mut screen) {
+pub unsafe fn screen_reset_tabs(s: *mut screen) {
     unsafe {
         free_((*s).tabs);
 
@@ -199,7 +199,7 @@ unsafe fn bit_set(bits: *mut u8, i: u32) {
 }
 
 /// Set screen cursor style and mode.
-pub unsafe extern "C" fn screen_set_cursor_style(
+pub unsafe fn screen_set_cursor_style(
     style: u32,
     cstyle: *mut screen_cursor_style,
     mode: *mut mode_flag,
@@ -237,14 +237,14 @@ pub unsafe extern "C" fn screen_set_cursor_style(
 }
 
 /// Set screen cursor colour.
-pub unsafe extern "C" fn screen_set_cursor_colour(s: *mut screen, colour: c_int) {
+pub unsafe fn screen_set_cursor_colour(s: *mut screen, colour: c_int) {
     unsafe {
         (*s).ccolour = colour;
     }
 }
 
 /// Set screen title.
-pub unsafe extern "C" fn screen_set_title(s: *mut screen, title: *const c_char) -> c_int {
+pub unsafe fn screen_set_title(s: *mut screen, title: *const c_char) -> c_int {
     unsafe {
         if !utf8_isvalid(title) {
             return 0;
@@ -256,7 +256,7 @@ pub unsafe extern "C" fn screen_set_title(s: *mut screen, title: *const c_char) 
 }
 
 /// Set screen path.
-pub unsafe extern "C" fn screen_set_path(s: *mut screen, path: *const c_char) {
+pub unsafe fn screen_set_path(s: *mut screen, path: *const c_char) {
     unsafe {
         free_((*s).path);
         utf8_stravis(
@@ -268,7 +268,7 @@ pub unsafe extern "C" fn screen_set_path(s: *mut screen, path: *const c_char) {
 }
 
 /// Push the current title onto the stack.
-pub unsafe extern "C" fn screen_push_title(s: *mut screen) {
+pub unsafe fn screen_push_title(s: *mut screen) {
     unsafe {
         if (*s).titles.is_null() {
             (*s).titles = xmalloc_::<screen_titles>().as_ptr();
@@ -282,7 +282,7 @@ pub unsafe extern "C" fn screen_push_title(s: *mut screen) {
 }
 
 /// Pop a title from the stack and set it as the screen title. If the stack is empty, do nothing.
-pub unsafe extern "C" fn screen_pop_title(s: *mut screen) {
+pub unsafe fn screen_pop_title(s: *mut screen) {
     unsafe {
         if (*s).titles.is_null() {
             return;
@@ -299,7 +299,7 @@ pub unsafe extern "C" fn screen_pop_title(s: *mut screen) {
 }
 
 /// Resize screen with options.
-pub unsafe extern "C" fn screen_resize_cursor(
+pub unsafe fn screen_resize_cursor(
     s: *mut screen,
     sx: u32,
     sy: u32,
@@ -374,14 +374,14 @@ pub unsafe extern "C" fn screen_resize_cursor(
 }
 
 /// Resize screen.
-pub unsafe extern "C" fn screen_resize(s: *mut screen, sx: u32, sy: u32, reflow: i32) {
+pub unsafe fn screen_resize(s: *mut screen, sx: u32, sy: u32, reflow: i32) {
     unsafe {
         screen_resize_cursor(s, sx, sy, reflow, 1, 1);
     }
 }
 
 /// Resize screen vertically.
-unsafe extern "C" fn screen_resize_y(s: *mut screen, sy: u32, eat_empty: i32, cy: *mut u32) {
+unsafe fn screen_resize_y(s: *mut screen, sy: u32, eat_empty: i32, cy: *mut u32) {
     unsafe {
         let gd = (*s).grid;
 
@@ -466,7 +466,7 @@ unsafe extern "C" fn screen_resize_y(s: *mut screen, sy: u32, eat_empty: i32, cy
 }
 
 /// Set selection.
-pub unsafe extern "C" fn screen_set_selection(
+pub unsafe fn screen_set_selection(
     s: *mut screen,
     sx: u32,
     sy: u32,
@@ -494,7 +494,7 @@ pub unsafe extern "C" fn screen_set_selection(
 }
 
 /// Clear selection.
-pub unsafe extern "C" fn screen_clear_selection(s: *mut screen) {
+pub unsafe fn screen_clear_selection(s: *mut screen) {
     unsafe {
         free_((*s).sel);
         (*s).sel = null_mut();
@@ -502,7 +502,7 @@ pub unsafe extern "C" fn screen_clear_selection(s: *mut screen) {
 }
 
 /// Hide selection.
-pub unsafe extern "C" fn screen_hide_selection(s: *mut screen) {
+pub unsafe fn screen_hide_selection(s: *mut screen) {
     unsafe {
         if !(*s).sel.is_null() {
             (*(*s).sel).hidden = 1;
@@ -511,7 +511,7 @@ pub unsafe extern "C" fn screen_hide_selection(s: *mut screen) {
 }
 
 /// Check if cell in selection.
-pub unsafe extern "C" fn screen_check_selection(s: *mut screen, px: u32, py: u32) -> c_int {
+pub unsafe fn screen_check_selection(s: *mut screen, px: u32, py: u32) -> c_int {
     unsafe {
         let sel = (*s).sel;
         let xx: u32;
@@ -638,7 +638,7 @@ pub unsafe extern "C" fn screen_check_selection(s: *mut screen, px: u32, py: u32
 }
 
 /// Get selected grid cell.
-pub unsafe extern "C" fn screen_select_cell(
+pub unsafe fn screen_select_cell(
     s: *mut screen,
     dst: *mut grid_cell,
     src: *const grid_cell,
@@ -658,7 +658,7 @@ pub unsafe extern "C" fn screen_select_cell(
 }
 
 /// Reflow wrapped lines.
-unsafe extern "C" fn screen_reflow(
+unsafe fn screen_reflow(
     s: *mut screen,
     new_x: u32,
     cx: *mut u32,
@@ -695,7 +695,7 @@ unsafe extern "C" fn screen_reflow(
 
 /// Enter alternative screen mode. A copy of the visible screen is saved and the
 /// history is not updated.
-pub unsafe extern "C" fn screen_alternate_on(s: *mut screen, gc: *mut grid_cell, cursor: i32) {
+pub unsafe fn screen_alternate_on(s: *mut screen, gc: *mut grid_cell, cursor: i32) {
     unsafe {
         if !(*s).saved_grid.is_null() {
             return;
@@ -719,7 +719,7 @@ pub unsafe extern "C" fn screen_alternate_on(s: *mut screen, gc: *mut grid_cell,
 }
 
 /// Exit alternate screen mode and restore the copied grid.
-pub unsafe extern "C" fn screen_alternate_off(s: *mut screen, gc: *mut grid_cell, cursor: i32) {
+pub unsafe fn screen_alternate_off(s: *mut screen, gc: *mut grid_cell, cursor: i32) {
     unsafe {
         let sx = screen_size_x(s);
         let sy = screen_size_y(s);
@@ -780,7 +780,7 @@ pub unsafe extern "C" fn screen_alternate_off(s: *mut screen, gc: *mut grid_cell
 }
 
 /// Get mode as a string.
-pub unsafe extern "C" fn screen_mode_to_string(mode: mode_flag) -> *const c_char {
+pub unsafe fn screen_mode_to_string(mode: mode_flag) -> *const c_char {
     const TMP_LEN: usize = 1024;
     static mut TMP: [MaybeUninit<c_char>; 1024] = [MaybeUninit::uninit(); 1024];
 

--- a/src/screen_redraw.rs
+++ b/src/screen_redraw.rs
@@ -30,7 +30,7 @@ pub enum screen_redraw_border_type {
 const BORDER_MARKERS: [u8; 6] = [b' ', b' ', b'+', b',', b'.', b'-'];
 
 /// Get cell border character.
-pub unsafe extern "C" fn screen_redraw_border_set(
+pub unsafe fn screen_redraw_border_set(
     w: *mut window,
     wp: *mut window_pane,
     pane_lines: pane_lines,
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn screen_redraw_border_set(
 }
 
 /// Return if window has only two panes.
-pub unsafe extern "C" fn screen_redraw_two_panes(w: *mut window, direction: i32) -> i32 {
+pub unsafe fn screen_redraw_two_panes(w: *mut window, direction: i32) -> i32 {
     unsafe {
         let wp: *mut window_pane =
             tailq_next::<_, _, discr_entry>(tailq_first(&raw mut (*w).panes));
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn screen_redraw_two_panes(w: *mut window, direction: i32)
 }
 
 /// Check if cell is on the border of a pane.
-pub unsafe extern "C" fn screen_redraw_pane_border(
+pub unsafe fn screen_redraw_pane_border(
     ctx: *mut screen_redraw_ctx,
     wp: *mut window_pane,
     px: u32,
@@ -191,7 +191,7 @@ pub unsafe extern "C" fn screen_redraw_pane_border(
 }
 
 /// Check if a cell is on a border.
-pub unsafe extern "C" fn screen_redraw_cell_border(
+pub unsafe fn screen_redraw_cell_border(
     ctx: *mut screen_redraw_ctx,
     px: u32,
     py: u32,
@@ -235,7 +235,7 @@ pub unsafe extern "C" fn screen_redraw_cell_border(
 }
 
 /// Work out type of border cell from surrounding cells.
-pub unsafe extern "C" fn screen_redraw_type_of_cell(
+pub unsafe fn screen_redraw_type_of_cell(
     ctx: *mut screen_redraw_ctx,
     px: u32,
     py: u32,
@@ -309,7 +309,7 @@ pub unsafe extern "C" fn screen_redraw_type_of_cell(
 }
 
 /// Check if cell inside a pane.
-pub unsafe extern "C" fn screen_redraw_check_cell(
+pub unsafe fn screen_redraw_check_cell(
     ctx: *mut screen_redraw_ctx,
     px: u32,
     py: u32,
@@ -401,7 +401,7 @@ pub unsafe extern "C" fn screen_redraw_check_cell(
 }
 
 /// Check if the border of a particular pane.
-pub unsafe extern "C" fn screen_redraw_check_is(
+pub unsafe fn screen_redraw_check_is(
     ctx: *mut screen_redraw_ctx,
     px: u32,
     py: u32,
@@ -419,7 +419,7 @@ pub unsafe extern "C" fn screen_redraw_check_is(
 }
 
 /// Update pane status.
-pub unsafe extern "C" fn screen_redraw_make_pane_status(
+pub unsafe fn screen_redraw_make_pane_status(
     c: *mut client,
     wp: NonNull<window_pane>,
     rctx: *mut screen_redraw_ctx,
@@ -514,7 +514,7 @@ pub unsafe extern "C" fn screen_redraw_make_pane_status(
 }
 
 /// Draw pane status.
-pub unsafe extern "C" fn screen_redraw_draw_pane_status(ctx: *mut screen_redraw_ctx) {
+pub unsafe fn screen_redraw_draw_pane_status(ctx: *mut screen_redraw_ctx) {
     unsafe {
         let c = (*ctx).c;
         let w = (*(*(*c).session).curw).window;
@@ -582,7 +582,7 @@ pub unsafe extern "C" fn screen_redraw_draw_pane_status(ctx: *mut screen_redraw_
 }
 
 /// Update status line and change flags if unchanged.
-unsafe extern "C" fn screen_redraw_update(c: *mut client, mut flags: client_flag) -> client_flag {
+unsafe fn screen_redraw_update(c: *mut client, mut flags: client_flag) -> client_flag {
     unsafe {
         let w = (*(*(*c).session).curw).window;
         let wo = (*w).options;
@@ -636,7 +636,7 @@ unsafe extern "C" fn screen_redraw_update(c: *mut client, mut flags: client_flag
 }
 
 /// Set up redraw context.
-pub unsafe extern "C" fn screen_redraw_set_context(c: *mut client, ctx: *mut screen_redraw_ctx) {
+pub unsafe fn screen_redraw_set_context(c: *mut client, ctx: *mut screen_redraw_ctx) {
     unsafe {
         let s = (*c).session;
         let oo = (*s).options;
@@ -687,7 +687,7 @@ pub unsafe extern "C" fn screen_redraw_set_context(c: *mut client, ctx: *mut scr
 }
 
 /// Redraw entire screen.
-pub unsafe extern "C" fn screen_redraw_screen(c: *mut client) {
+pub unsafe fn screen_redraw_screen(c: *mut client) {
     unsafe {
         let mut ctx = MaybeUninit::<screen_redraw_ctx>::uninit();
         let ctx = ctx.as_mut_ptr();
@@ -734,7 +734,7 @@ pub unsafe extern "C" fn screen_redraw_screen(c: *mut client) {
 }
 
 /// Redraw a single pane.
-pub unsafe extern "C" fn screen_redraw_pane(c: *mut client, wp: *mut window_pane) {
+pub unsafe fn screen_redraw_pane(c: *mut client, wp: *mut window_pane) {
     unsafe {
         let mut ctx = MaybeUninit::<screen_redraw_ctx>::uninit();
 
@@ -753,7 +753,7 @@ pub unsafe extern "C" fn screen_redraw_pane(c: *mut client, wp: *mut window_pane
 }
 
 /// Get border cell style.
-pub unsafe extern "C" fn screen_redraw_draw_borders_style(
+pub unsafe fn screen_redraw_draw_borders_style(
     ctx: *mut screen_redraw_ctx,
     x: u32,
     y: u32,
@@ -794,7 +794,7 @@ pub unsafe extern "C" fn screen_redraw_draw_borders_style(
 }
 
 /// Draw a border cell.
-pub unsafe extern "C" fn screen_redraw_draw_borders_cell(
+pub unsafe fn screen_redraw_draw_borders_cell(
     ctx: *mut screen_redraw_ctx,
     i: u32,
     j: u32,
@@ -905,7 +905,7 @@ pub unsafe extern "C" fn screen_redraw_draw_borders_cell(
 }
 
 /// Draw the borders.
-pub unsafe extern "C" fn screen_redraw_draw_borders(ctx: *mut screen_redraw_ctx) {
+pub unsafe fn screen_redraw_draw_borders(ctx: *mut screen_redraw_ctx) {
     unsafe {
         let c = (*ctx).c;
         let s = (*c).session;
@@ -931,7 +931,7 @@ pub unsafe extern "C" fn screen_redraw_draw_borders(ctx: *mut screen_redraw_ctx)
 }
 
 /// Draw the panes.
-pub unsafe extern "C" fn screen_redraw_draw_panes(ctx: *mut screen_redraw_ctx) {
+pub unsafe fn screen_redraw_draw_panes(ctx: *mut screen_redraw_ctx) {
     unsafe {
         let c = (*ctx).c;
         let w = (*(*(*c).session).curw).window;
@@ -952,7 +952,7 @@ pub unsafe extern "C" fn screen_redraw_draw_panes(ctx: *mut screen_redraw_ctx) {
 }
 
 /// Draw the status line.
-pub unsafe extern "C" fn screen_redraw_draw_status(ctx: *mut screen_redraw_ctx) {
+pub unsafe fn screen_redraw_draw_status(ctx: *mut screen_redraw_ctx) {
     unsafe {
         let c = (*ctx).c;
         let w = (*(*(*c).session).curw).window;
@@ -989,7 +989,7 @@ pub unsafe extern "C" fn screen_redraw_draw_status(ctx: *mut screen_redraw_ctx) 
 }
 
 /// Draw one pane.
-pub unsafe extern "C" fn screen_redraw_draw_pane(
+pub unsafe fn screen_redraw_draw_pane(
     ctx: *mut screen_redraw_ctx,
     wp: *mut window_pane,
 ) {

--- a/src/screen_write.rs
+++ b/src/screen_write.rs
@@ -53,7 +53,7 @@ pub struct screen_write_cline {
 pub static mut screen_write_citem_freelist: tailq_head<screen_write_citem> =
     TAILQ_HEAD_INITIALIZER!(screen_write_citem_freelist);
 
-unsafe extern "C" fn screen_write_get_citem() -> NonNull<screen_write_citem> {
+unsafe fn screen_write_get_citem() -> NonNull<screen_write_citem> {
     unsafe {
         if let Some(ci) = NonNull::new(tailq_first(&raw mut screen_write_citem_freelist)) {
             tailq_remove(&raw mut screen_write_citem_freelist, ci.as_ptr());
@@ -64,20 +64,20 @@ unsafe extern "C" fn screen_write_get_citem() -> NonNull<screen_write_citem> {
     }
 }
 
-unsafe extern "C" fn screen_write_free_citem(ci: *mut screen_write_citem) {
+unsafe fn screen_write_free_citem(ci: *mut screen_write_citem) {
     unsafe {
         tailq_insert_tail(&raw mut screen_write_citem_freelist, ci);
     }
 }
 
-unsafe extern "C" fn screen_write_offset_timer(_fd: i32, _events: i16, data: *mut c_void) {
+unsafe fn screen_write_offset_timer(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         tty_update_window_offset(data.cast());
     }
 }
 
 /// Set cursor position.
-unsafe extern "C" fn screen_write_set_cursor(ctx: *mut screen_write_ctx, mut cx: i32, mut cy: i32) {
+unsafe fn screen_write_set_cursor(ctx: *mut screen_write_ctx, mut cx: i32, mut cy: i32) {
     unsafe {
         let wp = (*ctx).wp;
         let s = (*ctx).s;
@@ -122,7 +122,7 @@ unsafe extern "C" fn screen_write_set_cursor(ctx: *mut screen_write_ctx, mut cx:
 }
 
 /// Do a full redraw.
-unsafe extern "C" fn screen_write_redraw_cb(ttyctx: *const tty_ctx) {
+unsafe fn screen_write_redraw_cb(ttyctx: *const tty_ctx) {
     unsafe {
         let wp: *mut window_pane = (*ttyctx).arg.cast();
 
@@ -133,7 +133,7 @@ unsafe extern "C" fn screen_write_redraw_cb(ttyctx: *const tty_ctx) {
 }
 
 /// Update context for client.
-unsafe extern "C" fn screen_write_set_client_cb(ttyctx: *mut tty_ctx, c: *mut client) -> i32 {
+unsafe fn screen_write_set_client_cb(ttyctx: *mut tty_ctx, c: *mut client) -> i32 {
     unsafe {
         let wp: *mut window_pane = (*ttyctx).arg.cast();
 
@@ -190,7 +190,7 @@ unsafe extern "C" fn screen_write_set_client_cb(ttyctx: *mut tty_ctx, c: *mut cl
 }
 
 /// Set up context for TTY command.
-unsafe extern "C" fn screen_write_initctx(
+unsafe fn screen_write_initctx(
     ctx: *mut screen_write_ctx,
     ttyctx: *mut tty_ctx,
     sync: i32,
@@ -253,7 +253,7 @@ unsafe extern "C" fn screen_write_initctx(
 }
 
 /// Make write list.
-pub unsafe extern "C" fn screen_write_make_list(s: *mut screen) {
+pub unsafe fn screen_write_make_list(s: *mut screen) {
     unsafe {
         (*s).write_list = xcalloc_(screen_size_y(s) as usize).as_ptr();
         for y in 0..screen_size_y(s) {
@@ -263,7 +263,7 @@ pub unsafe extern "C" fn screen_write_make_list(s: *mut screen) {
 }
 
 /// Free write list.
-pub unsafe extern "C" fn screen_write_free_list(s: *mut screen) {
+pub unsafe fn screen_write_free_list(s: *mut screen) {
     unsafe {
         for y in 0..screen_size_y(s) {
             free_((*(*s).write_list.add(y as usize)).data);
@@ -273,7 +273,7 @@ pub unsafe extern "C" fn screen_write_free_list(s: *mut screen) {
 }
 
 /// Set up for writing.
-unsafe extern "C" fn screen_write_init(ctx: *mut screen_write_ctx, s: *mut screen) {
+unsafe fn screen_write_init(ctx: *mut screen_write_ctx, s: *mut screen) {
     unsafe {
         memset0(ctx);
 
@@ -290,7 +290,7 @@ unsafe extern "C" fn screen_write_init(ctx: *mut screen_write_ctx, s: *mut scree
 }
 
 /// Initialize writing with a pane.
-pub unsafe extern "C" fn screen_write_start_pane(
+pub unsafe fn screen_write_start_pane(
     ctx: *mut screen_write_ctx,
     wp: *mut window_pane,
     mut s: *mut screen,
@@ -309,7 +309,7 @@ pub unsafe extern "C" fn screen_write_start_pane(
 }
 
 /// Initialize writing with a callback.
-pub unsafe extern "C" fn screen_write_start_callback(
+pub unsafe fn screen_write_start_callback(
     ctx: *mut screen_write_ctx,
     s: *mut screen,
     cb: screen_write_init_ctx_cb,
@@ -328,7 +328,7 @@ pub unsafe extern "C" fn screen_write_start_callback(
 }
 
 /// Initialize writing.
-pub unsafe extern "C" fn screen_write_start(ctx: *mut screen_write_ctx, s: *mut screen) {
+pub unsafe fn screen_write_start(ctx: *mut screen_write_ctx, s: *mut screen) {
     unsafe {
         screen_write_init(ctx, s);
 
@@ -339,7 +339,7 @@ pub unsafe extern "C" fn screen_write_start(ctx: *mut screen_write_ctx, s: *mut 
 }
 
 /// Finish writing.
-pub unsafe extern "C" fn screen_write_stop(ctx: *mut screen_write_ctx) {
+pub unsafe fn screen_write_stop(ctx: *mut screen_write_ctx) {
     unsafe {
         screen_write_collect_end(ctx);
         screen_write_collect_flush(ctx, 0, c"screen_write_stop".as_ptr());
@@ -349,7 +349,7 @@ pub unsafe extern "C" fn screen_write_stop(ctx: *mut screen_write_ctx) {
 }
 
 /// Reset screen state.
-pub unsafe extern "C" fn screen_write_reset(ctx: *mut screen_write_ctx) {
+pub unsafe fn screen_write_reset(ctx: *mut screen_write_ctx) {
     unsafe {
         let s = (*ctx).s;
 
@@ -368,7 +368,7 @@ pub unsafe extern "C" fn screen_write_reset(ctx: *mut screen_write_ctx) {
 }
 
 /// Write character.
-pub unsafe extern "C" fn screen_write_putc(
+pub unsafe fn screen_write_putc(
     ctx: *mut screen_write_ctx,
     gcp: *const grid_cell,
     ch: u8,
@@ -635,7 +635,7 @@ pub(crate) unsafe fn screen_write_vnputs_(
 
 /// Copy from another screen but without the selection stuff. Assumes the target
 /// region is already big enough.
-pub unsafe extern "C" fn screen_write_fast_copy(
+pub unsafe fn screen_write_fast_copy(
     ctx: *mut screen_write_ctx,
     src: *mut screen,
     px: u32,
@@ -675,7 +675,7 @@ pub unsafe extern "C" fn screen_write_fast_copy(
 }
 
 /// Select character set for drawing border lines.
-unsafe extern "C" fn screen_write_box_border_set(
+unsafe fn screen_write_box_border_set(
     lines: box_lines,
     cell_type: cell_type,
     gc: *mut grid_cell,
@@ -712,7 +712,7 @@ unsafe extern "C" fn screen_write_box_border_set(
 }
 
 /// Draw a horizontal line on screen.
-pub unsafe extern "C" fn screen_write_hline(
+pub unsafe fn screen_write_hline(
     ctx: *mut screen_write_ctx,
     nx: u32,
     left: i32,
@@ -759,7 +759,7 @@ pub unsafe extern "C" fn screen_write_hline(
 }
 
 /// Draw a vertical line on screen.
-pub unsafe extern "C" fn screen_write_vline(
+pub unsafe fn screen_write_vline(
     ctx: *mut screen_write_ctx,
     ny: u32,
     top: i32,
@@ -789,7 +789,7 @@ pub unsafe extern "C" fn screen_write_vline(
 }
 
 /// Draw a menu on screen.
-pub unsafe extern "C" fn screen_write_menu(
+pub unsafe fn screen_write_menu(
     ctx: *mut screen_write_ctx,
     menu: *mut menu,
     choice: i32,
@@ -854,7 +854,7 @@ pub unsafe extern "C" fn screen_write_menu(
 }
 
 /// Draw a box on screen.
-pub unsafe extern "C" fn screen_write_box(
+pub unsafe fn screen_write_box(
     ctx: *mut screen_write_ctx,
     nx: u32,
     ny: u32,
@@ -921,7 +921,7 @@ pub unsafe extern "C" fn screen_write_box(
 }
 
 /// Write a preview version of a window. Assumes target area is big enough and already cleared.
-pub unsafe extern "C" fn screen_write_preview(
+pub unsafe fn screen_write_preview(
     ctx: *mut screen_write_ctx,
     src: *mut screen,
     nx: u32,
@@ -988,7 +988,7 @@ pub unsafe extern "C" fn screen_write_preview(
 }
 
 /// Set a mode.
-pub unsafe extern "C" fn screen_write_mode_set(ctx: *mut screen_write_ctx, mode: mode_flag) {
+pub unsafe fn screen_write_mode_set(ctx: *mut screen_write_ctx, mode: mode_flag) {
     unsafe {
         let s = (*ctx).s;
 
@@ -1001,7 +1001,7 @@ pub unsafe extern "C" fn screen_write_mode_set(ctx: *mut screen_write_ctx, mode:
 }
 
 /// Clear a mode.
-pub unsafe extern "C" fn screen_write_mode_clear(ctx: *mut screen_write_ctx, mode: mode_flag) {
+pub unsafe fn screen_write_mode_clear(ctx: *mut screen_write_ctx, mode: mode_flag) {
     unsafe {
         let s = (*ctx).s;
 
@@ -1014,7 +1014,7 @@ pub unsafe extern "C" fn screen_write_mode_clear(ctx: *mut screen_write_ctx, mod
 }
 
 /// Cursor up by ny.
-pub unsafe extern "C" fn screen_write_cursorup(ctx: *mut screen_write_ctx, mut ny: u32) {
+pub unsafe fn screen_write_cursorup(ctx: *mut screen_write_ctx, mut ny: u32) {
     unsafe {
         let s = (*ctx).s;
         let mut cx: u32 = (*s).cx;
@@ -1046,7 +1046,7 @@ pub unsafe extern "C" fn screen_write_cursorup(ctx: *mut screen_write_ctx, mut n
 }
 
 /// Cursor down by ny.
-pub unsafe extern "C" fn screen_write_cursordown(ctx: *mut screen_write_ctx, mut ny: u32) {
+pub unsafe fn screen_write_cursordown(ctx: *mut screen_write_ctx, mut ny: u32) {
     unsafe {
         let s: *mut screen = (*ctx).s;
         let mut cx: u32 = (*s).cx;
@@ -1080,7 +1080,7 @@ pub unsafe extern "C" fn screen_write_cursordown(ctx: *mut screen_write_ctx, mut
 }
 
 /// Cursor right by nx.
-pub unsafe extern "C" fn screen_write_cursorright(ctx: *mut screen_write_ctx, mut nx: u32) {
+pub unsafe fn screen_write_cursorright(ctx: *mut screen_write_ctx, mut nx: u32) {
     unsafe {
         let s = (*ctx).s;
         let mut cx: u32 = (*s).cx;
@@ -1104,7 +1104,7 @@ pub unsafe extern "C" fn screen_write_cursorright(ctx: *mut screen_write_ctx, mu
 }
 
 /// Cursor left by nx.
-pub unsafe extern "C" fn screen_write_cursorleft(ctx: *mut screen_write_ctx, mut nx: u32) {
+pub unsafe fn screen_write_cursorleft(ctx: *mut screen_write_ctx, mut nx: u32) {
     unsafe {
         let s = (*ctx).s;
         let mut cx: u32 = (*s).cx;
@@ -1128,7 +1128,7 @@ pub unsafe extern "C" fn screen_write_cursorleft(ctx: *mut screen_write_ctx, mut
 }
 
 /// Backspace; cursor left unless at start of wrapped line when can move up.
-pub unsafe extern "C" fn screen_write_backspace(ctx: *mut screen_write_ctx) {
+pub unsafe fn screen_write_backspace(ctx: *mut screen_write_ctx) {
     unsafe {
         let s = (*ctx).s;
         let mut cx = (*s).cx;
@@ -1152,7 +1152,7 @@ pub unsafe extern "C" fn screen_write_backspace(ctx: *mut screen_write_ctx) {
 }
 
 /// VT100 alignment test.
-pub unsafe extern "C" fn screen_write_alignmenttest(ctx: *mut screen_write_ctx) {
+pub unsafe fn screen_write_alignmenttest(ctx: *mut screen_write_ctx) {
     unsafe {
         let s = (*ctx).s;
         let mut ttyctx: tty_ctx = zeroed();
@@ -1187,7 +1187,7 @@ pub unsafe extern "C" fn screen_write_alignmenttest(ctx: *mut screen_write_ctx) 
 }
 
 /// Insert nx characters.
-pub unsafe extern "C" fn screen_write_insertcharacter(
+pub unsafe fn screen_write_insertcharacter(
     ctx: *mut screen_write_ctx,
     mut nx: u32,
     bg: u32,
@@ -1230,7 +1230,7 @@ pub unsafe extern "C" fn screen_write_insertcharacter(
 }
 
 /// Delete nx characters.
-pub unsafe extern "C" fn screen_write_deletecharacter(
+pub unsafe fn screen_write_deletecharacter(
     ctx: *mut screen_write_ctx,
     mut nx: u32,
     bg: u32,
@@ -1273,7 +1273,7 @@ pub unsafe extern "C" fn screen_write_deletecharacter(
 }
 
 /// Clear nx characters.
-pub unsafe extern "C" fn screen_write_clearcharacter(
+pub unsafe fn screen_write_clearcharacter(
     ctx: *mut screen_write_ctx,
     mut nx: u32,
     bg: u32,
@@ -1316,7 +1316,7 @@ pub unsafe extern "C" fn screen_write_clearcharacter(
 }
 
 /// Insert ny lines.
-pub unsafe extern "C" fn screen_write_insertline(ctx: *mut screen_write_ctx, mut ny: u32, bg: u32) {
+pub unsafe fn screen_write_insertline(ctx: *mut screen_write_ctx, mut ny: u32, bg: u32) {
     unsafe {
         let s = (*ctx).s;
         let gd = (*s).grid;
@@ -1383,7 +1383,7 @@ pub unsafe extern "C" fn screen_write_insertline(ctx: *mut screen_write_ctx, mut
 }
 
 /// Delete ny lines.
-pub unsafe extern "C" fn screen_write_deleteline(ctx: *mut screen_write_ctx, mut ny: u32, bg: u32) {
+pub unsafe fn screen_write_deleteline(ctx: *mut screen_write_ctx, mut ny: u32, bg: u32) {
     unsafe {
         let s = (*ctx).s;
         let gd = (*s).grid;
@@ -1443,7 +1443,7 @@ pub unsafe extern "C" fn screen_write_deleteline(ctx: *mut screen_write_ctx, mut
 }
 
 /// Clear line at cursor.
-pub unsafe extern "C" fn screen_write_clearline(ctx: *mut screen_write_ctx, bg: u32) {
+pub unsafe fn screen_write_clearline(ctx: *mut screen_write_ctx, bg: u32) {
     unsafe {
         let s = (*ctx).s;
         let sx = screen_size_x(s);
@@ -1477,7 +1477,7 @@ pub unsafe extern "C" fn screen_write_clearline(ctx: *mut screen_write_ctx, bg: 
 }
 
 /// Clear to end of line from cursor.
-pub unsafe extern "C" fn screen_write_clearendofline(ctx: *mut screen_write_ctx, bg: u32) {
+pub unsafe fn screen_write_clearendofline(ctx: *mut screen_write_ctx, bg: u32) {
     unsafe {
         let s = (*ctx).s;
         let sx = screen_size_x(s);
@@ -1520,7 +1520,7 @@ pub unsafe extern "C" fn screen_write_clearendofline(ctx: *mut screen_write_ctx,
 }
 
 /// Clear to start of line from cursor.
-pub unsafe extern "C" fn screen_write_clearstartofline(ctx: *mut screen_write_ctx, bg: u32) {
+pub unsafe fn screen_write_clearstartofline(ctx: *mut screen_write_ctx, bg: u32) {
     unsafe {
         let s = (*ctx).s;
         let sx = screen_size_x(s);
@@ -1562,7 +1562,7 @@ pub unsafe extern "C" fn screen_write_clearstartofline(ctx: *mut screen_write_ct
 }
 
 /// Move cursor to px,py.
-pub unsafe extern "C" fn screen_write_cursormove(
+pub unsafe fn screen_write_cursormove(
     ctx: *mut screen_write_ctx,
     mut px: i32,
     mut py: i32,
@@ -1592,7 +1592,7 @@ pub unsafe extern "C" fn screen_write_cursormove(
 }
 
 /// Reverse index (up with scroll).
-pub unsafe extern "C" fn screen_write_reverseindex(ctx: *mut screen_write_ctx, bg: u32) {
+pub unsafe fn screen_write_reverseindex(ctx: *mut screen_write_ctx, bg: u32) {
     unsafe {
         let s = (*ctx).s;
         let mut ttyctx: tty_ctx = zeroed();
@@ -1619,7 +1619,7 @@ pub unsafe extern "C" fn screen_write_reverseindex(ctx: *mut screen_write_ctx, b
 }
 
 /// Set scroll region.
-pub unsafe extern "C" fn screen_write_scrollregion(
+pub unsafe fn screen_write_scrollregion(
     ctx: *mut screen_write_ctx,
     mut rupper: u32,
     mut rlower: u32,
@@ -1648,7 +1648,7 @@ pub unsafe extern "C" fn screen_write_scrollregion(
 }
 
 /// Line feed.
-pub unsafe extern "C" fn screen_write_linefeed(ctx: *mut screen_write_ctx, wrapped: i32, bg: u32) {
+pub unsafe fn screen_write_linefeed(ctx: *mut screen_write_ctx, wrapped: i32, bg: u32) {
     unsafe {
         let s = (*ctx).s;
         let gd = (*s).grid;
@@ -1695,7 +1695,7 @@ pub unsafe extern "C" fn screen_write_linefeed(ctx: *mut screen_write_ctx, wrapp
 }
 
 /// Scroll up.
-pub unsafe extern "C" fn screen_write_scrollup(
+pub unsafe fn screen_write_scrollup(
     ctx: *mut screen_write_ctx,
     mut lines: u32,
     bg: u32,
@@ -1731,7 +1731,7 @@ pub unsafe extern "C" fn screen_write_scrollup(
 }
 
 /// Scroll down.
-pub unsafe extern "C" fn screen_write_scrolldown(
+pub unsafe fn screen_write_scrolldown(
     ctx: *mut screen_write_ctx,
     mut lines: u32,
     bg: u32,
@@ -1768,14 +1768,14 @@ pub unsafe extern "C" fn screen_write_scrolldown(
 }
 
 /// Carriage return (cursor to start of line).
-pub unsafe extern "C" fn screen_write_carriagereturn(ctx: *mut screen_write_ctx) {
+pub unsafe fn screen_write_carriagereturn(ctx: *mut screen_write_ctx) {
     unsafe {
         screen_write_set_cursor(ctx, 0, -1);
     }
 }
 
 /// Clear to end of screen from cursor.
-pub unsafe extern "C" fn screen_write_clearendofscreen(ctx: *mut screen_write_ctx, bg: u32) {
+pub unsafe fn screen_write_clearendofscreen(ctx: *mut screen_write_ctx, bg: u32) {
     unsafe {
         let s = (*ctx).s;
         let gd = (*s).grid;
@@ -1815,7 +1815,7 @@ pub unsafe extern "C" fn screen_write_clearendofscreen(ctx: *mut screen_write_ct
 }
 
 /// Clear to start of screen.
-pub unsafe extern "C" fn screen_write_clearstartofscreen(ctx: *mut screen_write_ctx, bg: u32) {
+pub unsafe fn screen_write_clearstartofscreen(ctx: *mut screen_write_ctx, bg: u32) {
     unsafe {
         let s = (*ctx).s;
         let mut ttyctx: tty_ctx = zeroed();
@@ -1847,7 +1847,7 @@ pub unsafe extern "C" fn screen_write_clearstartofscreen(ctx: *mut screen_write_
 }
 
 /// Clear entire screen.
-pub unsafe extern "C" fn screen_write_clearscreen(ctx: *mut screen_write_ctx, bg: u32) {
+pub unsafe fn screen_write_clearscreen(ctx: *mut screen_write_ctx, bg: u32) {
     unsafe {
         let s = (*ctx).s;
         let mut ttyctx: tty_ctx = zeroed();
@@ -1880,14 +1880,14 @@ pub unsafe extern "C" fn screen_write_clearscreen(ctx: *mut screen_write_ctx, bg
 }
 
 /// Clear entire history.
-pub unsafe extern "C" fn screen_write_clearhistory(ctx: *mut screen_write_ctx) {
+pub unsafe fn screen_write_clearhistory(ctx: *mut screen_write_ctx) {
     unsafe {
         grid_clear_history((*(*ctx).s).grid);
     }
 }
 
 /// Force a full redraw.
-pub unsafe extern "C" fn screen_write_fullredraw(ctx: *mut screen_write_ctx) {
+pub unsafe fn screen_write_fullredraw(ctx: *mut screen_write_ctx) {
     unsafe {
         let mut ttyctx: tty_ctx = zeroed();
 
@@ -1901,7 +1901,7 @@ pub unsafe extern "C" fn screen_write_fullredraw(ctx: *mut screen_write_ctx) {
 }
 
 /// Trim collected items.
-pub unsafe extern "C" fn screen_write_collect_trim(
+pub unsafe fn screen_write_collect_trim(
     ctx: *mut screen_write_ctx,
     y: u32,
     x: u32,
@@ -1983,7 +1983,7 @@ pub unsafe extern "C" fn screen_write_collect_trim(
 }
 
 /// Clear collected lines.
-pub unsafe extern "C" fn screen_write_collect_clear(ctx: *mut screen_write_ctx, y: u32, n: u32) {
+pub unsafe fn screen_write_collect_clear(ctx: *mut screen_write_ctx, y: u32, n: u32) {
     unsafe {
         for i in y..(y + n) {
             let cl = (*(*ctx).s).write_list.add(i as usize);
@@ -1993,7 +1993,7 @@ pub unsafe extern "C" fn screen_write_collect_clear(ctx: *mut screen_write_ctx, 
 }
 
 /// Scroll collected lines up.
-pub unsafe extern "C" fn screen_write_collect_scroll(ctx: *mut screen_write_ctx, bg: u32) {
+pub unsafe fn screen_write_collect_scroll(ctx: *mut screen_write_ctx, bg: u32) {
     unsafe {
         let s = (*ctx).s;
         // log_debug("%s: at %u,%u (region %u-%u)", __func__, (*s).cx, (*s).cy, (*s).rupper, (*s).rlower);
@@ -2023,7 +2023,7 @@ pub unsafe extern "C" fn screen_write_collect_scroll(ctx: *mut screen_write_ctx,
 }
 
 /// Flush collected lines.
-pub unsafe extern "C" fn screen_write_collect_flush(
+pub unsafe fn screen_write_collect_flush(
     ctx: *mut screen_write_ctx,
     scroll_only: u32,
     from: *const c_char,
@@ -2092,7 +2092,7 @@ pub unsafe extern "C" fn screen_write_collect_flush(
 }
 
 /// Finish and store collected cells.
-pub unsafe extern "C" fn screen_write_collect_end(ctx: *mut screen_write_ctx) {
+pub unsafe fn screen_write_collect_end(ctx: *mut screen_write_ctx) {
     unsafe {
         let s = (*ctx).s;
         let ci = (*ctx).item;
@@ -2159,7 +2159,7 @@ pub unsafe extern "C" fn screen_write_collect_end(ctx: *mut screen_write_ctx) {
 }
 
 /// Write cell data, collecting if necessary.
-pub unsafe extern "C" fn screen_write_collect_add(
+pub unsafe fn screen_write_collect_add(
     ctx: *mut screen_write_ctx,
     gc: *const grid_cell,
 ) {
@@ -2216,7 +2216,7 @@ pub unsafe extern "C" fn screen_write_collect_add(
 }
 
 /// Write cell data.
-pub unsafe extern "C" fn screen_write_cell(ctx: *mut screen_write_ctx, gc: *const grid_cell) {
+pub unsafe fn screen_write_cell(ctx: *mut screen_write_ctx, gc: *const grid_cell) {
     unsafe {
         let s = (*ctx).s;
         let gd = (*s).grid;
@@ -2366,7 +2366,7 @@ pub unsafe extern "C" fn screen_write_cell(ctx: *mut screen_write_ctx, gc: *cons
 }
 
 /// Combine a UTF-8 zero-width character onto the previous if necessary.
-pub unsafe extern "C" fn screen_write_combine(
+pub unsafe fn screen_write_combine(
     ctx: *mut screen_write_ctx,
     gc: *const grid_cell,
 ) -> i32 {
@@ -2490,7 +2490,7 @@ pub unsafe extern "C" fn screen_write_combine(
  * by the same character.
  */
 
-pub unsafe extern "C" fn screen_write_overwrite(
+pub unsafe fn screen_write_overwrite(
     ctx: *mut screen_write_ctx,
     gc: *mut grid_cell,
     width: u32,
@@ -2553,7 +2553,7 @@ pub unsafe extern "C" fn screen_write_overwrite(
 }
 
 /// Set external clipboard.
-pub unsafe extern "C" fn screen_write_setselection(
+pub unsafe fn screen_write_setselection(
     ctx: *mut screen_write_ctx,
     flags: *const c_char,
     str: *mut u8,
@@ -2572,7 +2572,7 @@ pub unsafe extern "C" fn screen_write_setselection(
 }
 
 /// Write unmodified string.
-pub unsafe extern "C" fn screen_write_rawstring(
+pub unsafe fn screen_write_rawstring(
     ctx: *mut screen_write_ctx,
     str: *mut u8,
     len: u32,
@@ -2593,7 +2593,7 @@ pub unsafe extern "C" fn screen_write_rawstring(
 // TODO
 #[cfg(feature = "sixel")]
 /// Write a SIXEL image.
-unsafe extern "C" fn screen_write_sixelimage(
+unsafe fn screen_write_sixelimage(
     ctx: *mut screen_write_ctx,
     si: *mut sixel_image,
     bg: u32,
@@ -2664,7 +2664,7 @@ unsafe extern "C" fn screen_write_sixelimage(
 }
 
 /// Turn alternate screen on.
-pub unsafe extern "C" fn screen_write_alternateon(
+pub unsafe fn screen_write_alternateon(
     ctx: *mut screen_write_ctx,
     gc: *mut grid_cell,
     cursor: i32,
@@ -2688,7 +2688,7 @@ pub unsafe extern "C" fn screen_write_alternateon(
 }
 
 /// Turn alternate screen off.
-pub unsafe extern "C" fn screen_write_alternateoff(
+pub unsafe fn screen_write_alternateoff(
     ctx: *mut screen_write_ctx,
     gc: *mut grid_cell,
     cursor: i32,

--- a/src/screen_write.rs
+++ b/src/screen_write.rs
@@ -70,7 +70,7 @@ unsafe fn screen_write_free_citem(ci: *mut screen_write_citem) {
     }
 }
 
-unsafe fn screen_write_offset_timer(_fd: i32, _events: i16, data: *mut c_void) {
+unsafe extern "C" fn screen_write_offset_timer(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         tty_update_window_offset(data.cast());
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -51,7 +51,7 @@ pub static mut message_log: message_list = unsafe { zeroed() };
 
 pub static mut current_time: time_t = unsafe { zeroed() };
 
-pub unsafe extern "C" fn server_set_marked(
+pub unsafe fn server_set_marked(
     s: *mut session,
     wl: *mut winlink,
     wp: *mut window_pane,
@@ -65,13 +65,13 @@ pub unsafe extern "C" fn server_set_marked(
     }
 }
 
-pub unsafe extern "C" fn server_clear_marked() {
+pub unsafe fn server_clear_marked() {
     unsafe {
         cmd_find_clear_state(&raw mut marked_pane, 0);
     }
 }
 
-pub unsafe extern "C" fn server_is_marked(
+pub unsafe fn server_is_marked(
     s: *mut session,
     wl: *mut winlink,
     wp: *mut window_pane,
@@ -91,11 +91,11 @@ pub unsafe extern "C" fn server_is_marked(
     }
 }
 
-pub unsafe extern "C" fn server_check_marked() -> bool {
+pub unsafe fn server_check_marked() -> bool {
     unsafe { cmd_find_valid_state(&raw mut marked_pane) }
 }
 
-pub unsafe extern "C" fn server_create_socket(
+pub unsafe fn server_create_socket(
     flags: client_flag,
     cause: *mut *mut c_char,
 ) -> c_int {
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn server_create_socket(
 }
 
 /// Tidy up every hour.
-unsafe extern "C" fn server_tidy_event(_fd: i32, _events: i16, _data: *mut c_void) {
+unsafe fn server_tidy_event(_fd: i32, _events: i16, _data: *mut c_void) {
     let tv = timeval {
         tv_sec: 3600,
         tv_usec: 0,
@@ -179,7 +179,7 @@ unsafe extern "C" fn server_tidy_event(_fd: i32, _events: i16, _data: *mut c_voi
     }
 }
 
-pub unsafe extern "C" fn server_start(
+pub unsafe fn server_start(
     client: *mut tmuxproc,
     flags: client_flag,
     base: *mut event_base,
@@ -293,7 +293,7 @@ pub unsafe extern "C" fn server_start(
     }
 }
 
-pub unsafe extern "C" fn server_loop() -> i32 {
+pub unsafe fn server_loop() -> i32 {
     unsafe {
         current_time = libc::time(null_mut());
 
@@ -345,7 +345,7 @@ pub unsafe extern "C" fn server_loop() -> i32 {
     }
 }
 
-unsafe extern "C" fn server_send_exit() {
+unsafe fn server_send_exit() {
     unsafe {
         cmd_wait_for_flush();
 
@@ -365,7 +365,7 @@ unsafe extern "C" fn server_send_exit() {
     }
 }
 
-pub unsafe extern "C" fn server_update_socket() {
+pub unsafe fn server_update_socket() {
     static mut last: c_int = -1;
     unsafe {
         let mut sb: stat = zeroed(); // TODO remove unecessary init
@@ -403,7 +403,7 @@ pub unsafe extern "C" fn server_update_socket() {
     }
 }
 
-unsafe extern "C" fn server_accept(fd: i32, events: i16, _data: *mut c_void) {
+unsafe fn server_accept(fd: i32, events: i16, _data: *mut c_void) {
     unsafe {
         let mut sa: sockaddr_storage = zeroed(); // TODO remove this init
         let mut slen: socklen_t = size_of::<sockaddr_storage>() as socklen_t;
@@ -440,7 +440,7 @@ unsafe extern "C" fn server_accept(fd: i32, events: i16, _data: *mut c_void) {
     }
 }
 
-pub unsafe extern "C" fn server_add_accept(timeout: c_int) {
+pub unsafe fn server_add_accept(timeout: c_int) {
     unsafe {
         let mut tv = timeval {
             tv_sec: timeout as i64,
@@ -479,7 +479,7 @@ pub unsafe extern "C" fn server_add_accept(timeout: c_int) {
 
 // Signal handler.
 
-unsafe extern "C" fn server_signal(sig: i32) {
+unsafe fn server_signal(sig: i32) {
     unsafe {
         log_debug!("{}: {}", "server_signal", _s(strsignal(sig)));
         match sig {
@@ -508,7 +508,7 @@ unsafe extern "C" fn server_signal(sig: i32) {
 
 // handle SIGCHLD
 
-unsafe extern "C" fn server_child_signal() {
+unsafe fn server_child_signal() {
     let mut status = 0i32;
     unsafe {
         loop {
@@ -537,7 +537,7 @@ unsafe extern "C" fn server_child_signal() {
     }
 }
 
-unsafe extern "C" fn server_child_exited(pid: pid_t, status: i32) {
+unsafe fn server_child_exited(pid: pid_t, status: i32) {
     unsafe {
         for w in rb_foreach(&raw mut windows).map(NonNull::as_ptr) {
             for wp in tailq_foreach::<_, discr_entry>(&raw mut (*w).panes).map(NonNull::as_ptr) {
@@ -559,7 +559,7 @@ unsafe extern "C" fn server_child_exited(pid: pid_t, status: i32) {
     }
 }
 
-unsafe extern "C" fn server_child_stopped(pid: pid_t, status: i32) {
+unsafe fn server_child_stopped(pid: pid_t, status: i32) {
     unsafe {
         if WSTOPSIG(status) == SIGTTIN || WSTOPSIG(status) == SIGTTOU {
             return;

--- a/src/server.rs
+++ b/src/server.rs
@@ -158,7 +158,7 @@ pub unsafe fn server_create_socket(
 }
 
 /// Tidy up every hour.
-unsafe fn server_tidy_event(_fd: i32, _events: i16, _data: *mut c_void) {
+unsafe extern "C" fn server_tidy_event(_fd: i32, _events: i16, _data: *mut c_void) {
     let tv = timeval {
         tv_sec: 3600,
         tv_usec: 0,
@@ -403,7 +403,7 @@ pub unsafe fn server_update_socket() {
     }
 }
 
-unsafe fn server_accept(fd: i32, events: i16, _data: *mut c_void) {
+unsafe extern "C" fn server_accept(fd: i32, events: i16, _data: *mut c_void) {
     unsafe {
         let mut sa: sockaddr_storage = zeroed(); // TODO remove this init
         let mut slen: socklen_t = size_of::<sockaddr_storage>() as socklen_t;

--- a/src/server_acl.rs
+++ b/src/server_acl.rs
@@ -40,7 +40,7 @@ pub struct server_acl_user {
     pub entry: rb_entry<server_acl_user>,
 }
 
-pub unsafe extern "C" fn server_acl_cmp(
+pub unsafe fn server_acl_cmp(
     user1: *const server_acl_user,
     user2: *const server_acl_user,
 ) -> Ordering {
@@ -58,7 +58,7 @@ RB_GENERATE!(
     server_acl_cmp
 );
 
-pub unsafe extern "C" fn server_acl_init() {
+pub unsafe fn server_acl_init() {
     unsafe {
         rb_init(&raw mut server_acl_entries);
 
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn server_acl_init() {
     }
 }
 
-pub unsafe extern "C" fn server_acl_user_find(uid: uid_t) -> *mut server_acl_user {
+pub unsafe fn server_acl_user_find(uid: uid_t) -> *mut server_acl_user {
     unsafe {
         let mut find: server_acl_user = server_acl_user { uid, ..zeroed() };
 
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn server_acl_user_find(uid: uid_t) -> *mut server_acl_use
     }
 }
 
-pub unsafe extern "C" fn server_acl_display(item: *mut cmdq_item) {
+pub unsafe fn server_acl_display(item: *mut cmdq_item) {
     unsafe {
         // server_acl_entries
         for loop_ in rb_foreach(&raw mut server_acl_entries).map(NonNull::as_ptr) {
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn server_acl_display(item: *mut cmdq_item) {
     }
 }
 
-pub unsafe extern "C" fn server_acl_user_allow(uid: uid_t) {
+pub unsafe fn server_acl_user_allow(uid: uid_t) {
     unsafe {
         let mut user = server_acl_user_find(uid);
         if user.is_null() {
@@ -111,7 +111,7 @@ pub unsafe extern "C" fn server_acl_user_allow(uid: uid_t) {
     }
 }
 
-pub unsafe extern "C" fn server_acl_user_deny(uid: uid_t) {
+pub unsafe fn server_acl_user_deny(uid: uid_t) {
     unsafe {
         let user = server_acl_user_find(uid);
         if !user.is_null() {
@@ -122,7 +122,7 @@ pub unsafe extern "C" fn server_acl_user_deny(uid: uid_t) {
     }
 }
 
-pub unsafe extern "C" fn server_acl_user_allow_write(mut uid: uid_t) {
+pub unsafe fn server_acl_user_allow_write(mut uid: uid_t) {
     unsafe {
         let user = server_acl_user_find(uid);
         if user.is_null() {
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn server_acl_user_allow_write(mut uid: uid_t) {
     }
 }
 
-pub unsafe extern "C" fn server_acl_user_deny_write(mut uid: uid_t) {
+pub unsafe fn server_acl_user_deny_write(mut uid: uid_t) {
     unsafe {
         unsafe {
             let user = server_acl_user_find(uid);
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn server_acl_user_deny_write(mut uid: uid_t) {
     }
 }
 
-pub unsafe extern "C" fn server_acl_join(c: *mut client) -> c_int {
+pub unsafe fn server_acl_join(c: *mut client) -> c_int {
     unsafe {
         let uid = proc_get_peer_uid((*c).peer);
         if uid == -1i32 as uid_t {
@@ -179,6 +179,6 @@ pub unsafe extern "C" fn server_acl_join(c: *mut client) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn server_acl_get_uid(user: *mut server_acl_user) -> uid_t {
+pub unsafe fn server_acl_get_uid(user: *mut server_acl_user) -> uid_t {
     unsafe { (*user).uid }
 }

--- a/src/server_client.rs
+++ b/src/server_client.rs
@@ -44,7 +44,7 @@ pub unsafe fn server_client_how_many() -> u32 {
 }
 
 /// Overlay timer callback.
-pub unsafe fn server_client_overlay_timer(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe extern "C" fn server_client_overlay_timer(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         server_client_clear_overlay(data.cast());
     }
@@ -513,7 +513,7 @@ pub unsafe fn server_client_unref(c: *mut client) {
 }
 
 /// Free dead client.
-pub unsafe fn server_client_free(_fd: i32, _events: i16, arg: *mut c_void) {
+pub unsafe extern "C" fn server_client_free(_fd: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let c: *mut client = arg.cast();
         log_debug!("free client {:p} ({} references)", c, (*c).references);
@@ -2210,7 +2210,7 @@ pub unsafe fn server_client_check_window_resize(w: *mut window) {
 }
 
 /// Resize timer event.
-pub unsafe fn server_client_resize_timer(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe extern "C" fn server_client_resize_timer(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let wp: *mut window_pane = data.cast();
 
@@ -2551,7 +2551,7 @@ pub unsafe fn server_client_reset_state(c: *mut client) {
 }
 
 /// Repeat time callback.
-pub unsafe fn server_client_repeat_timer(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe extern "C" fn server_client_repeat_timer(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let c: *mut client = data.cast();
 
@@ -2564,7 +2564,7 @@ pub unsafe fn server_client_repeat_timer(_fd: i32, _events: i16, data: *mut c_vo
 }
 
 /// Double-click callback.
-pub unsafe fn server_client_click_timer(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe extern "C" fn server_client_click_timer(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let c: *mut client = data.cast();
         log_debug!("click timer expired");
@@ -2649,7 +2649,7 @@ pub unsafe fn server_client_check_exit(c: *mut client) {
 }
 
 /// Redraw timer callback.
-pub unsafe fn server_client_redraw_timer(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe extern "C" fn server_client_redraw_timer(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         log_debug!("redraw timer fired");
     }

--- a/src/server_client.rs
+++ b/src/server_client.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 /// Compare client windows.
-pub unsafe extern "C" fn server_client_window_cmp(
+pub unsafe fn server_client_window_cmp(
     cw1: *const client_window,
     cw2: *const client_window,
 ) -> std::cmp::Ordering {
@@ -32,7 +32,7 @@ pub unsafe extern "C" fn server_client_window_cmp(
 }
 
 /// Number of attached clients.
-pub unsafe extern "C" fn server_client_how_many() -> u32 {
+pub unsafe fn server_client_how_many() -> u32 {
     unsafe {
         tailq_foreach(&raw mut clients)
             .filter(|c| {
@@ -44,14 +44,14 @@ pub unsafe extern "C" fn server_client_how_many() -> u32 {
 }
 
 /// Overlay timer callback.
-pub unsafe extern "C" fn server_client_overlay_timer(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe fn server_client_overlay_timer(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         server_client_clear_overlay(data.cast());
     }
 }
 
 /// Set an overlay on client.
-pub unsafe extern "C" fn server_client_set_overlay(
+pub unsafe fn server_client_set_overlay(
     c: *mut client,
     delay: u32,
     checkcb: overlay_check_cb,
@@ -103,7 +103,7 @@ pub unsafe extern "C" fn server_client_set_overlay(
 }
 
 /// Clear overlay mode on client.
-pub unsafe extern "C" fn server_client_clear_overlay(c: *mut client) {
+pub unsafe fn server_client_clear_overlay(c: *mut client) {
     unsafe {
         if (*c).overlay_draw.is_none() {
             return;
@@ -130,7 +130,7 @@ pub unsafe extern "C" fn server_client_clear_overlay(c: *mut client) {
 }
 
 /// Given overlay position and dimensions, return parts of the input range which are visible.
-pub unsafe extern "C" fn server_client_overlay_range(
+pub unsafe fn server_client_overlay_range(
     x: u32,
     y: u32,
     sx: u32,
@@ -183,7 +183,7 @@ pub unsafe extern "C" fn server_client_overlay_range(
 }
 
 /// Check if this client is inside this server.
-pub unsafe extern "C" fn server_client_check_nested(c: *mut client) -> i32 {
+pub unsafe fn server_client_check_nested(c: *mut client) -> i32 {
     unsafe {
         let envent = environ_find((*c).environ, c"TMUX".as_ptr());
         if envent.is_null() || *transmute_ptr((*envent).value) == b'\0' as i8 {
@@ -200,7 +200,7 @@ pub unsafe extern "C" fn server_client_check_nested(c: *mut client) -> i32 {
 }
 
 /// Set client key table.
-pub unsafe extern "C" fn server_client_set_key_table(c: *mut client, mut name: *const c_char) {
+pub unsafe fn server_client_set_key_table(c: *mut client, mut name: *const c_char) {
     unsafe {
         if name.is_null() {
             name = server_client_get_key_table(c);
@@ -215,7 +215,7 @@ pub unsafe extern "C" fn server_client_set_key_table(c: *mut client, mut name: *
     }
 }
 
-pub unsafe extern "C" fn server_client_key_table_activity_diff(c: *mut client) -> u64 {
+pub unsafe fn server_client_key_table_activity_diff(c: *mut client) -> u64 {
     unsafe {
         let mut diff: libc::timeval = zeroed();
         timersub(
@@ -228,7 +228,7 @@ pub unsafe extern "C" fn server_client_key_table_activity_diff(c: *mut client) -
 }
 
 /// Get default key table.
-pub unsafe extern "C" fn server_client_get_key_table(c: *mut client) -> *const c_char {
+pub unsafe fn server_client_get_key_table(c: *mut client) -> *const c_char {
     unsafe {
         let s = (*c).session;
         if s.is_null() {
@@ -244,7 +244,7 @@ pub unsafe extern "C" fn server_client_get_key_table(c: *mut client) -> *const c
 }
 
 /// Is this table the default key table?
-pub unsafe extern "C" fn server_client_is_default_key_table(
+pub unsafe fn server_client_is_default_key_table(
     c: *mut client,
     table: *mut key_table,
 ) -> i32 {
@@ -252,7 +252,7 @@ pub unsafe extern "C" fn server_client_is_default_key_table(
 }
 
 /// Create a new client.
-pub unsafe extern "C" fn server_client_create(fd: i32) -> *mut client {
+pub unsafe fn server_client_create(fd: i32) -> *mut client {
     unsafe {
         setblocking(fd, 0);
 
@@ -301,7 +301,7 @@ pub unsafe extern "C" fn server_client_create(fd: i32) -> *mut client {
 }
 
 /// Open client terminal if needed.
-pub unsafe extern "C" fn server_client_open(c: *mut client, cause: *mut *mut c_char) -> i32 {
+pub unsafe fn server_client_open(c: *mut client, cause: *mut *mut c_char) -> i32 {
     unsafe {
         let mut ttynam = _PATH_TTY;
 
@@ -347,7 +347,7 @@ pub unsafe extern "C" fn server_client_open(c: *mut client, cause: *mut *mut c_c
 }
 
 /// Lost an attached client.
-pub unsafe extern "C" fn server_client_attached_lost(c: *mut client) {
+pub unsafe fn server_client_attached_lost(c: *mut client) {
     unsafe {
         log_debug!("lost attached client {:p}", c);
 
@@ -379,7 +379,7 @@ pub unsafe extern "C" fn server_client_attached_lost(c: *mut client) {
 }
 
 /// Set client session.
-pub unsafe extern "C" fn server_client_set_session(c: *mut client, s: *mut session) {
+pub unsafe fn server_client_set_session(c: *mut client, s: *mut session) {
     unsafe {
         let old = (*c).session;
 
@@ -414,7 +414,7 @@ pub unsafe extern "C" fn server_client_set_session(c: *mut client, s: *mut sessi
 }
 
 /// Lost a client.
-pub unsafe extern "C" fn server_client_lost(c: *mut client) {
+pub unsafe fn server_client_lost(c: *mut client) {
     unsafe {
         (*c).flags |= client_flag::DEAD;
 
@@ -495,7 +495,7 @@ pub unsafe extern "C" fn server_client_lost(c: *mut client) {
 }
 
 /// Remove reference from a client.
-pub unsafe extern "C" fn server_client_unref(c: *mut client) {
+pub unsafe fn server_client_unref(c: *mut client) {
     unsafe {
         log_debug!("unref client {:p} ({} references)", c, (*c).references);
 
@@ -513,7 +513,7 @@ pub unsafe extern "C" fn server_client_unref(c: *mut client) {
 }
 
 /// Free dead client.
-pub unsafe extern "C" fn server_client_free(_fd: i32, _events: i16, arg: *mut c_void) {
+pub unsafe fn server_client_free(_fd: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let c: *mut client = arg.cast();
         log_debug!("free client {:p} ({} references)", c, (*c).references);
@@ -528,7 +528,7 @@ pub unsafe extern "C" fn server_client_free(_fd: i32, _events: i16, arg: *mut c_
 }
 
 /// Suspend a client.
-pub unsafe extern "C" fn server_client_suspend(c: *mut client) {
+pub unsafe fn server_client_suspend(c: *mut client) {
     unsafe {
         let s: *mut session = (*c).session;
 
@@ -543,7 +543,7 @@ pub unsafe extern "C" fn server_client_suspend(c: *mut client) {
 }
 
 /// Detach a client.
-pub unsafe extern "C" fn server_client_detach(c: *mut client, msgtype: msgtype) {
+pub unsafe fn server_client_detach(c: *mut client, msgtype: msgtype) {
     unsafe {
         let s = (*c).session;
 
@@ -560,7 +560,7 @@ pub unsafe extern "C" fn server_client_detach(c: *mut client, msgtype: msgtype) 
 }
 
 /// Execute command to replace a client.
-pub unsafe extern "C" fn server_client_exec(c: *mut client, cmd: *const c_char) {
+pub unsafe fn server_client_exec(c: *mut client, cmd: *const c_char) {
     unsafe {
         let s = (*c).session;
         if *cmd == b'\0' as i8 {
@@ -594,7 +594,7 @@ pub unsafe extern "C" fn server_client_exec(c: *mut client, cmd: *const c_char) 
 }
 
 /// Check for mouse keys.
-pub unsafe extern "C" fn server_client_check_mouse(
+pub unsafe fn server_client_check_mouse(
     c: *mut client,
     event: *mut key_event,
 ) -> key_code {
@@ -1731,7 +1731,7 @@ pub unsafe extern "C" fn server_client_check_mouse(
 }
 
 /// Is this a bracket paste key?
-pub unsafe extern "C" fn server_client_is_bracket_pasting(c: *mut client, key: key_code) -> i32 {
+pub unsafe fn server_client_is_bracket_pasting(c: *mut client, key: key_code) -> i32 {
     unsafe {
         if key == keyc::KEYC_PASTE_START as u64 {
             (*c).flags |= client_flag::BRACKETPASTING;
@@ -1750,7 +1750,7 @@ pub unsafe extern "C" fn server_client_is_bracket_pasting(c: *mut client, key: k
 }
 
 /// Is this fast enough to probably be a paste?
-pub unsafe extern "C" fn server_client_assume_paste(s: *mut session) -> i32 {
+pub unsafe fn server_client_assume_paste(s: *mut session) -> i32 {
     unsafe {
         let mut tv: timeval = zeroed();
         let t: i32 = options_get_number_((*s).options, c"assume-paste-time") as i32;
@@ -1784,7 +1784,7 @@ pub unsafe extern "C" fn server_client_assume_paste(s: *mut session) -> i32 {
 }
 
 /// Has the latest client changed?
-pub unsafe extern "C" fn server_client_update_latest(c: *mut client) {
+pub unsafe fn server_client_update_latest(c: *mut client) {
     unsafe {
         if (*c).session.is_null() {
             return;
@@ -1807,7 +1807,7 @@ pub unsafe extern "C" fn server_client_update_latest(c: *mut client) {
 }
 
 /// Handle data key input from client. This owns and can modify the key event it is given and is responsible for freeing it.
-pub unsafe extern "C" fn server_client_key_callback(
+pub unsafe fn server_client_key_callback(
     item: *mut cmdq_item,
     data: *mut c_void,
 ) -> cmd_retval {
@@ -2100,7 +2100,7 @@ pub unsafe extern "C" fn server_client_key_callback(
 }
 
 /// Handle a key event.
-pub unsafe extern "C" fn server_client_handle_key(c: *mut client, event: *mut key_event) -> i32 {
+pub unsafe fn server_client_handle_key(c: *mut client, event: *mut key_event) -> i32 {
     unsafe {
         let s = (*c).session;
 
@@ -2145,7 +2145,7 @@ pub unsafe extern "C" fn server_client_handle_key(c: *mut client, event: *mut ke
 }
 
 /// Client functions that need to happen every loop.
-pub unsafe extern "C" fn server_client_loop() {
+pub unsafe fn server_client_loop() {
     unsafe {
         // Check for window resize. This is done before redrawing.
         for w in rb_foreach(&raw mut windows).map(NonNull::as_ptr) {
@@ -2177,7 +2177,7 @@ pub unsafe extern "C" fn server_client_loop() {
 }
 
 /// Check if window needs to be resized.
-pub unsafe extern "C" fn server_client_check_window_resize(w: *mut window) {
+pub unsafe fn server_client_check_window_resize(w: *mut window) {
     unsafe {
         if !(*w).flags.intersects(window_flag::RESIZE) {
             return;
@@ -2210,7 +2210,7 @@ pub unsafe extern "C" fn server_client_check_window_resize(w: *mut window) {
 }
 
 /// Resize timer event.
-pub unsafe extern "C" fn server_client_resize_timer(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe fn server_client_resize_timer(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let wp: *mut window_pane = data.cast();
 
@@ -2224,7 +2224,7 @@ pub unsafe extern "C" fn server_client_resize_timer(_fd: i32, _events: i16, data
 }
 
 /// Check if pane should be resized.
-pub unsafe extern "C" fn server_client_check_pane_resize(wp: *mut window_pane) {
+pub unsafe fn server_client_check_pane_resize(wp: *mut window_pane) {
     unsafe {
         let mut tv: libc::timeval = libc::timeval {
             tv_sec: 0,
@@ -2312,7 +2312,7 @@ pub unsafe extern "C" fn server_client_check_pane_resize(wp: *mut window_pane) {
 }
 
 /// Check pane buffer size.
-pub unsafe extern "C" fn server_client_check_pane_buffer(wp: *mut window_pane) {
+pub unsafe fn server_client_check_pane_buffer(wp: *mut window_pane) {
     unsafe {
         let evb = (*(*wp).event).input;
         let mut minimum: usize = 0;
@@ -2424,7 +2424,7 @@ pub unsafe extern "C" fn server_client_check_pane_buffer(wp: *mut window_pane) {
 ///
 /// tty_region/tty_reset/tty_update_mode already take care of not resetting
 /// things that are already in their default state.
-pub unsafe extern "C" fn server_client_reset_state(c: *mut client) {
+pub unsafe fn server_client_reset_state(c: *mut client) {
     unsafe {
         let tty = &raw mut (*c).tty;
         let w = (*(*(*c).session).curw).window;
@@ -2551,7 +2551,7 @@ pub unsafe extern "C" fn server_client_reset_state(c: *mut client) {
 }
 
 /// Repeat time callback.
-pub unsafe extern "C" fn server_client_repeat_timer(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe fn server_client_repeat_timer(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let c: *mut client = data.cast();
 
@@ -2564,7 +2564,7 @@ pub unsafe extern "C" fn server_client_repeat_timer(_fd: i32, _events: i16, data
 }
 
 /// Double-click callback.
-pub unsafe extern "C" fn server_client_click_timer(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe fn server_client_click_timer(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let c: *mut client = data.cast();
         log_debug!("click timer expired");
@@ -2583,7 +2583,7 @@ pub unsafe extern "C" fn server_client_click_timer(_fd: i32, _events: i16, data:
 }
 
 /// Check if client should be exited.
-pub unsafe extern "C" fn server_client_check_exit(c: *mut client) {
+pub unsafe fn server_client_check_exit(c: *mut client) {
     unsafe {
         let name = (*c).exit_session;
 
@@ -2649,7 +2649,7 @@ pub unsafe extern "C" fn server_client_check_exit(c: *mut client) {
 }
 
 /// Redraw timer callback.
-pub unsafe extern "C" fn server_client_redraw_timer(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe fn server_client_redraw_timer(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         log_debug!("redraw timer fired");
     }
@@ -2659,7 +2659,7 @@ pub unsafe extern "C" fn server_client_redraw_timer(_fd: i32, _events: i16, data
  * Check if modes need to be updated. Only modes in the current window are
  * updated and it is done when the status line is redrawn.
  */
-pub unsafe extern "C" fn server_client_check_modes(c: *mut client) {
+pub unsafe fn server_client_check_modes(c: *mut client) {
     unsafe {
         let w = (*(*(*c).session).curw).window;
 
@@ -2683,7 +2683,7 @@ pub unsafe extern "C" fn server_client_check_modes(c: *mut client) {
 }
 
 /// Check for client redraws.
-pub unsafe extern "C" fn server_client_check_redraw(c: *mut client) {
+pub unsafe fn server_client_check_redraw(c: *mut client) {
     static mut ev: event = unsafe { zeroed() };
     unsafe {
         let s = (*c).session;
@@ -2835,7 +2835,7 @@ pub unsafe extern "C" fn server_client_check_redraw(c: *mut client) {
 }
 
 /// Set client title.
-pub unsafe extern "C" fn server_client_set_title(c: *mut client) {
+pub unsafe fn server_client_set_title(c: *mut client) {
     unsafe {
         let s = (*c).session;
 
@@ -2857,7 +2857,7 @@ pub unsafe extern "C" fn server_client_set_title(c: *mut client) {
 }
 
 /// Set client path.
-pub unsafe extern "C" fn server_client_set_path(c: *mut client) {
+pub unsafe fn server_client_set_path(c: *mut client) {
     unsafe {
         let s = (*c).session;
 
@@ -2878,7 +2878,7 @@ pub unsafe extern "C" fn server_client_set_path(c: *mut client) {
 }
 
 /// Dispatch message from client.
-pub unsafe extern "C" fn server_client_dispatch(imsg: *mut imsg, arg: *mut c_void) {
+pub unsafe fn server_client_dispatch(imsg: *mut imsg, arg: *mut c_void) {
     unsafe {
         let c: *mut client = arg.cast();
 
@@ -2980,7 +2980,7 @@ pub unsafe extern "C" fn server_client_dispatch(imsg: *mut imsg, arg: *mut c_voi
 }
 
 /// Callback when command is not allowed.
-pub unsafe extern "C" fn server_client_read_only(
+pub unsafe fn server_client_read_only(
     item: *mut cmdq_item,
     _data: *mut c_void,
 ) -> cmd_retval {
@@ -2991,7 +2991,7 @@ pub unsafe extern "C" fn server_client_read_only(
 }
 
 /// Callback when command is done.
-pub unsafe extern "C" fn server_client_command_done(
+pub unsafe fn server_client_command_done(
     item: *mut cmdq_item,
     _data: *mut c_void,
 ) -> cmd_retval {
@@ -3011,7 +3011,7 @@ pub unsafe extern "C" fn server_client_command_done(
 }
 
 /// Handle command message.
-pub unsafe extern "C" fn server_client_dispatch_command(c: *mut client, imsg: *mut imsg) {
+pub unsafe fn server_client_dispatch_command(c: *mut client, imsg: *mut imsg) {
     unsafe {
         let mut data: msg_command = zeroed();
         let mut buf = null_mut();
@@ -3089,7 +3089,7 @@ pub unsafe extern "C" fn server_client_dispatch_command(c: *mut client, imsg: *m
 }
 
 /// Handle identify message.
-pub unsafe extern "C" fn server_client_dispatch_identify(c: *mut client, imsg: *mut imsg) {
+pub unsafe fn server_client_dispatch_identify(c: *mut client, imsg: *mut imsg) {
     unsafe {
         let mut feat: i32 = 0;
         let mut flags: i32 = 0;
@@ -3258,7 +3258,7 @@ pub unsafe extern "C" fn server_client_dispatch_identify(c: *mut client, imsg: *
 }
 
 /// Handle shell message.
-pub unsafe extern "C" fn server_client_dispatch_shell(c: *mut client) {
+pub unsafe fn server_client_dispatch_shell(c: *mut client) {
     unsafe {
         let mut shell = options_get_string_(global_s_options, c"default-shell");
         if !checkshell(shell) {
@@ -3277,7 +3277,7 @@ pub unsafe extern "C" fn server_client_dispatch_shell(c: *mut client) {
 }
 
 /// Get client working directory.
-pub unsafe extern "C" fn server_client_get_cwd(
+pub unsafe fn server_client_get_cwd(
     c: *mut client,
     mut s: *mut session,
 ) -> *const c_char {
@@ -3305,7 +3305,7 @@ pub unsafe extern "C" fn server_client_get_cwd(
 }
 
 /// Get control client flags.
-pub unsafe extern "C" fn server_client_control_flags(
+pub unsafe fn server_client_control_flags(
     c: *mut client,
     next: *const c_char,
 ) -> client_flag {
@@ -3327,7 +3327,7 @@ pub unsafe extern "C" fn server_client_control_flags(
 }
 
 /// Set client flags.
-pub unsafe extern "C" fn server_client_set_flags(c: *mut client, flags: *const c_char) {
+pub unsafe fn server_client_set_flags(c: *mut client, flags: *const c_char) {
     unsafe {
         let mut next = null_mut();
         let mut flag: client_flag = client_flag::empty();
@@ -3385,7 +3385,7 @@ pub unsafe extern "C" fn server_client_set_flags(c: *mut client, flags: *const c
 }
 
 /// Get client flags. This is only flags useful to show to users.
-pub unsafe extern "C" fn server_client_get_flags(c: *mut client) -> *const c_char {
+pub unsafe fn server_client_get_flags(c: *mut client) -> *const c_char {
     unsafe {
         const sizeof_s: usize = 256;
         const sizeof_tmp: usize = 32;
@@ -3440,7 +3440,7 @@ pub unsafe extern "C" fn server_client_get_flags(c: *mut client) -> *const c_cha
 }
 
 /// Get client window.
-pub unsafe extern "C" fn server_client_get_client_window(
+pub unsafe fn server_client_get_client_window(
     c: *mut client,
     id: u32,
 ) -> *mut client_window {
@@ -3455,7 +3455,7 @@ pub unsafe extern "C" fn server_client_get_client_window(
 }
 
 /// Add client window.
-pub unsafe extern "C" fn server_client_add_client_window(
+pub unsafe fn server_client_add_client_window(
     c: *mut client,
     id: u32,
 ) -> NonNull<client_window> {
@@ -3472,7 +3472,7 @@ pub unsafe extern "C" fn server_client_add_client_window(
 }
 
 /// Get client active pane.
-pub unsafe extern "C" fn server_client_get_pane(c: *mut client) -> *mut window_pane {
+pub unsafe fn server_client_get_pane(c: *mut client) -> *mut window_pane {
     unsafe {
         let s = (*c).session;
 
@@ -3492,7 +3492,7 @@ pub unsafe extern "C" fn server_client_get_pane(c: *mut client) -> *mut window_p
 }
 
 // Set client active pane.
-pub unsafe extern "C" fn server_client_set_pane(c: *mut client, wp: *mut window_pane) {
+pub unsafe fn server_client_set_pane(c: *mut client, wp: *mut window_pane) {
     unsafe {
         let s = (*c).session;
 
@@ -3507,7 +3507,7 @@ pub unsafe extern "C" fn server_client_set_pane(c: *mut client, wp: *mut window_
 }
 
 /// Remove pane from client lists.
-pub unsafe extern "C" fn server_client_remove_pane(wp: *mut window_pane) {
+pub unsafe fn server_client_remove_pane(wp: *mut window_pane) {
     unsafe {
         let w = (*wp).window;
 
@@ -3522,7 +3522,7 @@ pub unsafe extern "C" fn server_client_remove_pane(wp: *mut window_pane) {
 }
 
 /// Print to a client.
-pub unsafe extern "C" fn server_client_print(c: *mut client, parse: i32, evb: *mut evbuffer) {
+pub unsafe fn server_client_print(c: *mut client, parse: i32, evb: *mut evbuffer) {
     unsafe {
         let data = EVBUFFER_DATA(evb);
         let mut size = EVBUFFER_LENGTH(evb);

--- a/src/server_fn.rs
+++ b/src/server_fn.rs
@@ -22,19 +22,19 @@ use crate::compat::{
     tree::rb_foreach,
 };
 
-pub unsafe extern "C" fn server_redraw_client(c: *mut client) {
+pub unsafe fn server_redraw_client(c: *mut client) {
     unsafe {
         (*c).flags |= CLIENT_ALLREDRAWFLAGS;
     }
 }
 
-pub unsafe extern "C" fn server_status_client(c: *mut client) {
+pub unsafe fn server_status_client(c: *mut client) {
     unsafe {
         (*c).flags |= client_flag::REDRAWSTATUS;
     }
 }
 
-pub unsafe extern "C" fn server_redraw_session(s: *mut session) {
+pub unsafe fn server_redraw_session(s: *mut session) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             if (*c).session == s {
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn server_redraw_session(s: *mut session) {
     }
 }
 
-pub unsafe extern "C" fn server_redraw_session_group(s: *mut session) {
+pub unsafe fn server_redraw_session_group(s: *mut session) {
     unsafe {
         let sg = session_group_contains(s);
         if sg.is_null() {
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn server_redraw_session_group(s: *mut session) {
     }
 }
 
-pub unsafe extern "C" fn server_status_session(s: *mut session) {
+pub unsafe fn server_status_session(s: *mut session) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             if (*c).session == s {
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn server_status_session(s: *mut session) {
     }
 }
 
-pub unsafe extern "C" fn server_status_session_group(s: *mut session) {
+pub unsafe fn server_status_session_group(s: *mut session) {
     unsafe {
         let sg = session_group_contains(s);
         if sg.is_null() {
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn server_status_session_group(s: *mut session) {
     }
 }
 
-pub unsafe extern "C" fn server_redraw_window(w: *mut window) {
+pub unsafe fn server_redraw_window(w: *mut window) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             if !(*c).session.is_null() && (*(*(*c).session).curw).window == w {
@@ -90,7 +90,7 @@ pub unsafe extern "C" fn server_redraw_window(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn server_redraw_window_borders(w: *mut window) {
+pub unsafe fn server_redraw_window_borders(w: *mut window) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             if !(*c).session.is_null() && (*(*(*c).session).curw).window == w {
@@ -100,7 +100,7 @@ pub unsafe extern "C" fn server_redraw_window_borders(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn server_status_window(w: *mut window) {
+pub unsafe fn server_status_window(w: *mut window) {
     unsafe {
         /*
          * This is slightly different. We want to redraw the status line of any
@@ -116,7 +116,7 @@ pub unsafe extern "C" fn server_status_window(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn server_lock() {
+pub unsafe fn server_lock() {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             if !(*c).session.is_null() {
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn server_lock() {
     }
 }
 
-pub unsafe extern "C" fn server_lock_session(s: *mut session) {
+pub unsafe fn server_lock_session(s: *mut session) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             if (*c).session == s {
@@ -136,7 +136,7 @@ pub unsafe extern "C" fn server_lock_session(s: *mut session) {
     }
 }
 
-pub unsafe extern "C" fn server_lock_client(c: *mut client) {
+pub unsafe fn server_lock_client(c: *mut client) {
     unsafe {
         if (*c).flags.intersects(client_flag::CONTROL) {
             return;
@@ -176,7 +176,7 @@ pub unsafe extern "C" fn server_lock_client(c: *mut client) {
     }
 }
 
-pub unsafe extern "C" fn server_kill_pane(wp: *mut window_pane) {
+pub unsafe fn server_kill_pane(wp: *mut window_pane) {
     unsafe {
         let w = (*wp).window;
 
@@ -193,7 +193,7 @@ pub unsafe extern "C" fn server_kill_pane(wp: *mut window_pane) {
     }
 }
 
-pub unsafe extern "C" fn server_kill_window(w: *mut window, renumber: i32) {
+pub unsafe fn server_kill_window(w: *mut window, renumber: i32) {
     unsafe {
         for s in rb_foreach(&raw mut sessions).map(NonNull::as_ptr) {
             if session_has(s, w) == 0 {
@@ -218,7 +218,7 @@ pub unsafe extern "C" fn server_kill_window(w: *mut window, renumber: i32) {
     }
 }
 
-pub unsafe extern "C" fn server_renumber_session(s: *mut session) {
+pub unsafe fn server_renumber_session(s: *mut session) {
     unsafe {
         if options_get_number_((*s).options, c"renumber-windows") != 0 {
             let sg = session_group_contains(s);
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn server_renumber_session(s: *mut session) {
     }
 }
 
-pub unsafe extern "C" fn server_renumber_all() {
+pub unsafe fn server_renumber_all() {
     unsafe {
         for s in rb_foreach(&raw mut sessions) {
             server_renumber_session(s.as_ptr());
@@ -241,7 +241,7 @@ pub unsafe extern "C" fn server_renumber_all() {
     }
 }
 
-pub unsafe extern "C" fn server_link_window(
+pub unsafe fn server_link_window(
     src: *mut session,
     srcwl: *mut winlink,
     dst: *mut session,
@@ -303,7 +303,7 @@ pub unsafe extern "C" fn server_link_window(
     }
 }
 
-pub unsafe extern "C" fn server_unlink_window(s: *mut session, wl: *mut winlink) {
+pub unsafe fn server_unlink_window(s: *mut session, wl: *mut winlink) {
     unsafe {
         if session_detach(s, wl) != 0 {
             server_destroy_session_group(s);
@@ -313,7 +313,7 @@ pub unsafe extern "C" fn server_unlink_window(s: *mut session, wl: *mut winlink)
     }
 }
 
-pub unsafe extern "C" fn server_destroy_pane(wp: *mut window_pane, notify: i32) {
+pub unsafe fn server_destroy_pane(wp: *mut window_pane, notify: i32) {
     unsafe {
         let w = (*wp).window;
         let mut ctx: MaybeUninit<screen_write_ctx> = MaybeUninit::<screen_write_ctx>::uninit();
@@ -401,7 +401,7 @@ pub unsafe extern "C" fn server_destroy_pane(wp: *mut window_pane, notify: i32) 
     }
 }
 
-pub unsafe extern "C" fn server_destroy_session_group(s: *mut session) {
+pub unsafe fn server_destroy_session_group(s: *mut session) {
     unsafe {
         let sg = session_group_contains(s);
         if sg.is_null() {
@@ -416,9 +416,9 @@ pub unsafe extern "C" fn server_destroy_session_group(s: *mut session) {
     }
 }
 
-pub unsafe extern "C" fn server_find_session(
+pub unsafe fn server_find_session(
     s: *mut session,
-    f: unsafe extern "C" fn(*mut session, *mut session) -> i32,
+    f: unsafe fn(*mut session, *mut session) -> i32,
 ) -> *mut session {
     unsafe {
         let mut s_out: *mut session = null_mut();
@@ -431,14 +431,14 @@ pub unsafe extern "C" fn server_find_session(
     }
 }
 
-pub unsafe extern "C" fn server_newer_session(s_loop: *mut session, s_out: *mut session) -> i32 {
+pub unsafe fn server_newer_session(s_loop: *mut session, s_out: *mut session) -> i32 {
     unsafe {
         (timer::new(&raw const (*s_loop).activity_time)
             > timer::new(&raw const (*s_out).activity_time)) as i32
     }
 }
 
-pub unsafe extern "C" fn server_newer_detached_session(
+pub unsafe fn server_newer_detached_session(
     s_loop: *mut session,
     s_out: *mut session,
 ) -> i32 {
@@ -450,7 +450,7 @@ pub unsafe extern "C" fn server_newer_detached_session(
     }
 }
 
-pub unsafe extern "C" fn server_destroy_session(s: *mut session) {
+pub unsafe fn server_destroy_session(s: *mut session) {
     unsafe {
         let detach_on_destroy = options_get_number_((*s).options, c"detach-on-destroy");
 
@@ -484,7 +484,7 @@ pub unsafe extern "C" fn server_destroy_session(s: *mut session) {
     }
 }
 
-pub unsafe extern "C" fn server_check_unattached() {
+pub unsafe fn server_check_unattached() {
     unsafe {
         for s in rb_foreach(&raw mut sessions).map(NonNull::as_ptr) {
             if (*s).attached != 0 {
@@ -514,7 +514,7 @@ pub unsafe extern "C" fn server_check_unattached() {
     }
 }
 
-pub unsafe extern "C" fn server_unzoom_window(w: *mut window) {
+pub unsafe fn server_unzoom_window(w: *mut window) {
     unsafe {
         if window_unzoom(w, 1) == 0 {
             server_redraw_window(w);

--- a/src/session_.rs
+++ b/src/session_.rs
@@ -196,7 +196,7 @@ pub unsafe fn session_remove_ref(s: *mut session, from: *const c_char) {
 }
 
 /// Free session.
-pub unsafe fn session_free(_fd: i32, _events: i16, arg: *mut c_void) {
+pub unsafe extern "C" fn session_free(_fd: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let s = arg as *mut session;
 
@@ -280,7 +280,7 @@ pub unsafe fn session_check_name(name: *const c_char) -> *mut c_char {
 }
 
 /// Lock session if it has timed out.
-pub unsafe fn session_lock_timer(fd: i32, events: i16, arg: *mut c_void) {
+pub unsafe extern "C" fn session_lock_timer(fd: i32, events: i16, arg: *mut c_void) {
     unsafe {
         let s = arg as *mut session;
 

--- a/src/session_.rs
+++ b/src/session_.rs
@@ -39,11 +39,11 @@ pub static mut next_session_id: u32 = 0;
 
 pub static mut session_groups: session_groups = rb_initializer();
 
-pub unsafe extern "C" fn session_cmp(s1: *const session, s2: *const session) -> Ordering {
+pub unsafe fn session_cmp(s1: *const session, s2: *const session) -> Ordering {
     unsafe { i32_to_ordering(libc::strcmp((*s1).name, (*s2).name)) }
 }
 
-pub unsafe extern "C" fn session_group_cmp(
+pub unsafe fn session_group_cmp(
     s1: *const session_group,
     s2: *const session_group,
 ) -> Ordering {
@@ -55,7 +55,7 @@ pub unsafe fn session_alive(s: *mut session) -> bool {
 }
 
 /// Find session by name.
-pub unsafe extern "C" fn session_find(name: *mut c_char) -> *mut session {
+pub unsafe fn session_find(name: *mut c_char) -> *mut session {
     let mut s = MaybeUninit::<session>::uninit();
     let s = s.as_mut_ptr();
 
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn session_find(name: *mut c_char) -> *mut session {
 }
 
 /// Find session by id parsed from a string.
-pub unsafe extern "C" fn session_find_by_id_str(s: *const c_char) -> *mut session {
+pub unsafe fn session_find_by_id_str(s: *const c_char) -> *mut session {
     unsafe {
         if *s != b'$' as c_char {
             return null_mut();
@@ -150,7 +150,7 @@ impl session {
 }
 
 /// Create a new session.
-pub unsafe extern "C" fn session_create(
+pub unsafe fn session_create(
     prefix: *const c_char,
     name: *const c_char,
     cwd: *const c_char,
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn session_create(
 }
 
 /// Add a reference to a session.
-pub unsafe extern "C" fn session_add_ref(s: *mut session, from: *const c_char) {
+pub unsafe fn session_add_ref(s: *mut session, from: *const c_char) {
     let __func__ = "session_add_ref";
     unsafe {
         (*s).references += 1;
@@ -177,7 +177,7 @@ pub unsafe extern "C" fn session_add_ref(s: *mut session, from: *const c_char) {
 }
 
 /// Remove a reference from a session.
-pub unsafe extern "C" fn session_remove_ref(s: *mut session, from: *const c_char) {
+pub unsafe fn session_remove_ref(s: *mut session, from: *const c_char) {
     let __func__ = "session_remove_ref";
     unsafe {
         (*s).references -= 1;
@@ -196,7 +196,7 @@ pub unsafe extern "C" fn session_remove_ref(s: *mut session, from: *const c_char
 }
 
 /// Free session.
-pub unsafe extern "C" fn session_free(_fd: i32, _events: i16, arg: *mut c_void) {
+pub unsafe fn session_free(_fd: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let s = arg as *mut session;
 
@@ -216,7 +216,7 @@ pub unsafe extern "C" fn session_free(_fd: i32, _events: i16, arg: *mut c_void) 
 }
 
 /// Destroy a session.
-pub unsafe extern "C" fn session_destroy(s: *mut session, notify: i32, from: *const c_char) {
+pub unsafe fn session_destroy(s: *mut session, notify: i32, from: *const c_char) {
     let __func__ = c"session_destroy".as_ptr();
     unsafe {
         log_debug!("session {} destroyed ({})", _s((*s).name), _s(from));
@@ -255,7 +255,7 @@ pub unsafe extern "C" fn session_destroy(s: *mut session, notify: i32, from: *co
 }
 
 /// Sanitize session name.
-pub unsafe extern "C" fn session_check_name(name: *const c_char) -> *mut c_char {
+pub unsafe fn session_check_name(name: *const c_char) -> *mut c_char {
     unsafe {
         let mut new_name = null_mut();
         if *name == b'\0' as c_char {
@@ -280,7 +280,7 @@ pub unsafe extern "C" fn session_check_name(name: *const c_char) -> *mut c_char 
 }
 
 /// Lock session if it has timed out.
-pub unsafe extern "C" fn session_lock_timer(fd: i32, events: i16, arg: *mut c_void) {
+pub unsafe fn session_lock_timer(fd: i32, events: i16, arg: *mut c_void) {
     unsafe {
         let s = arg as *mut session;
 
@@ -300,7 +300,7 @@ pub unsafe extern "C" fn session_lock_timer(fd: i32, events: i16, arg: *mut c_vo
 }
 
 /// Update activity time.
-pub unsafe extern "C" fn session_update_activity(s: *mut session, from: *mut timeval) {
+pub unsafe fn session_update_activity(s: *mut session, from: *mut timeval) {
     unsafe {
         let last = &raw mut (*s).last_activity_time;
 
@@ -341,7 +341,7 @@ pub unsafe extern "C" fn session_update_activity(s: *mut session, from: *mut tim
 }
 
 /// Find the next usable session.
-pub unsafe extern "C" fn session_next_session(s: *mut session) -> *mut session {
+pub unsafe fn session_next_session(s: *mut session) -> *mut session {
     unsafe {
         if rb_empty(&raw mut sessions) || !session_alive(s) {
             return null_mut();
@@ -360,7 +360,7 @@ pub unsafe extern "C" fn session_next_session(s: *mut session) -> *mut session {
 }
 
 /// Find the previous usable session.
-pub unsafe extern "C" fn session_previous_session(s: *mut session) -> *mut session {
+pub unsafe fn session_previous_session(s: *mut session) -> *mut session {
     unsafe {
         if rb_empty(&raw mut sessions) || !session_alive(s) {
             return null_mut();
@@ -378,7 +378,7 @@ pub unsafe extern "C" fn session_previous_session(s: *mut session) -> *mut sessi
 }
 
 /// Attach a window to a session.
-pub unsafe extern "C" fn session_attach(
+pub unsafe fn session_attach(
     s: *mut session,
     w: *mut window,
     idx: i32,
@@ -401,7 +401,7 @@ pub unsafe extern "C" fn session_attach(
 }
 
 /// Detach a window from a session.
-pub unsafe extern "C" fn session_detach(s: *mut session, wl: *mut winlink) -> i32 {
+pub unsafe fn session_detach(s: *mut session, wl: *mut winlink) -> i32 {
     unsafe {
         if (*s).curw == wl && session_last(s) != 0 && session_previous(s, 0) != 0 {
             session_next(s, 0);
@@ -422,7 +422,7 @@ pub unsafe extern "C" fn session_detach(s: *mut session, wl: *mut winlink) -> i3
 }
 
 /// Return if session has window.
-pub unsafe extern "C" fn session_has(s: *mut session, w: *mut window) -> i32 {
+pub unsafe fn session_has(s: *mut session, w: *mut window) -> i32 {
     unsafe {
         tailq_foreach::<_, discr_wentry>(&raw mut (*w).winlinks)
             .any(|wl| (*wl.as_ptr()).session == s) as i32
@@ -430,7 +430,7 @@ pub unsafe extern "C" fn session_has(s: *mut session, w: *mut window) -> i32 {
 }
 
 /// Return 1 if a window is linked outside this session (not including session groups). The window must be in this session!
-pub unsafe extern "C" fn session_is_linked(s: *mut session, w: *mut window) -> i32 {
+pub unsafe fn session_is_linked(s: *mut session, w: *mut window) -> i32 {
     unsafe {
         let sg = session_group_contains(s);
         if sg.is_null() {
@@ -440,7 +440,7 @@ pub unsafe extern "C" fn session_is_linked(s: *mut session, w: *mut window) -> i
     }
 }
 
-pub unsafe extern "C" fn session_next_alert(mut wl: *mut winlink) -> *mut winlink {
+pub unsafe fn session_next_alert(mut wl: *mut winlink) -> *mut winlink {
     unsafe {
         while !wl.is_null() {
             if (*wl).flags.intersects(WINLINK_ALERTFLAGS) {
@@ -453,7 +453,7 @@ pub unsafe extern "C" fn session_next_alert(mut wl: *mut winlink) -> *mut winlin
 }
 
 /// Move session to next window.
-pub unsafe extern "C" fn session_next(s: *mut session, alert: i32) -> i32 {
+pub unsafe fn session_next(s: *mut session, alert: i32) -> i32 {
     unsafe {
         if (*s).curw.is_null() {
             return -1;
@@ -478,7 +478,7 @@ pub unsafe extern "C" fn session_next(s: *mut session, alert: i32) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn session_previous_alert(mut wl: *mut winlink) -> *mut winlink {
+pub unsafe fn session_previous_alert(mut wl: *mut winlink) -> *mut winlink {
     unsafe {
         while !wl.is_null() {
             if (*wl).flags.intersects(WINLINK_ALERTFLAGS) {
@@ -491,7 +491,7 @@ pub unsafe extern "C" fn session_previous_alert(mut wl: *mut winlink) -> *mut wi
 }
 
 /// Move session to previous window.
-pub unsafe extern "C" fn session_previous(s: *mut session, alert: i32) -> i32 {
+pub unsafe fn session_previous(s: *mut session, alert: i32) -> i32 {
     unsafe {
         if (*s).curw.is_null() {
             return -1;
@@ -517,7 +517,7 @@ pub unsafe extern "C" fn session_previous(s: *mut session, alert: i32) -> i32 {
 }
 
 /// Move session to specific window.
-pub unsafe extern "C" fn session_select(s: *mut session, idx: i32) -> i32 {
+pub unsafe fn session_select(s: *mut session, idx: i32) -> i32 {
     unsafe {
         let wl = winlink_find_by_index(&raw mut (*s).windows, idx);
         session_set_current(s, wl)
@@ -525,7 +525,7 @@ pub unsafe extern "C" fn session_select(s: *mut session, idx: i32) -> i32 {
 }
 
 /// Move session to last used window.
-pub unsafe extern "C" fn session_last(s: *mut session) -> i32 {
+pub unsafe fn session_last(s: *mut session) -> i32 {
     unsafe {
         let wl = tailq_first(&raw mut (*s).lastw);
         if wl.is_null() {
@@ -540,7 +540,7 @@ pub unsafe extern "C" fn session_last(s: *mut session) -> i32 {
 }
 
 /// Set current winlink to wl.
-pub unsafe extern "C" fn session_set_current(s: *mut session, wl: *mut winlink) -> i32 {
+pub unsafe fn session_set_current(s: *mut session, wl: *mut winlink) -> i32 {
     unsafe {
         let old: *mut winlink = (*s).curw;
 
@@ -569,7 +569,7 @@ pub unsafe extern "C" fn session_set_current(s: *mut session, wl: *mut winlink) 
 }
 
 /// Find the session group containing a session.
-pub unsafe extern "C" fn session_group_contains(target: *mut session) -> *mut session_group {
+pub unsafe fn session_group_contains(target: *mut session) -> *mut session_group {
     unsafe {
         for sg in rb_foreach(&raw mut session_groups) {
             for s in tailq_foreach(&raw mut (*sg.as_ptr()).sessions) {
@@ -584,7 +584,7 @@ pub unsafe extern "C" fn session_group_contains(target: *mut session) -> *mut se
 }
 
 /// Find session group by name.
-pub unsafe extern "C" fn session_group_find(name: *const c_char) -> *mut session_group {
+pub unsafe fn session_group_find(name: *const c_char) -> *mut session_group {
     unsafe {
         let mut sg = MaybeUninit::<session_group>::uninit();
         let sg = sg.as_mut_ptr();
@@ -595,7 +595,7 @@ pub unsafe extern "C" fn session_group_find(name: *const c_char) -> *mut session
 }
 
 /// Create a new session group.
-pub unsafe extern "C" fn session_group_new(name: *const c_char) -> *mut session_group {
+pub unsafe fn session_group_new(name: *const c_char) -> *mut session_group {
     unsafe {
         let mut sg = session_group_find(name);
         if !sg.is_null() {
@@ -612,7 +612,7 @@ pub unsafe extern "C" fn session_group_new(name: *const c_char) -> *mut session_
 }
 
 /// Add a session to a session group.
-pub unsafe extern "C" fn session_group_add(sg: *mut session_group, s: *mut session) {
+pub unsafe fn session_group_add(sg: *mut session_group, s: *mut session) {
     unsafe {
         if session_group_contains(s).is_null() {
             tailq_insert_tail(&raw mut (*sg).sessions, s);
@@ -621,7 +621,7 @@ pub unsafe extern "C" fn session_group_add(sg: *mut session_group, s: *mut sessi
 }
 
 /// Remove a session from its group and destroy the group if empty.
-pub unsafe extern "C" fn session_group_remove(s: *mut session) {
+pub unsafe fn session_group_remove(s: *mut session) {
     unsafe {
         let sg = session_group_contains(s);
 
@@ -638,12 +638,12 @@ pub unsafe extern "C" fn session_group_remove(s: *mut session) {
 }
 
 /// Count number of sessions in session group.
-pub unsafe extern "C" fn session_group_count(sg: *mut session_group) -> u32 {
+pub unsafe fn session_group_count(sg: *mut session_group) -> u32 {
     unsafe { tailq_foreach(&raw mut (*sg).sessions).count() as u32 }
 }
 
 /// Count number of clients attached to sessions in session group.
-pub unsafe extern "C" fn session_group_attached_count(sg: *mut session_group) -> u32 {
+pub unsafe fn session_group_attached_count(sg: *mut session_group) -> u32 {
     unsafe {
         tailq_foreach(&raw mut (*sg).sessions)
             .map(|s| (*s.as_ptr()).attached)
@@ -652,7 +652,7 @@ pub unsafe extern "C" fn session_group_attached_count(sg: *mut session_group) ->
 }
 
 /// Synchronize a session to its session group.
-pub unsafe extern "C" fn session_group_synchronize_to(s: *mut session) {
+pub unsafe fn session_group_synchronize_to(s: *mut session) {
     unsafe {
         let sg = session_group_contains(s);
         if sg.is_null() {
@@ -673,7 +673,7 @@ pub unsafe extern "C" fn session_group_synchronize_to(s: *mut session) {
 }
 
 /// Synchronize a session group to a session.
-pub unsafe extern "C" fn session_group_synchronize_from(target: *mut session) {
+pub unsafe fn session_group_synchronize_from(target: *mut session) {
     unsafe {
         let sg = session_group_contains(target);
         if sg.is_null() {
@@ -693,7 +693,7 @@ pub unsafe extern "C" fn session_group_synchronize_from(target: *mut session) {
  * winlinks then recreating them, then updating the current window, last window
  * stack and alerts.
  */
-pub unsafe extern "C" fn session_group_synchronize1(target: *mut session, s: *mut session) {
+pub unsafe fn session_group_synchronize1(target: *mut session, s: *mut session) {
     let mut old_windows = MaybeUninit::<winlinks>::uninit();
     let mut old_lastw = MaybeUninit::<winlink_stack>::uninit();
 
@@ -758,7 +758,7 @@ pub unsafe extern "C" fn session_group_synchronize1(target: *mut session, s: *mu
 }
 
 /// Renumber the windows across winlinks attached to a specific session.
-pub unsafe extern "C" fn session_renumber_windows(s: *mut session) {
+pub unsafe fn session_renumber_windows(s: *mut session) {
     unsafe {
         let mut old_wins = MaybeUninit::<winlinks>::uninit();
         let mut old_lastw = MaybeUninit::<winlink_stack>::uninit();

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -28,7 +28,7 @@ use libc::{
 #[cfg(feature = "utempter")]
 use crate::utempter::utempter_add_record;
 
-pub unsafe extern "C" fn spawn_log(from: *const c_char, sc: *mut spawn_context) {
+pub unsafe fn spawn_log(from: *const c_char, sc: *mut spawn_context) {
     unsafe {
         let s = (*sc).s;
         let wl = (*sc).wl;
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn spawn_log(from: *const c_char, sc: *mut spawn_context) 
     }
 }
 
-pub unsafe extern "C" fn spawn_window(
+pub unsafe fn spawn_window(
     sc: *mut spawn_context,
     cause: *mut *mut c_char,
 ) -> *mut winlink {
@@ -243,7 +243,7 @@ pub unsafe extern "C" fn spawn_window(
     }
 }
 
-pub unsafe extern "C" fn spawn_pane(
+pub unsafe fn spawn_pane(
     sc: *mut spawn_context,
     cause: *mut *mut c_char,
 ) -> *mut window_pane {

--- a/src/status.rs
+++ b/src/status.rs
@@ -167,7 +167,7 @@ pub unsafe fn status_prompt_save_history() {
 }
 
 /// Status timer callback.
-unsafe fn status_timer_callback(_fd: i32, _events: i16, arg: *mut c_void) {
+unsafe extern "C" fn status_timer_callback(_fd: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let c: *mut client = arg.cast();
         let s: *mut session = (*c).session;
@@ -595,7 +595,7 @@ pub unsafe fn status_message_clear(c: *mut client) {
 }
 
 /// Clear status line message after timer expires.
-unsafe fn status_message_callback(_fd: i32, _event: i16, data: *mut c_void) {
+unsafe extern "C" fn status_message_callback(_fd: i32, _event: i16, data: *mut c_void) {
     unsafe {
         status_message_clear(data.cast());
     }

--- a/src/status.rs
+++ b/src/status.rs
@@ -44,7 +44,7 @@ pub static mut status_prompt_hlist: [*mut *mut c_char; PROMPT_NTYPES as usize] =
 pub static mut status_prompt_hsize: [u32; PROMPT_NTYPES as usize] = [0; PROMPT_NTYPES as usize];
 
 /// Find the history file to load/save from/to.
-unsafe extern "C" fn status_prompt_find_history_file() -> *mut c_char {
+unsafe fn status_prompt_find_history_file() -> *mut c_char {
     unsafe {
         let history_file = options_get_string_(global_options, c"history-file");
         if *history_file == b'\0' as i8 {
@@ -67,7 +67,7 @@ unsafe extern "C" fn status_prompt_find_history_file() -> *mut c_char {
 }
 
 /// Add loaded history item to the appropriate list.
-unsafe extern "C" fn status_prompt_add_typed_history(mut line: *mut c_char) {
+unsafe fn status_prompt_add_typed_history(mut line: *mut c_char) {
     unsafe {
         let mut type_ = prompt_type::PROMPT_TYPE_INVALID;
 
@@ -92,7 +92,7 @@ unsafe extern "C" fn status_prompt_add_typed_history(mut line: *mut c_char) {
 }
 
 /// Load status prompt history from file.
-pub unsafe extern "C" fn status_prompt_load_history() {
+pub unsafe fn status_prompt_load_history() {
     unsafe {
         let mut length: usize = 0;
 
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn status_prompt_load_history() {
 }
 
 /// Save status prompt history to file.
-pub unsafe extern "C" fn status_prompt_save_history() {
+pub unsafe fn status_prompt_save_history() {
     unsafe {
         let Some(history_file) = NonNull::new(status_prompt_find_history_file()) else {
             return;
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn status_prompt_save_history() {
 }
 
 /// Status timer callback.
-unsafe extern "C" fn status_timer_callback(_fd: i32, _events: i16, arg: *mut c_void) {
+unsafe fn status_timer_callback(_fd: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let c: *mut client = arg.cast();
         let s: *mut session = (*c).session;
@@ -194,7 +194,7 @@ unsafe extern "C" fn status_timer_callback(_fd: i32, _events: i16, arg: *mut c_v
 }
 
 /// Start status timer for client.
-pub unsafe extern "C" fn status_timer_start(c: *mut client) {
+pub unsafe fn status_timer_start(c: *mut client) {
     unsafe {
         let s: *mut session = (*c).session;
 
@@ -215,7 +215,7 @@ pub unsafe extern "C" fn status_timer_start(c: *mut client) {
 }
 
 /// Start status timer for all clients.
-pub unsafe extern "C" fn status_timer_start_all() {
+pub unsafe fn status_timer_start_all() {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             status_timer_start(c);
@@ -224,7 +224,7 @@ pub unsafe extern "C" fn status_timer_start_all() {
 }
 
 /// Update status cache.
-pub unsafe extern "C" fn status_update_cache(s: *mut session) {
+pub unsafe fn status_update_cache(s: *mut session) {
     unsafe {
         (*s).statuslines = options_get_number_((*s).options, c"status") as u32;
         if (*s).statuslines == 0 {
@@ -238,7 +238,7 @@ pub unsafe extern "C" fn status_update_cache(s: *mut session) {
 }
 
 /// Get screen line of status line. -1 means off.
-pub unsafe extern "C" fn status_at_line(c: *mut client) -> i32 {
+pub unsafe fn status_at_line(c: *mut client) -> i32 {
     unsafe {
         let s: *mut session = (*c).session;
 
@@ -256,7 +256,7 @@ pub unsafe extern "C" fn status_at_line(c: *mut client) -> i32 {
 }
 
 /// Get size of status line for client's session. 0 means off.
-pub unsafe extern "C" fn status_line_size(c: *mut client) -> u32 {
+pub unsafe fn status_line_size(c: *mut client) -> u32 {
     unsafe {
         let s: *mut session = (*c).session;
 
@@ -274,7 +274,7 @@ pub unsafe extern "C" fn status_line_size(c: *mut client) -> u32 {
 }
 
 /// Get the prompt line number for client's session. 1 means at the bottom.
-unsafe extern "C" fn status_prompt_line_at(c: *mut client) -> u32 {
+unsafe fn status_prompt_line_at(c: *mut client) -> u32 {
     unsafe {
         let s = (*c).session;
 
@@ -289,7 +289,7 @@ unsafe extern "C" fn status_prompt_line_at(c: *mut client) -> u32 {
 }
 
 /// Get window at window list position.
-pub unsafe extern "C" fn status_get_range(c: *mut client, x: u32, y: u32) -> *mut style_range {
+pub unsafe fn status_get_range(c: *mut client, x: u32, y: u32) -> *mut style_range {
     unsafe {
         let sl = &raw mut (*c).status;
 
@@ -306,7 +306,7 @@ pub unsafe extern "C" fn status_get_range(c: *mut client, x: u32, y: u32) -> *mu
 }
 
 /// Free all ranges.
-unsafe extern "C" fn status_free_ranges(srs: *mut style_ranges) {
+unsafe fn status_free_ranges(srs: *mut style_ranges) {
     unsafe {
         for sr in tailq_foreach(srs).map(NonNull::as_ptr) {
             tailq_remove(srs, sr);
@@ -316,7 +316,7 @@ unsafe extern "C" fn status_free_ranges(srs: *mut style_ranges) {
 }
 
 /// Save old status line.
-unsafe extern "C" fn status_push_screen(c: *mut client) {
+unsafe fn status_push_screen(c: *mut client) {
     unsafe {
         let sl = &raw mut (*c).status;
 
@@ -329,7 +329,7 @@ unsafe extern "C" fn status_push_screen(c: *mut client) {
 }
 
 /// Restore old status line.
-unsafe extern "C" fn status_pop_screen(c: *mut client) {
+unsafe fn status_pop_screen(c: *mut client) {
     unsafe {
         let sl = &raw mut (*c).status;
 
@@ -343,7 +343,7 @@ unsafe extern "C" fn status_pop_screen(c: *mut client) {
 }
 
 /// Initialize status line.
-pub unsafe extern "C" fn status_init(c: *mut client) {
+pub unsafe fn status_init(c: *mut client) {
     unsafe {
         let sl = &raw mut (*c).status;
 
@@ -357,7 +357,7 @@ pub unsafe extern "C" fn status_init(c: *mut client) {
 }
 
 /// Free status line.
-pub unsafe extern "C" fn status_free(c: *mut client) {
+pub unsafe fn status_free(c: *mut client) {
     unsafe {
         let sl = &raw mut (*c).status;
 
@@ -379,7 +379,7 @@ pub unsafe extern "C" fn status_free(c: *mut client) {
 }
 
 /// Draw status line for client.
-pub unsafe extern "C" fn status_redraw(c: *mut client) -> i32 {
+pub unsafe fn status_redraw(c: *mut client) -> i32 {
     unsafe {
         let sl = &raw mut (*c).status;
         // status_line_entry *sle;
@@ -576,7 +576,7 @@ pub unsafe fn status_message_set_(
 }
 
 /// Clear status line message.
-pub unsafe extern "C" fn status_message_clear(c: *mut client) {
+pub unsafe fn status_message_clear(c: *mut client) {
     unsafe {
         if (*c).message_string.is_null() {
             return;
@@ -595,14 +595,14 @@ pub unsafe extern "C" fn status_message_clear(c: *mut client) {
 }
 
 /// Clear status line message after timer expires.
-unsafe extern "C" fn status_message_callback(_fd: i32, _event: i16, data: *mut c_void) {
+unsafe fn status_message_callback(_fd: i32, _event: i16, data: *mut c_void) {
     unsafe {
         status_message_clear(data.cast());
     }
 }
 
 /// Draw client message on status line of present else on last line.
-pub unsafe extern "C" fn status_message_redraw(c: *mut client) -> i32 {
+pub unsafe fn status_message_redraw(c: *mut client) -> i32 {
     unsafe {
         let sl = &raw mut (*c).status;
         let mut ctx: screen_write_ctx = zeroed();
@@ -683,7 +683,7 @@ pub unsafe extern "C" fn status_message_redraw(c: *mut client) -> i32 {
 }
 
 /// Enable status line prompt.
-pub unsafe extern "C" fn status_prompt_set(
+pub unsafe fn status_prompt_set(
     c: *mut client,
     fs: *mut cmd_find_state,
     msg: *const c_char,
@@ -761,7 +761,7 @@ pub unsafe extern "C" fn status_prompt_set(
 }
 
 /// Remove status line prompt.
-pub unsafe extern "C" fn status_prompt_clear(c: *mut client) {
+pub unsafe fn status_prompt_clear(c: *mut client) {
     unsafe {
         if (*c).prompt_string.is_null() {
             return;
@@ -793,7 +793,7 @@ pub unsafe extern "C" fn status_prompt_clear(c: *mut client) {
 }
 
 /// Update status line prompt with a new prompt string.
-pub unsafe extern "C" fn status_prompt_update(
+pub unsafe fn status_prompt_update(
     c: *mut client,
     msg: *const c_char,
     input: *const c_char,
@@ -825,7 +825,7 @@ pub unsafe extern "C" fn status_prompt_update(
 }
 
 /// Draw client prompt on status line of present else on last line.
-pub unsafe extern "C" fn status_prompt_redraw(c: *mut client) -> i32 {
+pub unsafe fn status_prompt_redraw(c: *mut client) -> i32 {
     unsafe {
         let sl = &raw mut (*c).status;
         let mut ctx: screen_write_ctx = zeroed();
@@ -965,7 +965,7 @@ pub unsafe extern "C" fn status_prompt_redraw(c: *mut client) -> i32 {
 }
 
 /// Is this a separator?
-unsafe extern "C" fn status_prompt_in_list(ws: *const c_char, ud: *const utf8_data) -> i32 {
+unsafe fn status_prompt_in_list(ws: *const c_char, ud: *const utf8_data) -> i32 {
     unsafe {
         if (*ud).size != 1 || (*ud).width != 1 {
             return 0;
@@ -975,7 +975,7 @@ unsafe extern "C" fn status_prompt_in_list(ws: *const c_char, ud: *const utf8_da
 }
 
 /// Is this a space?
-unsafe extern "C" fn status_prompt_space(ud: *const utf8_data) -> i32 {
+unsafe fn status_prompt_space(ud: *const utf8_data) -> i32 {
     unsafe {
         if (*ud).size != 1 || (*ud).width != 1 {
             return 0;
@@ -986,7 +986,7 @@ unsafe extern "C" fn status_prompt_space(ud: *const utf8_data) -> i32 {
 
 /// Translate key from vi to emacs. Return 0 to drop key, 1 to process the key
 /// as an emacs key; return 2 to append to the buffer.
-unsafe extern "C" fn status_prompt_translate_key(
+unsafe fn status_prompt_translate_key(
     c: *mut client,
     key: key_code,
     new_key: *mut key_code,
@@ -1139,7 +1139,7 @@ unsafe extern "C" fn status_prompt_translate_key(
 }
 
 /// Paste into prompt.
-unsafe extern "C" fn status_prompt_paste(c: *mut client) -> i32 {
+unsafe fn status_prompt_paste(c: *mut client) -> i32 {
     unsafe {
         // struct paste_buffer *pb;
         // const char *bufdata;
@@ -1223,7 +1223,7 @@ unsafe extern "C" fn status_prompt_paste(c: *mut client) -> i32 {
 }
 
 /// Finish completion.
-unsafe extern "C" fn status_prompt_replace_complete(c: *mut client, mut s: *const c_char) -> i32 {
+unsafe fn status_prompt_replace_complete(c: *mut client, mut s: *const c_char) -> i32 {
     unsafe {
         let mut word: [c_char; 64] = [0; 64];
         let mut allocated: *mut c_char = null_mut();
@@ -1320,7 +1320,7 @@ unsafe extern "C" fn status_prompt_replace_complete(c: *mut client, mut s: *cons
 }
 
 /// Prompt forward to the next beginning of a word.
-unsafe extern "C" fn status_prompt_forward_word(
+unsafe fn status_prompt_forward_word(
     c: *mut client,
     size: usize,
     vi: i32,
@@ -1373,7 +1373,7 @@ unsafe extern "C" fn status_prompt_forward_word(
 }
 
 /// Prompt forward to the next end of a word.
-unsafe extern "C" fn status_prompt_end_word(
+unsafe fn status_prompt_end_word(
     c: *mut client,
     size: usize,
     separators: *const c_char,
@@ -1422,7 +1422,7 @@ unsafe extern "C" fn status_prompt_end_word(
 }
 
 /// Prompt backward to the previous beginning of a word.
-unsafe extern "C" fn status_prompt_backward_word(c: *mut client, separators: *const c_char) {
+unsafe fn status_prompt_backward_word(c: *mut client, separators: *const c_char) {
     unsafe {
         let mut idx = (*c).prompt_index;
 
@@ -1452,7 +1452,7 @@ unsafe extern "C" fn status_prompt_backward_word(c: *mut client, separators: *co
 }
 
 /// Handle keys in prompt.
-pub unsafe extern "C" fn status_prompt_key(c: *mut client, mut key: key_code) -> i32 {
+pub unsafe fn status_prompt_key(c: *mut client, mut key: key_code) -> i32 {
     unsafe {
         let oo = (*(*c).session).options;
         let mut s = null_mut();
@@ -1821,7 +1821,7 @@ pub unsafe extern "C" fn status_prompt_key(c: *mut client, mut key: key_code) ->
 }
 
 /// Get previous line from the history.
-unsafe extern "C" fn status_prompt_up_history(idx: *mut u32, type_: u32) -> *mut c_char {
+unsafe fn status_prompt_up_history(idx: *mut u32, type_: u32) -> *mut c_char {
     unsafe {
         /*
          * History runs from 0 to size - 1. Index is from 0 to size. Zero is
@@ -1840,7 +1840,7 @@ unsafe extern "C" fn status_prompt_up_history(idx: *mut u32, type_: u32) -> *mut
 }
 
 /// Get next line from the history.
-unsafe extern "C" fn status_prompt_down_history(idx: *mut u32, type_: u32) -> *const c_char {
+unsafe fn status_prompt_down_history(idx: *mut u32, type_: u32) -> *const c_char {
     unsafe {
         if status_prompt_hsize[type_ as usize] == 0 || *idx.add(type_ as usize) == 0 {
             return c"".as_ptr();
@@ -1856,7 +1856,7 @@ unsafe extern "C" fn status_prompt_down_history(idx: *mut u32, type_: u32) -> *c
 }
 
 /// Add line to the history.
-unsafe extern "C" fn status_prompt_add_history(line: *const c_char, type_: u32) {
+unsafe fn status_prompt_add_history(line: *const c_char, type_: u32) {
     unsafe {
         let mut new: u32 = 1;
         let mut newsize: u32 = 0;
@@ -1919,7 +1919,7 @@ unsafe extern "C" fn status_prompt_add_history(line: *const c_char, type_: u32) 
 }
 
 /// Add to completion list.
-unsafe extern "C" fn status_prompt_add_list(
+unsafe fn status_prompt_add_list(
     list: *mut *mut *mut c_char,
     size: *mut u32,
     s: *const c_char,
@@ -1937,7 +1937,7 @@ unsafe extern "C" fn status_prompt_add_list(
 }
 
 /// Build completion list.
-unsafe extern "C" fn status_prompt_complete_list(
+unsafe fn status_prompt_complete_list(
     size: *mut u32,
     s: *const c_char,
     at_start: i32,
@@ -2014,7 +2014,7 @@ unsafe extern "C" fn status_prompt_complete_list(
 }
 
 /// Find longest prefix.
-unsafe extern "C" fn status_prompt_complete_prefix(
+unsafe fn status_prompt_complete_prefix(
     list: *mut *mut c_char,
     size: u32,
 ) -> *mut c_char {
@@ -2040,7 +2040,7 @@ unsafe extern "C" fn status_prompt_complete_prefix(
 }
 
 /// Complete word menu callback.
-unsafe extern "C" fn status_prompt_menu_callback(
+unsafe fn status_prompt_menu_callback(
     _menu: *mut menu,
     mut idx: u32,
     key: key_code,
@@ -2081,7 +2081,7 @@ unsafe extern "C" fn status_prompt_menu_callback(
 }
 
 /// Show complete word menu.
-unsafe extern "C" fn status_prompt_complete_list_menu(
+unsafe fn status_prompt_complete_list_menu(
     c: *mut client,
     list: *mut *mut c_char,
     size: u32,
@@ -2166,7 +2166,7 @@ unsafe extern "C" fn status_prompt_complete_list_menu(
 }
 
 /// Show complete word menu.
-unsafe extern "C" fn status_prompt_complete_window_menu(
+unsafe fn status_prompt_complete_window_menu(
     c: *mut client,
     s: *mut session,
     word: *const c_char,
@@ -2308,7 +2308,7 @@ unsafe extern "C" fn status_prompt_complete_sort(a: *const c_void, b: *const c_v
 }
 
 /// Complete a session.
-unsafe extern "C" fn status_prompt_complete_session(
+unsafe fn status_prompt_complete_session(
     list: *mut *mut *mut c_char,
     size: *mut u32,
     s: *const c_char,
@@ -2347,7 +2347,7 @@ unsafe extern "C" fn status_prompt_complete_session(
 }
 
 /// Complete word.
-unsafe extern "C" fn status_prompt_complete(
+unsafe fn status_prompt_complete(
     c: *mut client,
     word: *const c_char,
     mut offset: u32,
@@ -2459,7 +2459,7 @@ unsafe extern "C" fn status_prompt_complete(
 }
 
 /// Return the type of the prompt as an enum.
-pub unsafe extern "C" fn status_prompt_type(type_: *const c_char) -> prompt_type {
+pub unsafe fn status_prompt_type(type_: *const c_char) -> prompt_type {
     unsafe {
         for i in 0..PROMPT_NTYPES {
             if libc::strcmp(type_, status_prompt_type_string(i)) == 0 {
@@ -2471,7 +2471,7 @@ pub unsafe extern "C" fn status_prompt_type(type_: *const c_char) -> prompt_type
 }
 
 /// Accessor for prompt_type_strings.
-pub unsafe extern "C" fn status_prompt_type_string(type_: u32) -> *const c_char {
+pub unsafe fn status_prompt_type_string(type_: u32) -> *const c_char {
     if type_ >= PROMPT_NTYPES {
         return c"invalid".as_ptr();
     }

--- a/src/style_.rs
+++ b/src/style_.rs
@@ -44,13 +44,13 @@ pub static mut style_default: style = style {
     default_type: style_default_type::STYLE_DEFAULT_BASE,
 };
 
-pub unsafe extern "C" fn style_set_range_string(sy: *mut style, s: *const c_char) {
+pub unsafe fn style_set_range_string(sy: *mut style, s: *const c_char) {
     unsafe {
         strlcpy(&raw mut (*sy).range_string as _, s, 16); // TODO use better sizeof
     }
 }
 
-pub unsafe extern "C" fn style_parse(
+pub unsafe fn style_parse(
     sy: *mut style,
     base: *const grid_cell,
     mut in_: *const c_char,
@@ -275,7 +275,7 @@ pub unsafe extern "C" fn style_parse(
     }
 }
 
-pub unsafe extern "C" fn style_tostring(sy: *const style) -> *const c_char {
+pub unsafe fn style_tostring(sy: *const style) -> *const c_char {
     type s_type = [i8; 256];
     static mut s_buf: MaybeUninit<s_type> = MaybeUninit::<s_type>::uninit();
 
@@ -456,7 +456,7 @@ pub unsafe extern "C" fn style_tostring(sy: *const style) -> *const c_char {
     }
 }
 
-pub unsafe extern "C" fn style_add(
+pub unsafe fn style_add(
     gc: *mut grid_cell,
     oo: *mut options,
     name: *const c_char,
@@ -492,7 +492,7 @@ pub unsafe extern "C" fn style_add(
     }
 }
 
-pub unsafe extern "C" fn style_apply(
+pub unsafe fn style_apply(
     gc: *mut grid_cell,
     oo: *mut options,
     name: *const c_char,
@@ -504,14 +504,14 @@ pub unsafe extern "C" fn style_apply(
     }
 }
 
-pub unsafe extern "C" fn style_set(sy: *mut style, gc: *const grid_cell) {
+pub unsafe fn style_set(sy: *mut style, gc: *const grid_cell) {
     unsafe {
         memcpy__(sy, &raw const style_default);
         memcpy__(&raw mut (*sy).gc, gc);
     }
 }
 
-pub unsafe extern "C" fn style_copy(dst: *mut style, src: *const style) {
+pub unsafe fn style_copy(dst: *mut style, src: *const style) {
     unsafe {
         memcpy__(dst, src);
     }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -46,14 +46,14 @@ pub static mut ptm_fd: c_int = -1;
 
 pub static mut shell_command: *mut c_char = null_mut();
 
-pub extern "C" fn usage() -> ! {
+pub fn usage() -> ! {
     unsafe {
         libc::fprintf(stderr, c"usage: %s [-2CDlNuVv] [-c shell-command] [-f file] [-L socket-name]\n            [-S socket-path] [-T features] [command [flags]]\n".as_ptr(), getprogname());
         std::process::exit(1)
     }
 }
 
-pub unsafe extern "C" fn getshell() -> *const c_char {
+pub unsafe fn getshell() -> *const c_char {
     unsafe {
         let shell = getenv(c"SHELL".as_ptr());
         if checkshell(shell) {
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn getshell() -> *const c_char {
     }
 }
 
-pub unsafe extern "C" fn checkshell(shell: *const c_char) -> bool {
+pub unsafe fn checkshell(shell: *const c_char) -> bool {
     unsafe {
         if shell.is_null() || *shell != b'/' as c_char {
             return false;
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn checkshell(shell: *const c_char) -> bool {
     true
 }
 
-pub unsafe extern "C" fn areshell(shell: *const c_char) -> c_int {
+pub unsafe fn areshell(shell: *const c_char) -> c_int {
     unsafe {
         let ptr = strrchr(shell, b'/' as c_int);
         let ptr = if !ptr.is_null() {
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn areshell(shell: *const c_char) -> c_int {
     }
 }
 
-pub unsafe extern "C" fn expand_path(path: *const c_char, home: *const c_char) -> *mut c_char {
+pub unsafe fn expand_path(path: *const c_char, home: *const c_char) -> *mut c_char {
     unsafe {
         let mut expanded: *mut c_char = null_mut();
         let mut end: *const c_char = null_mut();
@@ -140,7 +140,7 @@ pub unsafe extern "C" fn expand_path(path: *const c_char, home: *const c_char) -
     }
 }
 
-unsafe extern "C" fn expand_paths(
+unsafe fn expand_paths(
     s: *const c_char,
     paths: *mut *mut *mut c_char,
     n: *mut u32,
@@ -204,7 +204,7 @@ unsafe extern "C" fn expand_paths(
     }
 }
 
-unsafe extern "C" fn make_label(
+unsafe fn make_label(
     mut label: *const c_char,
     cause: *mut *mut c_char,
 ) -> *const c_char {
@@ -270,7 +270,7 @@ unsafe extern "C" fn make_label(
     }
 }
 
-pub unsafe extern "C" fn shell_argv0(shell: *const c_char, is_login: c_int) -> *mut c_char {
+pub unsafe fn shell_argv0(shell: *const c_char, is_login: c_int) -> *mut c_char {
     unsafe {
         let slash = strrchr(shell, b'/' as _);
         let name = if !slash.is_null() && *slash.add(1) != b'\0' as c_char {
@@ -287,7 +287,7 @@ pub unsafe extern "C" fn shell_argv0(shell: *const c_char, is_login: c_int) -> *
     }
 }
 
-pub unsafe extern "C" fn setblocking(fd: c_int, state: c_int) {
+pub unsafe fn setblocking(fd: c_int, state: c_int) {
     unsafe {
         let mut mode = fcntl(fd, F_GETFL);
 
@@ -302,7 +302,7 @@ pub unsafe extern "C" fn setblocking(fd: c_int, state: c_int) {
     }
 }
 
-pub unsafe extern "C" fn get_timer() -> u64 {
+pub unsafe fn get_timer() -> u64 {
     unsafe {
         let mut ts: timespec = zeroed();
         //We want a timestamp in milliseconds suitable for time measurement,
@@ -314,7 +314,7 @@ pub unsafe extern "C" fn get_timer() -> u64 {
     }
 }
 
-pub unsafe extern "C" fn find_cwd() -> *mut c_char {
+pub unsafe fn find_cwd() -> *mut c_char {
     static mut cwd: [c_char; PATH_MAX as usize] = [0; PATH_MAX as usize];
     unsafe {
         let mut resolved1: [c_char; PATH_MAX as usize] = [0; PATH_MAX as usize];
@@ -344,7 +344,7 @@ pub unsafe extern "C" fn find_cwd() -> *mut c_char {
     }
 }
 
-pub unsafe extern "C" fn find_home() -> *mut c_char {
+pub unsafe fn find_home() -> *mut c_char {
     static mut home: *mut c_char = null_mut();
 
     unsafe {
@@ -376,7 +376,7 @@ pub fn getversion_c() -> *const c_char {
 
 /// entrypoint for tmux binary
 #[cfg_attr(not(test), unsafe(no_mangle))]
-pub unsafe extern "C" fn main(mut argc: i32, mut argv: *mut *mut c_char, env: *mut *mut c_char) {
+pub unsafe fn main(mut argc: i32, mut argv: *mut *mut c_char, env: *mut *mut c_char) {
     std::panic::set_hook(Box::new(|panic_info| {
         let backtrace = std::backtrace::Backtrace::capture();
         let err_str = format!("{backtrace:#?}");

--- a/src/tty_.rs
+++ b/src/tty_.rs
@@ -133,7 +133,7 @@ pub unsafe fn tty_set_size(tty: *mut tty, sx: u32, sy: u32, xpixel: u32, ypixel:
     }
 }
 
-pub unsafe fn tty_read_callback(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe extern "C" fn tty_read_callback(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let tty = data as *mut tty;
         let c = (*tty).client;
@@ -157,7 +157,7 @@ pub unsafe fn tty_read_callback(_fd: i32, _events: i16, data: *mut c_void) {
     }
 }
 
-pub unsafe fn tty_timer_callback(_fd: i32, events: i16, data: *mut c_void) {
+pub unsafe extern "C" fn tty_timer_callback(_fd: i32, events: i16, data: *mut c_void) {
     unsafe {
         let tty = data as *mut tty;
         let c = (*tty).client;
@@ -216,7 +216,7 @@ pub unsafe fn tty_block_maybe(tty: *mut tty) -> i32 {
     }
 }
 
-pub unsafe fn tty_write_callback(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe extern "C" fn tty_write_callback(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let tty = data as *mut tty;
         let c = (*tty).client;
@@ -301,7 +301,7 @@ pub unsafe fn tty_open(tty: *mut tty, cause: *mut *mut c_char) -> i32 {
     }
 }
 
-pub unsafe fn tty_start_timer_callback(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe extern "C" fn tty_start_timer_callback(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let tty = data as *mut tty;
         let c = (*tty).client;
@@ -3878,7 +3878,7 @@ pub unsafe fn tty_default_attributes(
     }
 }
 
-pub unsafe fn tty_clipboard_query_callback(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe extern "C" fn tty_clipboard_query_callback(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let tty: *mut tty = data.cast();
         let c = (*tty).client;

--- a/src/tty_.rs
+++ b/src/tty_.rs
@@ -44,7 +44,7 @@ unsafe fn TTY_BLOCK_STOP(tty: *const tty) -> u32 {
     unsafe { 1 + ((*tty).sx * (*tty).sy) / 8 }
 }
 
-pub unsafe extern "C" fn tty_create_log() {
+pub unsafe fn tty_create_log() {
     unsafe {
         let mut name: [c_char; 64] = [0; 64];
 
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn tty_create_log() {
     }
 }
 
-pub unsafe extern "C" fn tty_init(tty: *mut tty, c: *mut client) -> i32 {
+pub unsafe fn tty_init(tty: *mut tty, c: *mut client) -> i32 {
     unsafe {
         if libc::isatty((*c).fd) == 0 {
             return -1;
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn tty_init(tty: *mut tty, c: *mut client) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn tty_resize(tty: *mut tty) {
+pub unsafe fn tty_resize(tty: *mut tty) {
     unsafe {
         let c = (*tty).client;
         let mut ws: libc::winsize = zeroed();
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn tty_resize(tty: *mut tty) {
     }
 }
 
-pub unsafe extern "C" fn tty_set_size(tty: *mut tty, sx: u32, sy: u32, xpixel: u32, ypixel: u32) {
+pub unsafe fn tty_set_size(tty: *mut tty, sx: u32, sy: u32, xpixel: u32, ypixel: u32) {
     unsafe {
         (*tty).sx = sx;
         (*tty).sy = sy;
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn tty_set_size(tty: *mut tty, sx: u32, sy: u32, xpixel: u
     }
 }
 
-pub unsafe extern "C" fn tty_read_callback(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe fn tty_read_callback(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let tty = data as *mut tty;
         let c = (*tty).client;
@@ -157,7 +157,7 @@ pub unsafe extern "C" fn tty_read_callback(_fd: i32, _events: i16, data: *mut c_
     }
 }
 
-pub unsafe extern "C" fn tty_timer_callback(_fd: i32, events: i16, data: *mut c_void) {
+pub unsafe fn tty_timer_callback(_fd: i32, events: i16, data: *mut c_void) {
     unsafe {
         let tty = data as *mut tty;
         let c = (*tty).client;
@@ -181,7 +181,7 @@ pub unsafe extern "C" fn tty_timer_callback(_fd: i32, events: i16, data: *mut c_
     }
 }
 
-pub unsafe extern "C" fn tty_block_maybe(tty: *mut tty) -> i32 {
+pub unsafe fn tty_block_maybe(tty: *mut tty) -> i32 {
     unsafe {
         let c = (*tty).client;
         let size = EVBUFFER_LENGTH((*tty).out);
@@ -216,7 +216,7 @@ pub unsafe extern "C" fn tty_block_maybe(tty: *mut tty) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn tty_write_callback(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe fn tty_write_callback(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let tty = data as *mut tty;
         let c = (*tty).client;
@@ -245,7 +245,7 @@ pub unsafe extern "C" fn tty_write_callback(_fd: i32, _events: i16, data: *mut c
     }
 }
 
-pub unsafe extern "C" fn tty_open(tty: *mut tty, cause: *mut *mut c_char) -> i32 {
+pub unsafe fn tty_open(tty: *mut tty, cause: *mut *mut c_char) -> i32 {
     unsafe {
         let c = (*tty).client;
 
@@ -301,7 +301,7 @@ pub unsafe extern "C" fn tty_open(tty: *mut tty, cause: *mut *mut c_char) -> i32
     }
 }
 
-pub unsafe extern "C" fn tty_start_timer_callback(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe fn tty_start_timer_callback(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let tty = data as *mut tty;
         let c = (*tty).client;
@@ -317,7 +317,7 @@ pub unsafe extern "C" fn tty_start_timer_callback(_fd: i32, _events: i16, data: 
     }
 }
 
-pub unsafe extern "C" fn tty_start_tty(tty: *mut tty) {
+pub unsafe fn tty_start_tty(tty: *mut tty) {
     unsafe {
         let c = (*tty).client;
         let mut tio: libc::termios = zeroed();
@@ -395,7 +395,7 @@ pub unsafe extern "C" fn tty_start_tty(tty: *mut tty) {
     }
 }
 
-pub unsafe extern "C" fn tty_send_requests(tty: *mut tty) {
+pub unsafe fn tty_send_requests(tty: *mut tty) {
     unsafe {
         if !(*tty).flags.intersects(tty_flags::TTY_STARTED) {
             return;
@@ -421,7 +421,7 @@ pub unsafe extern "C" fn tty_send_requests(tty: *mut tty) {
     }
 }
 
-pub unsafe extern "C" fn tty_repeat_requests(tty: *mut tty) {
+pub unsafe fn tty_repeat_requests(tty: *mut tty) {
     unsafe {
         let t = libc::time(null_mut());
 
@@ -441,7 +441,7 @@ pub unsafe extern "C" fn tty_repeat_requests(tty: *mut tty) {
     }
 }
 
-pub unsafe extern "C" fn tty_stop_tty(tty: *mut tty) {
+pub unsafe fn tty_stop_tty(tty: *mut tty) {
     unsafe {
         let c = (*tty).client;
         let ws: libc::winsize = zeroed();
@@ -524,7 +524,7 @@ pub unsafe extern "C" fn tty_stop_tty(tty: *mut tty) {
     }
 }
 
-pub unsafe extern "C" fn tty_close(tty: *mut tty) {
+pub unsafe fn tty_close(tty: *mut tty) {
     unsafe {
         if event_initialized(&raw mut (*tty).key_timer) != 0 {
             evtimer_del(&raw mut (*tty).key_timer);
@@ -545,13 +545,13 @@ pub unsafe extern "C" fn tty_close(tty: *mut tty) {
     }
 }
 
-pub unsafe extern "C" fn tty_free(tty: *mut tty) {
+pub unsafe fn tty_free(tty: *mut tty) {
     unsafe {
         tty_close(tty);
     }
 }
 
-pub unsafe extern "C" fn tty_update_features(tty: *mut tty) {
+pub unsafe fn tty_update_features(tty: *mut tty) {
     unsafe {
         let c = (*tty).client;
 
@@ -582,7 +582,7 @@ pub unsafe extern "C" fn tty_update_features(tty: *mut tty) {
     }
 }
 
-pub unsafe extern "C" fn tty_raw(tty: *mut tty, mut s: *const c_char) {
+pub unsafe fn tty_raw(tty: *mut tty, mut s: *const c_char) {
     unsafe {
         let c = (*tty).client;
 
@@ -603,13 +603,13 @@ pub unsafe extern "C" fn tty_raw(tty: *mut tty, mut s: *const c_char) {
     }
 }
 
-pub unsafe extern "C" fn tty_putcode(tty: *mut tty, code: tty_code_code) {
+pub unsafe fn tty_putcode(tty: *mut tty, code: tty_code_code) {
     unsafe {
         tty_puts(tty, tty_term_string((*tty).term, code));
     }
 }
 
-pub unsafe extern "C" fn tty_putcode_i(tty: *mut tty, code: tty_code_code, a: i32) {
+pub unsafe fn tty_putcode_i(tty: *mut tty, code: tty_code_code, a: i32) {
     unsafe {
         if a < 0 {
             return;
@@ -618,7 +618,7 @@ pub unsafe extern "C" fn tty_putcode_i(tty: *mut tty, code: tty_code_code, a: i3
     }
 }
 
-pub unsafe extern "C" fn tty_putcode_ii(tty: *mut tty, code: tty_code_code, a: i32, b: i32) {
+pub unsafe fn tty_putcode_ii(tty: *mut tty, code: tty_code_code, a: i32, b: i32) {
     unsafe {
         if a < 0 || b < 0 {
             return;
@@ -627,7 +627,7 @@ pub unsafe extern "C" fn tty_putcode_ii(tty: *mut tty, code: tty_code_code, a: i
     }
 }
 
-pub unsafe extern "C" fn tty_putcode_iii(
+pub unsafe fn tty_putcode_iii(
     tty: *mut tty,
     code: tty_code_code,
     a: i32,
@@ -642,7 +642,7 @@ pub unsafe extern "C" fn tty_putcode_iii(
     }
 }
 
-pub unsafe extern "C" fn tty_putcode_s(tty: *mut tty, code: tty_code_code, a: *const c_char) {
+pub unsafe fn tty_putcode_s(tty: *mut tty, code: tty_code_code, a: *const c_char) {
     unsafe {
         if !a.is_null() {
             tty_puts(tty, tty_term_string_s((*tty).term, code, a));
@@ -650,7 +650,7 @@ pub unsafe extern "C" fn tty_putcode_s(tty: *mut tty, code: tty_code_code, a: *c
     }
 }
 
-pub unsafe extern "C" fn tty_putcode_ss(
+pub unsafe fn tty_putcode_ss(
     tty: *mut tty,
     code: tty_code_code,
     a: *const c_char,
@@ -663,7 +663,7 @@ pub unsafe extern "C" fn tty_putcode_ss(
     }
 }
 
-pub unsafe extern "C" fn tty_add(tty: *mut tty, buf: *const c_char, len: usize) {
+pub unsafe fn tty_add(tty: *mut tty, buf: *const c_char, len: usize) {
     unsafe {
         let c = (*tty).client;
 
@@ -685,7 +685,7 @@ pub unsafe extern "C" fn tty_add(tty: *mut tty, buf: *const c_char, len: usize) 
     }
 }
 
-pub unsafe extern "C" fn tty_puts(tty: *mut tty, s: *const c_char) {
+pub unsafe fn tty_puts(tty: *mut tty, s: *const c_char) {
     unsafe {
         if *s != b'\0' as i8 {
             tty_add(tty, s, strlen(s));
@@ -693,7 +693,7 @@ pub unsafe extern "C" fn tty_puts(tty: *mut tty, s: *const c_char) {
     }
 }
 
-pub unsafe extern "C" fn tty_putc(tty: *mut tty, ch: u8) {
+pub unsafe fn tty_putc(tty: *mut tty, ch: u8) {
     unsafe {
         if (*(*tty).term).flags.intersects(term_flags::TERM_NOAM)
             && ch >= 0x20
@@ -742,7 +742,7 @@ pub unsafe extern "C" fn tty_putc(tty: *mut tty, ch: u8) {
     }
 }
 
-pub unsafe extern "C" fn tty_putn(tty: *mut tty, buf: *const c_void, mut len: usize, width: u32) {
+pub unsafe fn tty_putn(tty: *mut tty, buf: *const c_void, mut len: usize, width: u32) {
     unsafe {
         if (*(*tty).term).flags.intersects(term_flags::TERM_NOAM)
             && (*tty).cy == (*tty).sy - 1
@@ -766,7 +766,7 @@ pub unsafe extern "C" fn tty_putn(tty: *mut tty, buf: *const c_void, mut len: us
     }
 }
 
-pub unsafe extern "C" fn tty_set_italics(tty: *mut tty) {
+pub unsafe fn tty_set_italics(tty: *mut tty) {
     unsafe {
         if tty_term_has((*tty).term, tty_code_code::TTYC_SITM) {
             let s = options_get_string_(global_options, c"default-terminal");
@@ -779,7 +779,7 @@ pub unsafe extern "C" fn tty_set_italics(tty: *mut tty) {
     }
 }
 
-pub unsafe extern "C" fn tty_set_title(tty: *mut tty, title: *const c_char) {
+pub unsafe fn tty_set_title(tty: *mut tty, title: *const c_char) {
     unsafe {
         if !tty_term_has((*tty).term, tty_code_code::TTYC_TSL)
             || !tty_term_has((*tty).term, tty_code_code::TTYC_FSL)
@@ -793,7 +793,7 @@ pub unsafe extern "C" fn tty_set_title(tty: *mut tty, title: *const c_char) {
     }
 }
 
-pub unsafe extern "C" fn tty_set_path(tty: *mut tty, title: *const c_char) {
+pub unsafe fn tty_set_path(tty: *mut tty, title: *const c_char) {
     unsafe {
         if !tty_term_has((*tty).term, tty_code_code::TTYC_SWD)
             || !tty_term_has((*tty).term, tty_code_code::TTYC_FSL)
@@ -807,7 +807,7 @@ pub unsafe extern "C" fn tty_set_path(tty: *mut tty, title: *const c_char) {
     }
 }
 
-pub unsafe extern "C" fn tty_force_cursor_colour(tty: *mut tty, mut c: i32) {
+pub unsafe fn tty_force_cursor_colour(tty: *mut tty, mut c: i32) {
     unsafe {
         let mut s: [c_char; 13] = [0; 13];
 
@@ -828,7 +828,7 @@ pub unsafe extern "C" fn tty_force_cursor_colour(tty: *mut tty, mut c: i32) {
     }
 }
 
-pub unsafe extern "C" fn tty_update_cursor(
+pub unsafe fn tty_update_cursor(
     tty: *mut tty,
     mode: mode_flag,
     s: *mut screen,
@@ -943,7 +943,7 @@ pub unsafe extern "C" fn tty_update_cursor(
     }
 }
 
-pub unsafe extern "C" fn tty_update_mode(tty: *mut tty, mut mode: mode_flag, s: *mut screen) {
+pub unsafe fn tty_update_mode(tty: *mut tty, mut mode: mode_flag, s: *mut screen) {
     unsafe {
         let term = (*tty).term;
         let c = (*tty).client;
@@ -989,7 +989,7 @@ pub unsafe extern "C" fn tty_update_mode(tty: *mut tty, mut mode: mode_flag, s: 
     }
 }
 
-pub unsafe extern "C" fn tty_emulate_repeat(
+pub unsafe fn tty_emulate_repeat(
     tty: *mut tty,
     code: tty_code_code,
     code1: tty_code_code,
@@ -1009,7 +1009,7 @@ pub unsafe extern "C" fn tty_emulate_repeat(
     }
 }
 
-pub unsafe extern "C" fn tty_repeat_space(tty: *mut tty, mut n: u32) {
+pub unsafe fn tty_repeat_space(tty: *mut tty, mut n: u32) {
     const sizeof_s: usize = 500;
     static mut s: [u8; sizeof_s] = [0; sizeof_s];
 
@@ -1029,7 +1029,7 @@ pub unsafe extern "C" fn tty_repeat_space(tty: *mut tty, mut n: u32) {
 }
 
 /// Is this window bigger than the terminal?
-pub unsafe extern "C" fn tty_window_bigger(tty: *mut tty) -> bool {
+pub unsafe fn tty_window_bigger(tty: *mut tty) -> bool {
     unsafe {
         let c = (*tty).client;
         let w = (*(*(*c).session).curw).window;
@@ -1039,7 +1039,7 @@ pub unsafe extern "C" fn tty_window_bigger(tty: *mut tty) -> bool {
 }
 
 /// What offset should this window be drawn at?
-pub unsafe extern "C" fn tty_window_offset(
+pub unsafe fn tty_window_offset(
     tty: *mut tty,
     ox: *mut u32,
     oy: *mut u32,
@@ -1057,7 +1057,7 @@ pub unsafe extern "C" fn tty_window_offset(
 }
 
 /// What offset should this window be drawn at?
-pub unsafe extern "C" fn tty_window_offset1(
+pub unsafe fn tty_window_offset1(
     tty: *mut tty,
     ox: *mut u32,
     oy: *mut u32,
@@ -1133,7 +1133,7 @@ pub unsafe extern "C" fn tty_window_offset1(
 }
 
 /// Update stored offsets for a window and redraw if necessary.
-pub unsafe extern "C" fn tty_update_window_offset(w: *mut window) {
+pub unsafe fn tty_update_window_offset(w: *mut window) {
     unsafe {
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
             if !(*c).session.is_null()
@@ -1147,7 +1147,7 @@ pub unsafe extern "C" fn tty_update_window_offset(w: *mut window) {
 }
 
 /// Update stored offsets for a client and redraw if necessary.
-pub unsafe extern "C" fn tty_update_client_offset(c: *mut client) {
+pub unsafe fn tty_update_client_offset(c: *mut client) {
     unsafe {
         let mut ox: u32 = 0;
         let mut oy: u32 = 0;
@@ -1195,12 +1195,12 @@ pub unsafe extern "C" fn tty_update_client_offset(c: *mut client) {
 /// Is the region large enough to be worth redrawing once later rather than
 /// probably several times now? Currently yes if it is more than 50% of the
 /// pane.
-pub unsafe extern "C" fn tty_large_region(_tty: *mut tty, ctx: *const tty_ctx) -> bool {
+pub unsafe fn tty_large_region(_tty: *mut tty, ctx: *const tty_ctx) -> bool {
     unsafe { (*ctx).orlower - (*ctx).orupper >= (*ctx).sy / 2 }
 }
 
 /// Return if BCE is needed but the terminal doesn't have it - it'll need to be emulated.
-pub unsafe extern "C" fn tty_fake_bce(tty: *const tty, gc: *const grid_cell, bg: u32) -> bool {
+pub unsafe fn tty_fake_bce(tty: *const tty, gc: *const grid_cell, bg: u32) -> bool {
     unsafe {
         if tty_term_flag((*tty).term, tty_code_code::TTYC_BCE) != 0 {
             false
@@ -1216,7 +1216,7 @@ pub unsafe extern "C" fn tty_fake_bce(tty: *const tty, gc: *const grid_cell, bg:
  * width of the terminal.
  */
 
-pub unsafe extern "C" fn tty_redraw_region(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_redraw_region(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let c = (*tty).client;
 
@@ -1238,7 +1238,7 @@ pub unsafe extern "C" fn tty_redraw_region(tty: *mut tty, ctx: *const tty_ctx) {
 
 /// Is this position visible in the pane?
 #[expect(clippy::needless_bool)]
-pub unsafe extern "C" fn tty_is_visible(
+pub unsafe fn tty_is_visible(
     _tty: *mut tty,
     ctx: *const tty_ctx,
     px: u32,
@@ -1265,7 +1265,7 @@ pub unsafe extern "C" fn tty_is_visible(
 }
 
 /// Clamp line position to visible part of pane.
-pub unsafe extern "C" fn tty_clamp_line(
+pub unsafe fn tty_clamp_line(
     tty: *mut tty,
     ctx: *const tty_ctx,
     px: u32,
@@ -1314,7 +1314,7 @@ pub unsafe extern "C" fn tty_clamp_line(
 }
 
 /// Clear a line.
-pub unsafe extern "C" fn tty_clear_line(
+pub unsafe fn tty_clear_line(
     tty: *mut tty,
     defaults: *const grid_cell,
     py: u32,
@@ -1375,7 +1375,7 @@ pub unsafe extern "C" fn tty_clear_line(
 }
 
 /// Clear a line, adjusting to visible part of pane.
-pub unsafe extern "C" fn tty_clear_pane_line(
+pub unsafe fn tty_clear_pane_line(
     tty: *mut tty,
     ctx: *const tty_ctx,
     py: u32,
@@ -1410,7 +1410,7 @@ pub unsafe extern "C" fn tty_clear_pane_line(
 }
 
 /// Clamp area position to visible part of pane.
-pub unsafe extern "C" fn tty_clamp_area(
+pub unsafe fn tty_clamp_area(
     tty: *mut tty,
     ctx: *const tty_ctx,
     px: u32,
@@ -1487,7 +1487,7 @@ pub unsafe extern "C" fn tty_clamp_area(
 }
 
 /// Clear an area, adjusting to visible part of pane.
-pub unsafe extern "C" fn tty_clear_area(
+pub unsafe fn tty_clear_area(
     tty: *mut tty,
     defaults: *const grid_cell,
     py: u32,
@@ -1581,7 +1581,7 @@ pub unsafe extern "C" fn tty_clear_area(
 }
 
 /// Clear an area in a pane.
-pub unsafe extern "C" fn tty_clear_pane_area(
+pub unsafe fn tty_clear_pane_area(
     tty: *mut tty,
     ctx: *const tty_ctx,
     py: u32,
@@ -1617,7 +1617,7 @@ pub unsafe extern "C" fn tty_clear_pane_area(
     }
 }
 
-pub unsafe extern "C" fn tty_draw_pane(tty: *mut tty, ctx: *const tty_ctx, py: u32) {
+pub unsafe fn tty_draw_pane(tty: *mut tty, ctx: *const tty_ctx, py: u32) {
     unsafe {
         let s = (*ctx).s;
         let nx = (*ctx).sx;
@@ -1668,7 +1668,7 @@ pub unsafe extern "C" fn tty_draw_pane(tty: *mut tty, ctx: *const tty_ctx, py: u
     }
 }
 
-pub unsafe extern "C" fn tty_check_codeset(
+pub unsafe fn tty_check_codeset(
     tty: *mut tty,
     gc: *const grid_cell,
 ) -> *const grid_cell {
@@ -1712,7 +1712,7 @@ pub unsafe extern "C" fn tty_check_codeset(
 }
 
 /// Check if a single character is obstructed by the overlay and return a boolean.
-pub unsafe extern "C" fn tty_check_overlay(tty: *mut tty, px: u32, py: u32) -> bool {
+pub unsafe fn tty_check_overlay(tty: *mut tty, px: u32, py: u32) -> bool {
     unsafe {
         let mut r: overlay_ranges = zeroed();
 
@@ -1727,7 +1727,7 @@ pub unsafe extern "C" fn tty_check_overlay(tty: *mut tty, px: u32, py: u32) -> b
 }
 
 /// Return parts of the input range which are visible.
-pub unsafe extern "C" fn tty_check_overlay_range(
+pub unsafe fn tty_check_overlay_range(
     tty: *mut tty,
     px: u32,
     py: u32,
@@ -1750,7 +1750,7 @@ pub unsafe extern "C" fn tty_check_overlay_range(
     }
 }
 
-pub unsafe extern "C" fn tty_draw_line(
+pub unsafe fn tty_draw_line(
     tty: *mut tty,
     s: *mut screen,
     px: u32,
@@ -1962,7 +1962,7 @@ pub unsafe extern "C" fn tty_draw_line(
 
 /// Update context for client.
 #[cfg(feature = "sixel")]
-pub unsafe extern "C" fn tty_set_client_cb(ttyctx: *mut tty_ctx, c: *mut client) -> i32 {
+pub unsafe fn tty_set_client_cb(ttyctx: *mut tty_ctx, c: *mut client) -> i32 {
     unsafe {
         let mut wp: *mut window_pane = (*ttyctx).arg.cast();
 
@@ -1993,7 +1993,7 @@ pub unsafe extern "C" fn tty_set_client_cb(ttyctx: *mut tty_ctx, c: *mut client)
 }
 
 #[cfg(feature = "sixel")]
-pub unsafe extern "C" fn tty_draw_images(c: *mut client, wp: *mut window_pane, s: *mut screen) {
+pub unsafe fn tty_draw_images(c: *mut client, wp: *mut window_pane, s: *mut screen) {
     unsafe {
         for im in tailq_foreach(&raw mut (*s).images).map(NonNull::as_ptr) {
             let mut ttyctx: tty_ctx = zeroed();
@@ -2020,7 +2020,7 @@ pub unsafe extern "C" fn tty_draw_images(c: *mut client, wp: *mut window_pane, s
     }
 }
 
-pub unsafe extern "C" fn tty_sync_start(tty: *mut tty) {
+pub unsafe fn tty_sync_start(tty: *mut tty) {
     unsafe {
         if (*tty).flags.intersects(tty_flags::TTY_BLOCK) {
             return;
@@ -2037,7 +2037,7 @@ pub unsafe extern "C" fn tty_sync_start(tty: *mut tty) {
     }
 }
 
-pub unsafe extern "C" fn tty_sync_end(tty: *mut tty) {
+pub unsafe fn tty_sync_end(tty: *mut tty) {
     unsafe {
         if (*tty).flags.intersects(tty_flags::TTY_BLOCK) {
             return;
@@ -2054,7 +2054,7 @@ pub unsafe extern "C" fn tty_sync_end(tty: *mut tty) {
     }
 }
 
-pub unsafe extern "C" fn tty_client_ready(ctx: *const tty_ctx, c: *mut client) -> i32 {
+pub unsafe fn tty_client_ready(ctx: *const tty_ctx, c: *mut client) -> i32 {
     unsafe {
         if (*c).session.is_null() || (*c).tty.term.is_null() {
             return 0;
@@ -2081,8 +2081,8 @@ pub unsafe extern "C" fn tty_client_ready(ctx: *const tty_ctx, c: *mut client) -
     }
 }
 
-pub unsafe extern "C" fn tty_write(
-    cmdfn: Option<unsafe extern "C" fn(*mut tty, *const tty_ctx)>,
+pub unsafe fn tty_write(
+    cmdfn: Option<unsafe fn(*mut tty, *const tty_ctx)>,
     ctx: *mut tty_ctx,
 ) {
     unsafe {
@@ -2107,7 +2107,7 @@ pub unsafe extern "C" fn tty_write(
 
 /// Only write to the incoming tty instead of every client.
 #[cfg(feature = "sixel")]
-pub unsafe extern "C" fn tty_write_one(
+pub unsafe fn tty_write_one(
     cmdfn: fn(*mut tty, *const tty_ctx),
     c: *mut client,
     ctx: *mut tty_ctx,
@@ -2120,7 +2120,7 @@ pub unsafe extern "C" fn tty_write_one(
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_insertcharacter(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_insertcharacter(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let c = (*tty).client;
 
@@ -2154,7 +2154,7 @@ pub unsafe extern "C" fn tty_cmd_insertcharacter(tty: *mut tty, ctx: *const tty_
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_deletecharacter(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_deletecharacter(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let c = (*tty).client;
 
@@ -2188,7 +2188,7 @@ pub unsafe extern "C" fn tty_cmd_deletecharacter(tty: *mut tty, ctx: *const tty_
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_clearcharacter(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_clearcharacter(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         tty_default_attributes(
             tty,
@@ -2202,7 +2202,7 @@ pub unsafe extern "C" fn tty_cmd_clearcharacter(tty: *mut tty, ctx: *const tty_c
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_insertline(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_insertline(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let c = (*tty).client;
 
@@ -2242,7 +2242,7 @@ pub unsafe extern "C" fn tty_cmd_insertline(tty: *mut tty, ctx: *const tty_ctx) 
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_deleteline(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_deleteline(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let c = (*tty).client;
 
@@ -2282,7 +2282,7 @@ pub unsafe extern "C" fn tty_cmd_deleteline(tty: *mut tty, ctx: *const tty_ctx) 
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_clearline(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_clearline(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         tty_default_attributes(
             tty,
@@ -2296,7 +2296,7 @@ pub unsafe extern "C" fn tty_cmd_clearline(tty: *mut tty, ctx: *const tty_ctx) {
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_clearendofline(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_clearendofline(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let nx = (*ctx).sx - (*ctx).ocx;
 
@@ -2312,7 +2312,7 @@ pub unsafe extern "C" fn tty_cmd_clearendofline(tty: *mut tty, ctx: *const tty_c
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_clearstartofline(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_clearstartofline(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         tty_default_attributes(
             tty,
@@ -2326,7 +2326,7 @@ pub unsafe extern "C" fn tty_cmd_clearstartofline(tty: *mut tty, ctx: *const tty
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_reverseindex(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_reverseindex(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let c = (*tty).client;
 
@@ -2368,7 +2368,7 @@ pub unsafe extern "C" fn tty_cmd_reverseindex(tty: *mut tty, ctx: *const tty_ctx
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_linefeed(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_linefeed(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let c = (*tty).client;
 
@@ -2420,7 +2420,7 @@ pub unsafe extern "C" fn tty_cmd_linefeed(tty: *mut tty, ctx: *const tty_ctx) {
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_scrollup(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_scrollup(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let c = (*tty).client;
 
@@ -2467,7 +2467,7 @@ pub unsafe extern "C" fn tty_cmd_scrollup(tty: *mut tty, ctx: *const tty_ctx) {
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_scrolldown(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_scrolldown(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let c = (*tty).client;
 
@@ -2507,7 +2507,7 @@ pub unsafe extern "C" fn tty_cmd_scrolldown(tty: *mut tty, ctx: *const tty_ctx) 
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_clearendofscreen(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_clearendofscreen(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         tty_default_attributes(
             tty,
@@ -2535,7 +2535,7 @@ pub unsafe extern "C" fn tty_cmd_clearendofscreen(tty: *mut tty, ctx: *const tty
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_clearstartofscreen(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_clearstartofscreen(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         tty_default_attributes(
             tty,
@@ -2563,7 +2563,7 @@ pub unsafe extern "C" fn tty_cmd_clearstartofscreen(tty: *mut tty, ctx: *const t
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_clearscreen(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_clearscreen(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         tty_default_attributes(
             tty,
@@ -2585,7 +2585,7 @@ pub unsafe extern "C" fn tty_cmd_clearscreen(tty: *mut tty, ctx: *const tty_ctx)
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_alignmenttest(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_alignmenttest(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         if (*ctx).bigger != 0 {
             (*ctx).redraw_cb.unwrap()(ctx);
@@ -2612,7 +2612,7 @@ pub unsafe extern "C" fn tty_cmd_alignmenttest(tty: *mut tty, ctx: *const tty_ct
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_cell(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_cell(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let gcp = (*ctx).cell;
         let s = (*ctx).s;
@@ -2673,7 +2673,7 @@ pub unsafe extern "C" fn tty_cmd_cell(tty: *mut tty, ctx: *const tty_ctx) {
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_cells(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_cells(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let mut r: overlay_ranges = zeroed();
         let cp: *mut i8 = (*ctx).ptr.cast();
@@ -2733,7 +2733,7 @@ pub unsafe extern "C" fn tty_cmd_cells(tty: *mut tty, ctx: *const tty_ctx) {
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_setselection(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_setselection(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         tty_set_selection(
             tty,
@@ -2744,7 +2744,7 @@ pub unsafe extern "C" fn tty_cmd_setselection(tty: *mut tty, ctx: *const tty_ctx
     }
 }
 
-pub unsafe extern "C" fn tty_set_selection(
+pub unsafe fn tty_set_selection(
     tty: *mut tty,
     flags: *const c_char,
     buf: *const c_char,
@@ -2769,7 +2769,7 @@ pub unsafe extern "C" fn tty_set_selection(
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_rawstring(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_rawstring(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         (*tty).flags |= tty_flags::TTY_NOBLOCK;
         tty_add(tty, (*ctx).ptr.cast(), (*ctx).num as usize);
@@ -2778,7 +2778,7 @@ pub unsafe extern "C" fn tty_cmd_rawstring(tty: *mut tty, ctx: *const tty_ctx) {
 }
 
 #[cfg(feature = "sixel")]
-pub unsafe extern "C" fn tty_cmd_sixelimage(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_sixelimage(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         let mut im: *mut image = (*ctx).ptr.cast();
         let mut si: *mut sixel_image = (*im).data;
@@ -2857,7 +2857,7 @@ pub unsafe extern "C" fn tty_cmd_sixelimage(tty: *mut tty, ctx: *const tty_ctx) 
     }
 }
 
-pub unsafe extern "C" fn tty_cmd_syncstart(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_cmd_syncstart(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         if (*ctx).num == 0x11 {
             /*
@@ -2876,7 +2876,7 @@ pub unsafe extern "C" fn tty_cmd_syncstart(tty: *mut tty, ctx: *const tty_ctx) {
     }
 }
 
-pub unsafe extern "C" fn tty_cell(
+pub unsafe fn tty_cell(
     tty: *mut tty,
     gc: *const grid_cell,
     defaults: *const grid_cell,
@@ -2921,7 +2921,7 @@ pub unsafe extern "C" fn tty_cell(
     }
 }
 
-pub unsafe extern "C" fn tty_reset(tty: *mut tty) {
+pub unsafe fn tty_reset(tty: *mut tty) {
     unsafe {
         let gc = &raw mut (*tty).cell;
 
@@ -2939,7 +2939,7 @@ pub unsafe extern "C" fn tty_reset(tty: *mut tty) {
     }
 }
 
-pub unsafe extern "C" fn tty_invalidate(tty: *mut tty) {
+pub unsafe fn tty_invalidate(tty: *mut tty) {
     unsafe {
         memcpy__(&raw mut (*tty).cell, &raw const grid_default_cell);
         memcpy__(&raw mut (*tty).last_cell, &raw const grid_default_cell);
@@ -2970,14 +2970,14 @@ pub unsafe extern "C" fn tty_invalidate(tty: *mut tty) {
 }
 
 /// Turn off margin.
-pub unsafe extern "C" fn tty_region_off(tty: *mut tty) {
+pub unsafe fn tty_region_off(tty: *mut tty) {
     unsafe {
         tty_region(tty, 0, (*tty).sy - 1);
     }
 }
 
 /// Set region inside pane.
-pub unsafe extern "C" fn tty_region_pane(
+pub unsafe fn tty_region_pane(
     tty: *mut tty,
     ctx: *const tty_ctx,
     rupper: u32,
@@ -2993,7 +2993,7 @@ pub unsafe extern "C" fn tty_region_pane(
 }
 
 /// Set region at absolute position.
-pub unsafe extern "C" fn tty_region(tty: *mut tty, rupper: u32, rlower: u32) {
+pub unsafe fn tty_region(tty: *mut tty, rupper: u32, rlower: u32) {
     unsafe {
         if (*tty).rlower == rlower && (*tty).rupper == rupper {
             return;
@@ -3031,14 +3031,14 @@ pub unsafe extern "C" fn tty_region(tty: *mut tty, rupper: u32, rlower: u32) {
 }
 
 /// Turn off margin.
-pub unsafe extern "C" fn tty_margin_off(tty: *mut tty) {
+pub unsafe fn tty_margin_off(tty: *mut tty) {
     unsafe {
         tty_margin(tty, 0, (*tty).sx - 1);
     }
 }
 
 /// Set margin inside pane.
-pub unsafe extern "C" fn tty_margin_pane(tty: *mut tty, ctx: *const tty_ctx) {
+pub unsafe fn tty_margin_pane(tty: *mut tty, ctx: *const tty_ctx) {
     unsafe {
         tty_margin(
             tty,
@@ -3050,7 +3050,7 @@ pub unsafe extern "C" fn tty_margin_pane(tty: *mut tty, ctx: *const tty_ctx) {
 
 /* Set margin at absolute position. */
 
-pub unsafe extern "C" fn tty_margin(tty: *mut tty, rleft: u32, rright: u32) {
+pub unsafe fn tty_margin(tty: *mut tty, rleft: u32, rright: u32) {
     unsafe {
         if !tty_use_margin(tty) {
             return;
@@ -3084,7 +3084,7 @@ pub unsafe extern "C" fn tty_margin(tty: *mut tty, rleft: u32, rright: u32) {
  * printed.
  */
 
-pub unsafe extern "C" fn tty_cursor_pane_unless_wrap(
+pub unsafe fn tty_cursor_pane_unless_wrap(
     tty: *mut tty,
     ctx: *const tty_ctx,
     cx: u32,
@@ -3108,7 +3108,7 @@ pub unsafe extern "C" fn tty_cursor_pane_unless_wrap(
 
 /* Move cursor inside pane. */
 
-pub unsafe extern "C" fn tty_cursor_pane(tty: *mut tty, ctx: *const tty_ctx, cx: u32, cy: u32) {
+pub unsafe fn tty_cursor_pane(tty: *mut tty, ctx: *const tty_ctx, cx: u32, cy: u32) {
     unsafe {
         tty_cursor(
             tty,
@@ -3120,7 +3120,7 @@ pub unsafe extern "C" fn tty_cursor_pane(tty: *mut tty, ctx: *const tty_ctx, cx:
 
 /* Move cursor to absolute position. */
 
-pub unsafe extern "C" fn tty_cursor(tty: *mut tty, mut cx: u32, cy: u32) {
+pub unsafe fn tty_cursor(tty: *mut tty, mut cx: u32, cy: u32) {
     unsafe {
         let term = (*tty).term;
 
@@ -3280,7 +3280,7 @@ pub unsafe extern "C" fn tty_cursor(tty: *mut tty, mut cx: u32, cy: u32) {
     }
 }
 
-pub unsafe extern "C" fn tty_hyperlink(tty: *mut tty, gc: *const grid_cell, hl: *mut hyperlinks) {
+pub unsafe fn tty_hyperlink(tty: *mut tty, gc: *const grid_cell, hl: *mut hyperlinks) {
     unsafe {
         if (*gc).link == (*tty).cell.link {
             return;
@@ -3302,7 +3302,7 @@ pub unsafe extern "C" fn tty_hyperlink(tty: *mut tty, gc: *const grid_cell, hl: 
     }
 }
 
-pub unsafe extern "C" fn tty_attributes(
+pub unsafe fn tty_attributes(
     tty: *mut tty,
     gc: *const grid_cell,
     defaults: *const grid_cell,
@@ -3428,7 +3428,7 @@ pub unsafe extern "C" fn tty_attributes(
     }
 }
 
-pub unsafe extern "C" fn tty_colours(tty: *mut tty, gc: *const grid_cell) {
+pub unsafe fn tty_colours(tty: *mut tty, gc: *const grid_cell) {
     unsafe {
         let tc = &raw mut (*tty).cell;
 
@@ -3481,7 +3481,7 @@ pub unsafe extern "C" fn tty_colours(tty: *mut tty, gc: *const grid_cell) {
     }
 }
 
-pub unsafe extern "C" fn tty_check_fg(
+pub unsafe fn tty_check_fg(
     tty: *const tty,
     palette: *const colour_palette,
     gc: *mut grid_cell,
@@ -3549,7 +3549,7 @@ pub unsafe extern "C" fn tty_check_fg(
     }
 }
 
-pub unsafe extern "C" fn tty_check_bg(
+pub unsafe fn tty_check_bg(
     tty: *const tty,
     palette: *const colour_palette,
     gc: *mut grid_cell,
@@ -3609,7 +3609,7 @@ pub unsafe extern "C" fn tty_check_bg(
     }
 }
 
-pub unsafe extern "C" fn tty_check_us(
+pub unsafe fn tty_check_us(
     tty: *const tty,
     palette: *const colour_palette,
     gc: *mut grid_cell,
@@ -3637,7 +3637,7 @@ pub unsafe extern "C" fn tty_check_us(
     }
 }
 
-pub unsafe extern "C" fn tty_colours_fg(tty: *mut tty, gc: *const grid_cell) {
+pub unsafe fn tty_colours_fg(tty: *mut tty, gc: *const grid_cell) {
     unsafe {
         let tc = &raw mut (*tty).cell;
         let sizeof_s: usize = 32;
@@ -3681,7 +3681,7 @@ pub unsafe extern "C" fn tty_colours_fg(tty: *mut tty, gc: *const grid_cell) {
     }
 }
 
-pub unsafe extern "C" fn tty_colours_bg(tty: *mut tty, gc: *const grid_cell) {
+pub unsafe fn tty_colours_bg(tty: *mut tty, gc: *const grid_cell) {
     unsafe {
         let tc = &raw mut (*tty).cell;
         let sizeof_s: usize = 32;
@@ -3717,7 +3717,7 @@ pub unsafe extern "C" fn tty_colours_bg(tty: *mut tty, gc: *const grid_cell) {
     }
 }
 
-pub unsafe extern "C" fn tty_colours_us(tty: *mut tty, gc: *const grid_cell) {
+pub unsafe fn tty_colours_us(tty: *mut tty, gc: *const grid_cell) {
     unsafe {
         let tc = &raw mut (*tty).cell;
         let mut c: u32 = 0;
@@ -3771,7 +3771,7 @@ pub unsafe extern "C" fn tty_colours_us(tty: *mut tty, gc: *const grid_cell) {
     }
 }
 
-pub unsafe extern "C" fn tty_try_colour(tty: *mut tty, colour: i32, type_: *const c_char) -> i32 {
+pub unsafe fn tty_try_colour(tty: *mut tty, colour: i32, type_: *const c_char) -> i32 {
     unsafe {
         if colour & COLOUR_FLAG_256 != 0 {
             if *type_ == b'3' as i8 && tty_term_has((*tty).term, tty_code_code::TTYC_SETAF) {
@@ -3808,7 +3808,7 @@ pub unsafe extern "C" fn tty_try_colour(tty: *mut tty, colour: i32, type_: *cons
     }
 }
 
-pub unsafe extern "C" fn tty_window_default_style(gc: *mut grid_cell, wp: *mut window_pane) {
+pub unsafe fn tty_window_default_style(gc: *mut grid_cell, wp: *mut window_pane) {
     unsafe {
         memcpy__(gc, &raw const grid_default_cell);
         (*gc).fg = (*wp).palette.fg;
@@ -3816,7 +3816,7 @@ pub unsafe extern "C" fn tty_window_default_style(gc: *mut grid_cell, wp: *mut w
     }
 }
 
-pub unsafe extern "C" fn tty_default_colours(gc: *mut grid_cell, wp: *mut window_pane) {
+pub unsafe fn tty_default_colours(gc: *mut grid_cell, wp: *mut window_pane) {
     unsafe {
         let oo = (*wp).options;
 
@@ -3863,7 +3863,7 @@ pub unsafe extern "C" fn tty_default_colours(gc: *mut grid_cell, wp: *mut window
     }
 }
 
-pub unsafe extern "C" fn tty_default_attributes(
+pub unsafe fn tty_default_attributes(
     tty: *mut tty,
     defaults: *const grid_cell,
     palette: *const colour_palette,
@@ -3878,7 +3878,7 @@ pub unsafe extern "C" fn tty_default_attributes(
     }
 }
 
-pub unsafe extern "C" fn tty_clipboard_query_callback(_fd: i32, _events: i16, data: *mut c_void) {
+pub unsafe fn tty_clipboard_query_callback(_fd: i32, _events: i16, data: *mut c_void) {
     unsafe {
         let tty: *mut tty = data.cast();
         let c = (*tty).client;
@@ -3892,7 +3892,7 @@ pub unsafe extern "C" fn tty_clipboard_query_callback(_fd: i32, _events: i16, da
     }
 }
 
-pub unsafe extern "C" fn tty_clipboard_query(tty: *mut tty) {
+pub unsafe fn tty_clipboard_query(tty: *mut tty) {
     unsafe {
         let tv = libc::timeval {
             tv_sec: TTY_QUERY_TIMEOUT as i64,

--- a/src/tty_acs.rs
+++ b/src/tty_acs.rs
@@ -168,17 +168,17 @@ static tty_acs_rounded_borders_list: [utf8_data; 13] = [
     utf8_data::new([0o302, 0o267, 0o000, 0o000], 0, 2, 1), /* U+00B7 */
 ];
 
-pub unsafe extern "C" fn tty_acs_double_borders(cell_type: cell_type) -> *const utf8_data {
+pub unsafe fn tty_acs_double_borders(cell_type: cell_type) -> *const utf8_data {
     unsafe { &raw const tty_acs_double_borders_list[cell_type as usize] }
 }
 
-pub unsafe extern "C" fn tty_acs_heavy_borders(cell_type: cell_type) -> *const utf8_data {
+pub unsafe fn tty_acs_heavy_borders(cell_type: cell_type) -> *const utf8_data {
     unsafe { &raw const tty_acs_heavy_borders_list[cell_type as usize] }
 }
 
 /* Get cell border character for rounded style. */
 
-pub unsafe extern "C" fn tty_acs_rounded_borders(cell_type: cell_type) -> *const utf8_data {
+pub unsafe fn tty_acs_rounded_borders(cell_type: cell_type) -> *const utf8_data {
     unsafe { &raw const tty_acs_rounded_borders_list[cell_type as usize] }
 }
 
@@ -202,7 +202,7 @@ pub unsafe extern "C" fn tty_acs_reverse_cmp(key: *const c_void, value: *const c
 
 /* Should this terminal use ACS instead of UTF-8 line drawing? */
 
-pub unsafe extern "C" fn tty_acs_needed(tty: *const tty) -> i32 {
+pub unsafe fn tty_acs_needed(tty: *const tty) -> i32 {
     unsafe {
         if tty.is_null() {
             return 0;
@@ -223,7 +223,7 @@ pub unsafe extern "C" fn tty_acs_needed(tty: *const tty) -> i32 {
 
 /* Retrieve ACS to output as UTF-8. */
 
-pub unsafe extern "C" fn tty_acs_get(tty: *mut tty, ch: u8) -> *const c_char {
+pub unsafe fn tty_acs_get(tty: *mut tty, ch: u8) -> *const c_char {
     unsafe {
         // const struct tty_acs_entry	*entry;
 
@@ -253,7 +253,7 @@ pub unsafe extern "C" fn tty_acs_get(tty: *mut tty, ch: u8) -> *const c_char {
 
 /* Reverse UTF-8 into ACS. */
 
-pub unsafe extern "C" fn tty_acs_reverse_get(
+pub unsafe fn tty_acs_reverse_get(
     tty: *const tty,
     s: *const c_char,
     slen: usize,

--- a/src/tty_features.rs
+++ b/src/tty_features.rs
@@ -360,7 +360,7 @@ static tty_features: [&tty_feature; 20] = [
     &tty_feature_usstyle,
 ];
 
-pub unsafe extern "C" fn tty_add_features(
+pub unsafe fn tty_add_features(
     feat: *mut i32,
     s: *const c_char,
     separators: *const c_char,
@@ -395,7 +395,7 @@ pub unsafe extern "C" fn tty_add_features(
     }
 }
 
-pub unsafe extern "C" fn tty_get_features(feat: i32) -> *const c_char {
+pub unsafe fn tty_get_features(feat: i32) -> *const c_char {
     static mut s_buf: [MaybeUninit<c_char>; 512] = [MaybeUninit::uninit(); 512];
     unsafe {
         let s: *mut c_char = (&raw mut s_buf).cast();
@@ -418,7 +418,7 @@ pub unsafe extern "C" fn tty_get_features(feat: i32) -> *const c_char {
     }
 }
 
-pub unsafe extern "C" fn tty_apply_features(term: *mut tty_term, feat: i32) -> bool {
+pub unsafe fn tty_apply_features(term: *mut tty_term, feat: i32) -> bool {
     if feat == 0 {
         return false;
     }
@@ -451,7 +451,7 @@ pub unsafe extern "C" fn tty_apply_features(term: *mut tty_term, feat: i32) -> b
     true
 }
 
-pub unsafe extern "C" fn tty_default_features(feat: *mut i32, name: *const c_char, version: u32) {
+pub unsafe fn tty_default_features(feat: *mut i32, name: *const c_char, version: u32) {
     struct entry {
         name: &'static CStr,
         version: u32,

--- a/src/tty_keys.rs
+++ b/src/tty_keys.rs
@@ -773,7 +773,7 @@ static tty_default_code_keys: [tty_default_key_code; 136] = [
 ];
 
 /// Add key to tree.
-unsafe extern "C" fn tty_keys_add(tty: *mut tty, s: *const c_char, key: key_code) {
+unsafe fn tty_keys_add(tty: *mut tty, s: *const c_char, key: key_code) {
     unsafe {
         let mut size: usize = 0;
 
@@ -790,7 +790,7 @@ unsafe extern "C" fn tty_keys_add(tty: *mut tty, s: *const c_char, key: key_code
 }
 
 /// Add next node to the tree.
-unsafe extern "C" fn tty_keys_add1(
+unsafe fn tty_keys_add1(
     mut tkp: *mut *mut tty_key,
     mut s: *const c_char,
     key: key_code,
@@ -830,7 +830,7 @@ unsafe extern "C" fn tty_keys_add1(
 }
 
 /// Initialise a key tree from the table.
-pub unsafe extern "C" fn tty_keys_build(tty: *mut tty) {
+pub unsafe fn tty_keys_build(tty: *mut tty) {
     unsafe {
         let mut copy: [c_char; 16] = [0; 16];
 
@@ -887,14 +887,14 @@ pub unsafe extern "C" fn tty_keys_build(tty: *mut tty) {
 }
 
 /// Free the entire key tree.
-pub unsafe extern "C" fn tty_keys_free(tty: *mut tty) {
+pub unsafe fn tty_keys_free(tty: *mut tty) {
     unsafe {
         tty_keys_free1((*tty).key_tree);
     }
 }
 
 /// Free a single key.
-unsafe extern "C" fn tty_keys_free1(tk: *mut tty_key) {
+unsafe fn tty_keys_free1(tk: *mut tty_key) {
     unsafe {
         if !(*tk).next.is_null() {
             tty_keys_free1((*tk).next);
@@ -910,7 +910,7 @@ unsafe extern "C" fn tty_keys_free1(tk: *mut tty_key) {
 }
 
 /// Lookup a key in the tree.
-pub unsafe extern "C" fn tty_keys_find(
+pub unsafe fn tty_keys_find(
     tty: *mut tty,
     buf: *const c_char,
     len: usize,
@@ -922,7 +922,7 @@ pub unsafe extern "C" fn tty_keys_find(
     }
 }
 
-unsafe extern "C" fn tty_keys_find1(
+unsafe fn tty_keys_find1(
     mut tk: *mut tty_key,
     mut buf: *const c_char,
     mut len: usize,
@@ -964,7 +964,7 @@ unsafe extern "C" fn tty_keys_find1(
     }
 }
 
-unsafe extern "C" fn tty_keys_next1(
+unsafe fn tty_keys_next1(
     tty: *mut tty,
     buf: *const c_char,
     len: usize,
@@ -1033,7 +1033,7 @@ unsafe extern "C" fn tty_keys_next1(
 
 /* Process at least one key in the buffer. Return 0 if no keys present. */
 
-pub unsafe extern "C" fn tty_keys_next(tty: *mut tty) -> i32 {
+pub unsafe fn tty_keys_next(tty: *mut tty) -> i32 {
     unsafe {
         let c = (*tty).client;
         let mut tv: timeval = zeroed();
@@ -1356,7 +1356,7 @@ pub unsafe extern "C" fn tty_keys_next(tty: *mut tty) -> i32 {
 }
 
 /// Key timer callback.
-unsafe extern "C" fn tty_keys_callback(_fd: i32, _events: i16, data: *mut c_void) {
+unsafe fn tty_keys_callback(_fd: i32, _events: i16, data: *mut c_void) {
     let tty: *mut tty = data.cast();
 
     unsafe {
@@ -1369,7 +1369,7 @@ unsafe extern "C" fn tty_keys_callback(_fd: i32, _events: i16, data: *mut c_void
 /// Handle extended key input. This has two forms: \x1b[27;m;k~ and \x1b[k;mu,
 /// where k is key as a number and m is a modifier. Returns 0 for success, -1
 /// for failure, 1 for partial;
-unsafe extern "C" fn tty_keys_extended_key(
+unsafe fn tty_keys_extended_key(
     tty: *mut tty,
     buf: *const c_char,
     len: usize,
@@ -1524,7 +1524,7 @@ unsafe extern "C" fn tty_keys_extended_key(
 /// Handle mouse key input. Returns 0 for success, -1 for failure, 1 for partial
 /// (probably a mouse sequence but need more data), -2 if an invalid mouse
 /// sequence.
-unsafe extern "C" fn tty_keys_mouse(
+unsafe fn tty_keys_mouse(
     tty: *mut tty,
     buf: *const c_char,
     len: usize,
@@ -1697,7 +1697,7 @@ unsafe extern "C" fn tty_keys_mouse(
  * partial.
  */
 
-unsafe extern "C" fn tty_keys_clipboard(
+unsafe fn tty_keys_clipboard(
     tty: *mut tty,
     mut buf: *const c_char,
     len: usize,
@@ -1831,7 +1831,7 @@ unsafe extern "C" fn tty_keys_clipboard(
  * failure, 1 for partial.
  */
 
-unsafe extern "C" fn tty_keys_device_attributes(
+unsafe fn tty_keys_device_attributes(
     tty: *mut tty,
     buf: *const c_char,
     len: usize,
@@ -1938,7 +1938,7 @@ unsafe extern "C" fn tty_keys_device_attributes(
  * failure, 1 for partial.
  */
 
-unsafe extern "C" fn tty_keys_device_attributes2(
+unsafe fn tty_keys_device_attributes2(
     tty: *mut tty,
     buf: *const c_char,
     len: usize,
@@ -2050,7 +2050,7 @@ unsafe extern "C" fn tty_keys_device_attributes2(
  * failure, 1 for partial.
  */
 
-unsafe extern "C" fn tty_keys_extended_device_attributes(
+unsafe fn tty_keys_extended_device_attributes(
     tty: *mut tty,
     buf: *const c_char,
     len: usize,
@@ -2139,7 +2139,7 @@ unsafe extern "C" fn tty_keys_extended_device_attributes(
  * failure, 1 for partial.
  */
 
-pub unsafe extern "C" fn tty_keys_colours(
+pub unsafe fn tty_keys_colours(
     tty: *mut tty,
     buf: *const c_char,
     len: usize,

--- a/src/tty_keys.rs
+++ b/src/tty_keys.rs
@@ -1356,7 +1356,7 @@ pub unsafe fn tty_keys_next(tty: *mut tty) -> i32 {
 }
 
 /// Key timer callback.
-unsafe fn tty_keys_callback(_fd: i32, _events: i16, data: *mut c_void) {
+unsafe extern "C" fn tty_keys_callback(_fd: i32, _events: i16, data: *mut c_void) {
     let tty: *mut tty = data.cast();
 
     unsafe {

--- a/src/tty_term_.rs
+++ b/src/tty_term_.rs
@@ -475,11 +475,11 @@ static tty_term_codes: [tty_term_code_entry; 232] = const {
     tmp
 };
 
-pub const unsafe extern "C" fn tty_term_ncodes() -> u32 {
+pub const unsafe fn tty_term_ncodes() -> u32 {
     tty_term_codes.len() as u32
 }
 
-pub unsafe extern "C" fn tty_term_strip(s: *const c_char) -> *mut c_char {
+pub unsafe fn tty_term_strip(s: *const c_char) -> *mut c_char {
     let sizeof_buf: usize = 8192;
     static mut buf: [c_char; 8192] = [0; 8192];
 
@@ -521,7 +521,7 @@ pub unsafe extern "C" fn tty_term_strip(s: *const c_char) -> *mut c_char {
     }
 }
 
-pub unsafe extern "C" fn tty_term_override_next(
+pub unsafe fn tty_term_override_next(
     s: *const c_char,
     offset: *mut usize,
 ) -> *mut c_char {
@@ -564,7 +564,7 @@ pub unsafe extern "C" fn tty_term_override_next(
     }
 }
 
-pub unsafe extern "C" fn tty_term_apply(
+pub unsafe fn tty_term_apply(
     term: *mut tty_term,
     capabilities: *const c_char,
     quiet: i32,
@@ -653,7 +653,7 @@ pub unsafe extern "C" fn tty_term_apply(
     }
 }
 
-pub unsafe extern "C" fn tty_term_apply_overrides(term: *mut tty_term) {
+pub unsafe fn tty_term_apply_overrides(term: *mut tty_term) {
     let mut ov: *mut options_value = null_mut();
     let mut s: *const c_char = null();
     let mut acs: *const c_char = null();
@@ -770,7 +770,7 @@ pub unsafe extern "C" fn tty_term_apply_overrides(term: *mut tty_term) {
     }
 }
 
-pub unsafe extern "C" fn tty_term_create(
+pub unsafe fn tty_term_create(
     tty: *mut tty,
     name: *mut c_char,
     caps: *mut *mut c_char,
@@ -925,7 +925,7 @@ pub unsafe extern "C" fn tty_term_create(
     }
 }
 
-pub unsafe extern "C" fn tty_term_free(term: *mut tty_term) {
+pub unsafe fn tty_term_free(term: *mut tty_term) {
     unsafe {
         log_debug!("removing term {}", _s((*term).name));
 
@@ -942,7 +942,7 @@ pub unsafe extern "C" fn tty_term_free(term: *mut tty_term) {
     }
 }
 
-pub unsafe extern "C" fn tty_term_read_list(
+pub unsafe fn tty_term_read_list(
     name: *const c_char,
     fd: i32,
     caps: *mut *mut *mut c_char,
@@ -1017,7 +1017,7 @@ pub unsafe extern "C" fn tty_term_read_list(
     }
 }
 
-pub unsafe extern "C" fn tty_term_free_list(caps: *mut *mut c_char, ncaps: u32) {
+pub unsafe fn tty_term_free_list(caps: *mut *mut c_char, ncaps: u32) {
     unsafe {
         for i in 0..ncaps {
             free_(*caps.add(i as usize));
@@ -1026,11 +1026,11 @@ pub unsafe extern "C" fn tty_term_free_list(caps: *mut *mut c_char, ncaps: u32) 
     }
 }
 
-pub unsafe extern "C" fn tty_term_has(term: *mut tty_term, code: tty_code_code) -> bool {
+pub unsafe fn tty_term_has(term: *mut tty_term, code: tty_code_code) -> bool {
     unsafe { (*(*term).codes.add(code as usize)).type_ != tty_code_type::None }
 }
 
-pub unsafe extern "C" fn tty_term_string(
+pub unsafe fn tty_term_string(
     term: *mut tty_term,
     code: tty_code_code,
 ) -> *const c_char {
@@ -1045,7 +1045,7 @@ pub unsafe extern "C" fn tty_term_string(
     }
 }
 
-pub unsafe extern "C" fn tty_term_string_i(
+pub unsafe fn tty_term_string_i(
     term: *mut tty_term,
     code: tty_code_code,
     a: i32,
@@ -1071,7 +1071,7 @@ pub unsafe extern "C" fn tty_term_string_i(
     }
 }
 
-pub unsafe extern "C" fn tty_term_string_ii(
+pub unsafe fn tty_term_string_ii(
     term: *mut tty_term,
     code: tty_code_code,
     a: i32,
@@ -1100,7 +1100,7 @@ pub unsafe extern "C" fn tty_term_string_ii(
     }
 }
 
-pub unsafe extern "C" fn tty_term_string_iii(
+pub unsafe fn tty_term_string_iii(
     term: *mut tty_term,
     code: tty_code_code,
     a: i32,
@@ -1129,7 +1129,7 @@ pub unsafe extern "C" fn tty_term_string_iii(
     }
 }
 
-pub unsafe extern "C" fn tty_term_string_s(
+pub unsafe fn tty_term_string_s(
     term: *mut tty_term,
     code: tty_code_code,
     a: *const c_char,
@@ -1157,7 +1157,7 @@ pub unsafe extern "C" fn tty_term_string_s(
     }
 }
 
-pub unsafe extern "C" fn tty_term_string_ss(
+pub unsafe fn tty_term_string_ss(
     term: *mut tty_term,
     code: tty_code_code,
     a: *const c_char,
@@ -1187,7 +1187,7 @@ pub unsafe extern "C" fn tty_term_string_ss(
     }
 }
 
-pub unsafe extern "C" fn tty_term_number(term: *mut tty_term, code: tty_code_code) -> i32 {
+pub unsafe fn tty_term_number(term: *mut tty_term, code: tty_code_code) -> i32 {
     unsafe {
         if !tty_term_has(term, code) {
             return 0;
@@ -1199,7 +1199,7 @@ pub unsafe extern "C" fn tty_term_number(term: *mut tty_term, code: tty_code_cod
     }
 }
 
-pub unsafe extern "C" fn tty_term_flag(term: *mut tty_term, code: tty_code_code) -> i32 {
+pub unsafe fn tty_term_flag(term: *mut tty_term, code: tty_code_code) -> i32 {
     unsafe {
         if !tty_term_has(term, code) {
             return 0;
@@ -1211,7 +1211,7 @@ pub unsafe extern "C" fn tty_term_flag(term: *mut tty_term, code: tty_code_code)
     }
 }
 
-pub unsafe extern "C" fn tty_term_describe(
+pub unsafe fn tty_term_describe(
     term: *mut tty_term,
     code: tty_code_code,
 ) -> *const c_char {

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -59,7 +59,7 @@ pub struct utf8_item {
     pub size: c_uchar,
 }
 
-pub unsafe extern "C" fn utf8_data_cmp(
+pub unsafe fn utf8_data_cmp(
     ui1: *const utf8_item,
     ui2: *const utf8_item,
 ) -> std::cmp::Ordering {
@@ -83,7 +83,7 @@ RB_GENERATE!(
 );
 static mut utf8_data_tree: utf8_data_tree = rb_initializer();
 
-pub unsafe extern "C" fn utf8_index_cmp(
+pub unsafe fn utf8_index_cmp(
     ui1: *const utf8_item,
     ui2: *const utf8_item,
 ) -> std::cmp::Ordering {
@@ -198,7 +198,7 @@ pub unsafe fn utf8_in_table(find: wchar_t, table: *const wchar_t, count: u32) ->
     }
 }
 
-pub unsafe extern "C" fn utf8_from_data(ud: *const utf8_data, uc: *mut utf8_char) -> utf8_state {
+pub unsafe fn utf8_from_data(ud: *const utf8_data, uc: *mut utf8_char) -> utf8_state {
     unsafe {
         let mut index: u32 = 0;
         'fail: {
@@ -245,7 +245,7 @@ pub unsafe extern "C" fn utf8_from_data(ud: *const utf8_data, uc: *mut utf8_char
     }
 }
 
-pub unsafe extern "C" fn utf8_to_data(uc: utf8_char, ud: *mut utf8_data) {
+pub unsafe fn utf8_to_data(uc: utf8_char, ud: *mut utf8_data) {
     unsafe {
         core::ptr::write(ud, zeroed());
         (*ud).size = utf8_get_size(uc);
@@ -285,11 +285,11 @@ pub unsafe extern "C" fn utf8_to_data(uc: utf8_char, ud: *mut utf8_data) {
     }
 }
 
-pub extern "C" fn utf8_build_one(ch: c_uchar) -> u32 {
+pub fn utf8_build_one(ch: c_uchar) -> u32 {
     utf8_set_size(1) | utf8_set_width(1) | ch as u32
 }
 
-pub unsafe extern "C" fn utf8_set(ud: *mut utf8_data, ch: c_uchar) {
+pub unsafe fn utf8_set(ud: *mut utf8_data, ch: c_uchar) {
     static empty: utf8_data = utf8_data {
         data: unsafe { zeroed() },
         have: 1,
@@ -303,7 +303,7 @@ pub unsafe extern "C" fn utf8_set(ud: *mut utf8_data, ch: c_uchar) {
     }
 }
 
-pub unsafe extern "C" fn utf8_copy(to: *mut utf8_data, from: *const utf8_data) {
+pub unsafe fn utf8_copy(to: *mut utf8_data, from: *const utf8_data) {
     unsafe {
         memcpy__(to, from);
 
@@ -313,7 +313,7 @@ pub unsafe extern "C" fn utf8_copy(to: *mut utf8_data, from: *const utf8_data) {
     }
 }
 
-pub unsafe extern "C" fn utf8_width(ud: *mut utf8_data, width: *mut i32) -> utf8_state {
+pub unsafe fn utf8_width(ud: *mut utf8_data, width: *mut i32) -> utf8_state {
     unsafe {
         let mut wc: wchar_t = 0;
 
@@ -348,7 +348,7 @@ pub unsafe extern "C" fn utf8_width(ud: *mut utf8_data, width: *mut i32) -> utf8
     }
 }
 
-pub unsafe extern "C" fn utf8_towc(ud: *const utf8_data, wc: *mut wchar_t) -> utf8_state {
+pub unsafe fn utf8_towc(ud: *const utf8_data, wc: *mut wchar_t) -> utf8_state {
     unsafe {
         #[cfg(feature = "utf8proc")]
         let value = utf8proc_mbtowc(wc, (*ud).data.as_ptr().cast(), (*ud).size as usize);
@@ -380,7 +380,7 @@ pub unsafe extern "C" fn utf8_towc(ud: *const utf8_data, wc: *mut wchar_t) -> ut
     utf8_state::UTF8_DONE
 }
 
-pub unsafe extern "C" fn utf8_fromwc(wc: wchar_t, ud: *mut utf8_data) -> utf8_state {
+pub unsafe fn utf8_fromwc(wc: wchar_t, ud: *mut utf8_data) -> utf8_state {
     unsafe {
         let mut width: i32 = 0;
 
@@ -407,7 +407,7 @@ pub unsafe extern "C" fn utf8_fromwc(wc: wchar_t, ud: *mut utf8_data) -> utf8_st
     utf8_state::UTF8_ERROR
 }
 
-pub unsafe extern "C" fn utf8_open(ud: *mut utf8_data, ch: c_uchar) -> utf8_state {
+pub unsafe fn utf8_open(ud: *mut utf8_data, ch: c_uchar) -> utf8_state {
     unsafe {
         memset(ud.cast(), 0, size_of::<utf8_data>());
 
@@ -424,7 +424,7 @@ pub unsafe extern "C" fn utf8_open(ud: *mut utf8_data, ch: c_uchar) -> utf8_stat
     utf8_state::UTF8_MORE
 }
 
-pub unsafe extern "C" fn utf8_append(ud: *mut utf8_data, ch: c_uchar) -> utf8_state {
+pub unsafe fn utf8_append(ud: *mut utf8_data, ch: c_uchar) -> utf8_state {
     unsafe {
         let mut width: i32 = 0;
 
@@ -456,7 +456,7 @@ pub unsafe extern "C" fn utf8_append(ud: *mut utf8_data, ch: c_uchar) -> utf8_st
     utf8_state::UTF8_DONE
 }
 
-pub unsafe extern "C" fn utf8_strvis(
+pub unsafe fn utf8_strvis(
     mut dst: *mut c_char,
     mut src: *const c_char,
     len: usize,
@@ -508,7 +508,7 @@ pub unsafe extern "C" fn utf8_strvis(
     }
 }
 
-pub unsafe extern "C" fn utf8_stravis(
+pub unsafe fn utf8_stravis(
     dst: *mut *mut c_char,
     src: *const c_char,
     flag: vis_flags,
@@ -522,7 +522,7 @@ pub unsafe extern "C" fn utf8_stravis(
     }
 }
 
-pub unsafe extern "C" fn utf8_stravisx(
+pub unsafe fn utf8_stravisx(
     dst: *mut *mut c_char,
     src: *const c_char,
     srclen: usize,

--- a/src/utf8_combined.rs
+++ b/src/utf8_combined.rs
@@ -24,7 +24,7 @@ static utf8_modifier_table: [wchar_t; 31] = [
     0x1F3FF,
 ];
 
-pub unsafe extern "C" fn utf8_has_zwj(ud: *const utf8_data) -> i32 {
+pub unsafe fn utf8_has_zwj(ud: *const utf8_data) -> i32 {
     unsafe {
         if (*ud).size < 3 {
             return 0;
@@ -37,7 +37,7 @@ pub unsafe extern "C" fn utf8_has_zwj(ud: *const utf8_data) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn utf8_is_zwj(ud: *const utf8_data) -> i32 {
+pub unsafe fn utf8_is_zwj(ud: *const utf8_data) -> i32 {
     unsafe {
         if (*ud).size != 3 {
             return 0;
@@ -50,7 +50,7 @@ pub unsafe extern "C" fn utf8_is_zwj(ud: *const utf8_data) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn utf8_is_vs(ud: *const utf8_data) -> i32 {
+pub unsafe fn utf8_is_vs(ud: *const utf8_data) -> i32 {
     unsafe {
         if (*ud).size != 3 {
             return 0;
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn utf8_is_vs(ud: *const utf8_data) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn utf8_is_modifier(ud: *const utf8_data) -> i32 {
+pub unsafe fn utf8_is_modifier(ud: *const utf8_data) -> i32 {
     let mut wc: wchar_t = 0;
     unsafe {
         if utf8_towc(ud, &raw mut wc) != utf8_state::UTF8_DONE {

--- a/src/window_.rs
+++ b/src/window_.rs
@@ -1117,7 +1117,7 @@ unsafe fn window_pane_destroy(wp: *mut window_pane) {
     }
 }
 
-unsafe fn window_pane_read_callback(_bufev: *mut bufferevent, data: *mut c_void) {
+unsafe extern "C" fn window_pane_read_callback(_bufev: *mut bufferevent, data: *mut c_void) {
     unsafe {
         let wp: *mut window_pane = data as _;
         let evb: *mut evbuffer = (*(*wp).event).input;
@@ -1144,7 +1144,7 @@ unsafe fn window_pane_read_callback(_bufev: *mut bufferevent, data: *mut c_void)
     }
 }
 
-unsafe fn window_pane_error_callback(
+unsafe extern "C" fn window_pane_error_callback(
     _bufev: *mut bufferevent,
     _what: c_short,
     data: *mut c_void,

--- a/src/window_.rs
+++ b/src/window_.rs
@@ -59,22 +59,22 @@ RB_GENERATE!(
     window_pane_cmp
 );
 
-pub unsafe extern "C" fn window_cmp(w1: *const window, w2: *const window) -> Ordering {
+pub unsafe fn window_cmp(w1: *const window, w2: *const window) -> Ordering {
     unsafe { (*w1).id.cmp(&(*w2).id) }
 }
 
-pub unsafe extern "C" fn winlink_cmp(wl1: *const winlink, wl2: *const winlink) -> Ordering {
+pub unsafe fn winlink_cmp(wl1: *const winlink, wl2: *const winlink) -> Ordering {
     unsafe { (*wl1).idx.cmp(&(*wl2).idx) }
 }
 
-pub unsafe extern "C" fn window_pane_cmp(
+pub unsafe fn window_pane_cmp(
     wp1: *const window_pane,
     wp2: *const window_pane,
 ) -> Ordering {
     unsafe { (*wp1).id.cmp(&(*wp2).id) }
 }
 
-pub unsafe extern "C" fn winlink_find_by_window(
+pub unsafe fn winlink_find_by_window(
     wwl: *mut winlinks,
     w: *mut window,
 ) -> Option<NonNull<winlink>> {
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn winlink_find_by_window(
     }
 }
 
-pub unsafe extern "C" fn winlink_find_by_index(wwl: *mut winlinks, idx: i32) -> *mut winlink {
+pub unsafe fn winlink_find_by_index(wwl: *mut winlinks, idx: i32) -> *mut winlink {
     unsafe {
         if idx < 0 {
             fatalx(c"bad index");
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn winlink_find_by_index(wwl: *mut winlinks, idx: i32) -> 
     }
 }
 
-pub unsafe extern "C" fn winlink_find_by_window_id(wwl: *mut winlinks, id: u32) -> *mut winlink {
+pub unsafe fn winlink_find_by_window_id(wwl: *mut winlinks, id: u32) -> *mut winlink {
     unsafe {
         for wl in rb_foreach(wwl).map(NonNull::as_ptr) {
             if (*(*wl).window).id == id {
@@ -113,7 +113,7 @@ pub unsafe extern "C" fn winlink_find_by_window_id(wwl: *mut winlinks, id: u32) 
     }
 }
 
-unsafe extern "C" fn winlink_next_index(wwl: *mut winlinks, idx: i32) -> i32 {
+unsafe fn winlink_next_index(wwl: *mut winlinks, idx: i32) -> i32 {
     let mut i = idx;
 
     loop {
@@ -135,11 +135,11 @@ unsafe extern "C" fn winlink_next_index(wwl: *mut winlinks, idx: i32) -> i32 {
     -1
 }
 
-pub unsafe extern "C" fn winlink_count(wwl: *mut winlinks) -> u32 {
+pub unsafe fn winlink_count(wwl: *mut winlinks) -> u32 {
     unsafe { rb_foreach(wwl).count() as u32 }
 }
 
-pub unsafe extern "C" fn winlink_add(wwl: *mut winlinks, mut idx: i32) -> *mut winlink {
+pub unsafe fn winlink_add(wwl: *mut winlinks, mut idx: i32) -> *mut winlink {
     unsafe {
         if idx < 0 {
             idx = winlink_next_index(wwl, -idx - 1);
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn winlink_add(wwl: *mut winlinks, mut idx: i32) -> *mut w
     }
 }
 
-pub unsafe extern "C" fn winlink_set_window(wl: *mut winlink, w: *mut window) {
+pub unsafe fn winlink_set_window(wl: *mut winlink, w: *mut window) {
     unsafe {
         if !(*wl).window.is_null() {
             tailq_remove::<_, discr_wentry>(&raw mut (*(*wl).window).winlinks, wl);
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn winlink_set_window(wl: *mut winlink, w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn winlink_remove(wwl: *mut winlinks, wl: *mut winlink) {
+pub unsafe fn winlink_remove(wwl: *mut winlinks, wl: *mut winlink) {
     unsafe {
         let w = (*wl).window;
 
@@ -184,15 +184,15 @@ pub unsafe extern "C" fn winlink_remove(wwl: *mut winlinks, wl: *mut winlink) {
     }
 }
 
-pub unsafe extern "C" fn winlink_next(wl: *mut winlink) -> *mut winlink {
+pub unsafe fn winlink_next(wl: *mut winlink) -> *mut winlink {
     unsafe { rb_next(wl) }
 }
 
-pub unsafe extern "C" fn winlink_previous(wl: *mut winlink) -> *mut winlink {
+pub unsafe fn winlink_previous(wl: *mut winlink) -> *mut winlink {
     unsafe { rb_prev(wl) }
 }
 
-pub unsafe extern "C" fn winlink_next_by_number(
+pub unsafe fn winlink_next_by_number(
     mut wl: *mut winlink,
     s: *mut session,
     n: i32,
@@ -209,7 +209,7 @@ pub unsafe extern "C" fn winlink_next_by_number(
     wl
 }
 
-pub unsafe extern "C" fn winlink_previous_by_number(
+pub unsafe fn winlink_previous_by_number(
     mut wl: *mut winlink,
     s: *mut session,
     n: i32,
@@ -226,7 +226,7 @@ pub unsafe extern "C" fn winlink_previous_by_number(
     wl
 }
 
-pub unsafe extern "C" fn winlink_stack_push(stack: *mut winlink_stack, wl: *mut winlink) {
+pub unsafe fn winlink_stack_push(stack: *mut winlink_stack, wl: *mut winlink) {
     if wl.is_null() {
         return;
     }
@@ -238,7 +238,7 @@ pub unsafe extern "C" fn winlink_stack_push(stack: *mut winlink_stack, wl: *mut 
     }
 }
 
-pub unsafe extern "C" fn winlink_stack_remove(stack: *mut winlink_stack, wl: *mut winlink) {
+pub unsafe fn winlink_stack_remove(stack: *mut winlink_stack, wl: *mut winlink) {
     unsafe {
         if !wl.is_null() && (*wl).flags.intersects(winlink_flags::WINLINK_VISITED) {
             tailq_remove::<_, discr_sentry>(stack, wl);
@@ -247,7 +247,7 @@ pub unsafe extern "C" fn winlink_stack_remove(stack: *mut winlink_stack, wl: *mu
     }
 }
 
-pub unsafe extern "C" fn window_find_by_id_str(s: *const c_char) -> *mut window {
+pub unsafe fn window_find_by_id_str(s: *const c_char) -> *mut window {
     unsafe {
         let mut errstr: *const c_char = null_mut();
 
@@ -263,7 +263,7 @@ pub unsafe extern "C" fn window_find_by_id_str(s: *const c_char) -> *mut window 
     }
 }
 
-pub unsafe extern "C" fn window_find_by_id(id: u32) -> *mut window {
+pub unsafe fn window_find_by_id(id: u32) -> *mut window {
     unsafe {
         let mut w: window = std::mem::zeroed();
 
@@ -272,14 +272,14 @@ pub unsafe extern "C" fn window_find_by_id(id: u32) -> *mut window {
     }
 }
 
-pub unsafe extern "C" fn window_update_activity(w: NonNull<window>) {
+pub unsafe fn window_update_activity(w: NonNull<window>) {
     unsafe {
         gettimeofday(&raw mut (*w.as_ptr()).activity_time, null_mut());
         alerts_queue(w, window_flag::ACTIVITY);
     }
 }
 
-pub unsafe extern "C" fn window_create(
+pub unsafe fn window_create(
     sx: u32,
     sy: u32,
     mut xpixel: u32,
@@ -335,7 +335,7 @@ pub unsafe extern "C" fn window_create(
     }
 }
 
-unsafe extern "C" fn window_destroy(w: *mut window) {
+unsafe fn window_destroy(w: *mut window) {
     unsafe {
         log_debug!(
             "window @{} destroyed ({} references)",
@@ -375,7 +375,7 @@ unsafe extern "C" fn window_destroy(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn window_pane_destroy_ready(wp: *mut window_pane) -> i32 {
+pub unsafe fn window_pane_destroy_ready(wp: *mut window_pane) -> i32 {
     let mut n = 0;
     unsafe {
         if (*wp).pipe_fd != -1 {
@@ -395,7 +395,7 @@ pub unsafe extern "C" fn window_pane_destroy_ready(wp: *mut window_pane) -> i32 
     1
 }
 
-pub unsafe extern "C" fn window_add_ref(w: *mut window, from: *const c_char) {
+pub unsafe fn window_add_ref(w: *mut window, from: *const c_char) {
     unsafe {
         (*w).references += 1;
         log_debug!(
@@ -408,7 +408,7 @@ pub unsafe extern "C" fn window_add_ref(w: *mut window, from: *const c_char) {
     }
 }
 
-pub unsafe extern "C" fn window_remove_ref(w: *mut window, from: *const c_char) {
+pub unsafe fn window_remove_ref(w: *mut window, from: *const c_char) {
     unsafe {
         (*w).references -= 1;
         log_debug!(
@@ -425,7 +425,7 @@ pub unsafe extern "C" fn window_remove_ref(w: *mut window, from: *const c_char) 
     }
 }
 
-pub unsafe extern "C" fn window_set_name(w: *mut window, new_name: *const c_char) {
+pub unsafe fn window_set_name(w: *mut window, new_name: *const c_char) {
     unsafe {
         free_((*w).name);
         utf8_stravis(
@@ -437,7 +437,7 @@ pub unsafe extern "C" fn window_set_name(w: *mut window, new_name: *const c_char
     }
 }
 
-pub unsafe extern "C" fn window_resize(
+pub unsafe fn window_resize(
     w: *mut window,
     sx: u32,
     sy: u32,
@@ -481,7 +481,7 @@ pub unsafe extern "C" fn window_resize(
     }
 }
 
-pub unsafe extern "C" fn window_pane_send_resize(wp: *mut window_pane, sx: u32, sy: u32) {
+pub unsafe fn window_pane_send_resize(wp: *mut window_pane, sx: u32, sy: u32) {
     unsafe {
         let w = (*wp).window;
         let mut ws: winsize = core::mem::zeroed();
@@ -513,11 +513,11 @@ pub unsafe extern "C" fn window_pane_send_resize(wp: *mut window_pane, sx: u32, 
     }
 }
 
-pub unsafe extern "C" fn window_has_pane(w: *mut window, wp: *mut window_pane) -> bool {
+pub unsafe fn window_has_pane(w: *mut window, wp: *mut window_pane) -> bool {
     unsafe { tailq_foreach::<_, discr_entry>(&raw mut (*w).panes).any(|wp1| wp1.as_ptr() == wp) }
 }
 
-pub unsafe extern "C" fn window_update_focus(w: *mut window) {
+pub unsafe fn window_update_focus(w: *mut window) {
     unsafe {
         if !w.is_null() {
             log_debug!("{}: @{}", "window_update_focus", (*w).id);
@@ -526,7 +526,7 @@ pub unsafe extern "C" fn window_update_focus(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn window_pane_update_focus(wp: *mut window_pane) {
+pub unsafe fn window_pane_update_focus(wp: *mut window_pane) {
     unsafe {
         let mut focused = false;
 
@@ -570,7 +570,7 @@ pub unsafe extern "C" fn window_pane_update_focus(wp: *mut window_pane) {
     }
 }
 
-pub unsafe extern "C" fn window_set_active_pane(
+pub unsafe fn window_set_active_pane(
     w: *mut window,
     wp: *mut window_pane,
     notify: i32,
@@ -606,7 +606,7 @@ pub unsafe extern "C" fn window_set_active_pane(
     1
 }
 
-unsafe extern "C" fn window_pane_get_palette(wp: *mut window_pane, c: i32) -> i32 {
+unsafe fn window_pane_get_palette(wp: *mut window_pane, c: i32) -> i32 {
     if wp.is_null() {
         -1
     } else {
@@ -614,7 +614,7 @@ unsafe extern "C" fn window_pane_get_palette(wp: *mut window_pane, c: i32) -> i3
     }
 }
 
-pub unsafe extern "C" fn window_redraw_active_switch(w: *mut window, mut wp: *mut window_pane) {
+pub unsafe fn window_redraw_active_switch(w: *mut window, mut wp: *mut window_pane) {
     unsafe {
         if wp == (*w).active {
             return;
@@ -650,7 +650,7 @@ pub unsafe extern "C" fn window_redraw_active_switch(w: *mut window, mut wp: *mu
     }
 }
 
-pub unsafe extern "C" fn window_get_active_at(w: *mut window, x: u32, y: u32) -> *mut window_pane {
+pub unsafe fn window_get_active_at(w: *mut window, x: u32, y: u32) -> *mut window_pane {
     unsafe {
         for wp in tailq_foreach::<_, discr_entry>(&raw mut (*w).panes).map(NonNull::as_ptr) {
             if window_pane_visible(wp) != 0 {
@@ -668,7 +668,7 @@ pub unsafe extern "C" fn window_get_active_at(w: *mut window, x: u32, y: u32) ->
     }
 }
 
-pub unsafe extern "C" fn window_find_string(w: *mut window, s: *const c_char) -> *mut window_pane {
+pub unsafe fn window_find_string(w: *mut window, s: *const c_char) -> *mut window_pane {
     unsafe {
         let mut top: u32 = 0;
         let mut bottom: u32 = (*w).sy - 1;
@@ -712,7 +712,7 @@ pub unsafe extern "C" fn window_find_string(w: *mut window, s: *const c_char) ->
     }
 }
 
-pub unsafe extern "C" fn window_zoom(wp: *mut window_pane) -> i32 {
+pub unsafe fn window_zoom(wp: *mut window_pane) -> i32 {
     unsafe {
         let w = (*wp).window;
 
@@ -742,7 +742,7 @@ pub unsafe extern "C" fn window_zoom(wp: *mut window_pane) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn window_unzoom(w: *mut window, notify: i32) -> i32 {
+pub unsafe fn window_unzoom(w: *mut window, notify: i32) -> i32 {
     unsafe {
         if !(*w).flags.intersects(window_flag::ZOOMED) {
             return -1;
@@ -767,7 +767,7 @@ pub unsafe extern "C" fn window_unzoom(w: *mut window, notify: i32) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn window_push_zoom(w: *mut window, always: i32, flag: i32) -> i32 {
+pub unsafe fn window_push_zoom(w: *mut window, always: i32, flag: i32) -> i32 {
     unsafe {
         log_debug!(
             "{}: @{} {}",
@@ -785,7 +785,7 @@ pub unsafe extern "C" fn window_push_zoom(w: *mut window, always: i32, flag: i32
     }
 }
 
-pub unsafe extern "C" fn window_pop_zoom(w: *mut window) -> i32 {
+pub unsafe fn window_pop_zoom(w: *mut window) -> i32 {
     unsafe {
         log_debug!(
             "{}: @{} {}",
@@ -801,7 +801,7 @@ pub unsafe extern "C" fn window_pop_zoom(w: *mut window) -> i32 {
     0
 }
 
-pub unsafe extern "C" fn window_add_pane(
+pub unsafe fn window_add_pane(
     w: *mut window,
     mut other: *mut window_pane,
     hlimit: u32,
@@ -837,7 +837,7 @@ pub unsafe extern "C" fn window_add_pane(
     }
 }
 
-pub unsafe extern "C" fn window_lost_pane(w: *mut window, wp: *mut window_pane) {
+pub unsafe fn window_lost_pane(w: *mut window, wp: *mut window_pane) {
     unsafe {
         log_debug!("{}: @{} pane %%{}", "window_lost_pane", (*w).id, (*wp).id);
 
@@ -864,7 +864,7 @@ pub unsafe extern "C" fn window_lost_pane(w: *mut window, wp: *mut window_pane) 
     }
 }
 
-pub unsafe extern "C" fn window_remove_pane(w: *mut window, wp: *mut window_pane) {
+pub unsafe fn window_remove_pane(w: *mut window, wp: *mut window_pane) {
     unsafe {
         window_lost_pane(w, wp);
 
@@ -873,7 +873,7 @@ pub unsafe extern "C" fn window_remove_pane(w: *mut window, wp: *mut window_pane
     }
 }
 
-pub unsafe extern "C" fn window_pane_at_index(w: *mut window, idx: u32) -> *mut window_pane {
+pub unsafe fn window_pane_at_index(w: *mut window, idx: u32) -> *mut window_pane {
     unsafe {
         let mut n: u32 = options_get_number_((*w).options, c"pane-base-index") as _;
 
@@ -888,7 +888,7 @@ pub unsafe extern "C" fn window_pane_at_index(w: *mut window, idx: u32) -> *mut 
     }
 }
 
-pub unsafe extern "C" fn window_pane_next_by_number(
+pub unsafe fn window_pane_next_by_number(
     w: *mut window,
     mut wp: *mut window_pane,
     n: u32,
@@ -905,7 +905,7 @@ pub unsafe extern "C" fn window_pane_next_by_number(
     wp
 }
 
-pub unsafe extern "C" fn window_pane_previous_by_number(
+pub unsafe fn window_pane_previous_by_number(
     w: *mut window,
     mut wp: *mut window_pane,
     n: u32,
@@ -922,7 +922,7 @@ pub unsafe extern "C" fn window_pane_previous_by_number(
     wp
 }
 
-pub unsafe extern "C" fn window_pane_index(wp: *mut window_pane, i: *mut u32) -> i32 {
+pub unsafe fn window_pane_index(wp: *mut window_pane, i: *mut u32) -> i32 {
     unsafe {
         let w = (*wp).window;
 
@@ -937,11 +937,11 @@ pub unsafe extern "C" fn window_pane_index(wp: *mut window_pane, i: *mut u32) ->
     }
 }
 
-pub unsafe extern "C" fn window_count_panes(w: *mut window) -> u32 {
+pub unsafe fn window_count_panes(w: *mut window) -> u32 {
     unsafe { tailq_foreach::<_, discr_entry>(&raw mut (*w).panes).count() as u32 }
 }
 
-pub unsafe extern "C" fn window_destroy_panes(w: *mut window) {
+pub unsafe fn window_destroy_panes(w: *mut window) {
     let mut wp: *mut window_pane;
     unsafe {
         while !tailq_empty(&raw mut (*w).last_panes) {
@@ -957,7 +957,7 @@ pub unsafe extern "C" fn window_destroy_panes(w: *mut window) {
     }
 }
 
-pub unsafe extern "C" fn window_printable_flags(wl: *mut winlink, escape: i32) -> *const c_char {
+pub unsafe fn window_printable_flags(wl: *mut winlink, escape: i32) -> *const c_char {
     static mut flags: [c_char; 32] = [0; 32];
 
     unsafe {
@@ -1001,7 +1001,7 @@ pub unsafe extern "C" fn window_printable_flags(wl: *mut winlink, escape: i32) -
     }
 }
 
-pub unsafe extern "C" fn window_pane_find_by_id_str(s: *const c_char) -> *mut window_pane {
+pub unsafe fn window_pane_find_by_id_str(s: *const c_char) -> *mut window_pane {
     let mut errstr: *const c_char = null_mut();
     unsafe {
         if *s != b'%' as c_char {
@@ -1015,7 +1015,7 @@ pub unsafe extern "C" fn window_pane_find_by_id_str(s: *const c_char) -> *mut wi
     }
 }
 
-pub unsafe extern "C" fn window_pane_find_by_id(id: u32) -> *mut window_pane {
+pub unsafe fn window_pane_find_by_id(id: u32) -> *mut window_pane {
     unsafe {
         let mut wp: window_pane = zeroed();
         wp.id = id;
@@ -1023,7 +1023,7 @@ pub unsafe extern "C" fn window_pane_find_by_id(id: u32) -> *mut window_pane {
     }
 }
 
-pub unsafe extern "C" fn window_pane_create(
+pub unsafe fn window_pane_create(
     w: *mut window,
     sx: u32,
     sy: u32,
@@ -1072,7 +1072,7 @@ pub unsafe extern "C" fn window_pane_create(
     }
 }
 
-unsafe extern "C" fn window_pane_destroy(wp: *mut window_pane) {
+unsafe fn window_pane_destroy(wp: *mut window_pane) {
     unsafe {
         window_pane_reset_mode_all(wp);
         free((*wp).searchstr as _);
@@ -1117,7 +1117,7 @@ unsafe extern "C" fn window_pane_destroy(wp: *mut window_pane) {
     }
 }
 
-unsafe extern "C" fn window_pane_read_callback(_bufev: *mut bufferevent, data: *mut c_void) {
+unsafe fn window_pane_read_callback(_bufev: *mut bufferevent, data: *mut c_void) {
     unsafe {
         let wp: *mut window_pane = data as _;
         let evb: *mut evbuffer = (*(*wp).event).input;
@@ -1144,7 +1144,7 @@ unsafe extern "C" fn window_pane_read_callback(_bufev: *mut bufferevent, data: *
     }
 }
 
-unsafe extern "C" fn window_pane_error_callback(
+unsafe fn window_pane_error_callback(
     _bufev: *mut bufferevent,
     _what: c_short,
     data: *mut c_void,
@@ -1160,7 +1160,7 @@ unsafe extern "C" fn window_pane_error_callback(
     }
 }
 
-pub unsafe extern "C" fn window_pane_set_event(wp: *mut window_pane) {
+pub unsafe fn window_pane_set_event(wp: *mut window_pane) {
     unsafe {
         setblocking((*wp).fd, 0);
 
@@ -1180,7 +1180,7 @@ pub unsafe extern "C" fn window_pane_set_event(wp: *mut window_pane) {
     }
 }
 
-pub unsafe extern "C" fn window_pane_resize(wp: *mut window_pane, sx: u32, sy: u32) {
+pub unsafe fn window_pane_resize(wp: *mut window_pane, sx: u32, sy: u32) {
     unsafe {
         if sx == (*wp).sx && sy == (*wp).sy {
             return;
@@ -1218,7 +1218,7 @@ pub unsafe extern "C" fn window_pane_resize(wp: *mut window_pane, sx: u32, sy: u
     }
 }
 
-pub unsafe extern "C" fn window_pane_set_mode(
+pub unsafe fn window_pane_set_mode(
     wp: *mut window_pane,
     swp: *mut window_pane,
     mode: *const window_mode,
@@ -1262,7 +1262,7 @@ pub unsafe extern "C" fn window_pane_set_mode(
     }
 }
 
-pub unsafe extern "C" fn window_pane_reset_mode(wp: *mut window_pane) {
+pub unsafe fn window_pane_reset_mode(wp: *mut window_pane) {
     let func = "window_pane_reset_mode";
     unsafe {
         if tailq_empty(&raw mut (*wp).modes) {
@@ -1297,7 +1297,7 @@ pub unsafe extern "C" fn window_pane_reset_mode(wp: *mut window_pane) {
     }
 }
 
-pub unsafe extern "C" fn window_pane_reset_mode_all(wp: *mut window_pane) {
+pub unsafe fn window_pane_reset_mode_all(wp: *mut window_pane) {
     unsafe {
         while !tailq_empty(&raw mut (*wp).modes) {
             window_pane_reset_mode(wp);
@@ -1305,7 +1305,7 @@ pub unsafe extern "C" fn window_pane_reset_mode_all(wp: *mut window_pane) {
     }
 }
 
-unsafe extern "C" fn window_pane_copy_key(wp: *mut window_pane, key: key_code) {
+unsafe fn window_pane_copy_key(wp: *mut window_pane, key: key_code) {
     unsafe {
         for loop_ in
             tailq_foreach::<_, discr_entry>(&raw mut (*(*wp).window).panes).map(NonNull::as_ptr)
@@ -1323,7 +1323,7 @@ unsafe extern "C" fn window_pane_copy_key(wp: *mut window_pane, key: key_code) {
     }
 }
 
-pub unsafe extern "C" fn window_pane_key(
+pub unsafe fn window_pane_key(
     wp: *mut window_pane,
     c: *mut client,
     s: *mut session,
@@ -1363,7 +1363,7 @@ pub unsafe extern "C" fn window_pane_key(
     0
 }
 
-pub unsafe extern "C" fn window_pane_visible(wp: *mut window_pane) -> i32 {
+pub unsafe fn window_pane_visible(wp: *mut window_pane) -> i32 {
     unsafe {
         if !(*(*wp).window).flags.intersects(window_flag::ZOOMED) {
             return 1;
@@ -1372,7 +1372,7 @@ pub unsafe extern "C" fn window_pane_visible(wp: *mut window_pane) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn window_pane_exited(wp: *mut window_pane) -> i32 {
+pub unsafe fn window_pane_exited(wp: *mut window_pane) -> i32 {
     unsafe {
         if (*wp).fd == -1 || (*wp).flags.intersects(window_pane_flags::PANE_EXITED) {
             1
@@ -1382,7 +1382,7 @@ pub unsafe extern "C" fn window_pane_exited(wp: *mut window_pane) -> i32 {
     }
 }
 
-pub unsafe extern "C" fn window_pane_search(
+pub unsafe fn window_pane_search(
     wp: *mut window_pane,
     term: *const c_char,
     regex: i32,
@@ -1449,7 +1449,7 @@ pub unsafe extern "C" fn window_pane_search(
 
 /* Get MRU pane from a list. */
 
-unsafe extern "C" fn window_pane_choose_best(
+unsafe fn window_pane_choose_best(
     list: *mut *mut window_pane,
     size: u32,
 ) -> *mut window_pane {
@@ -1474,7 +1474,7 @@ unsafe extern "C" fn window_pane_choose_best(
  * top edge and then choose the best.
  */
 
-pub unsafe extern "C" fn window_pane_find_up(wp: *mut window_pane) -> *mut window_pane {
+pub unsafe fn window_pane_find_up(wp: *mut window_pane) -> *mut window_pane {
     unsafe {
         if wp.is_null() {
             return null_mut();
@@ -1543,7 +1543,7 @@ pub unsafe extern "C" fn window_pane_find_up(wp: *mut window_pane) -> *mut windo
 
 /* Find the pane directly below another. */
 
-pub unsafe extern "C" fn window_pane_find_down(wp: *mut window_pane) -> *mut window_pane {
+pub unsafe fn window_pane_find_down(wp: *mut window_pane) -> *mut window_pane {
     unsafe {
         if wp.is_null() {
             return null_mut();
@@ -1612,7 +1612,7 @@ pub unsafe extern "C" fn window_pane_find_down(wp: *mut window_pane) -> *mut win
 
 /* Find the pane directly to the left of another. */
 
-pub unsafe extern "C" fn window_pane_find_left(wp: *mut window_pane) -> *mut window_pane {
+pub unsafe fn window_pane_find_left(wp: *mut window_pane) -> *mut window_pane {
     if wp.is_null() {
         return null_mut();
     }
@@ -1664,7 +1664,7 @@ pub unsafe extern "C" fn window_pane_find_left(wp: *mut window_pane) -> *mut win
 
 /* Find the pane directly to the right of another. */
 
-pub unsafe extern "C" fn window_pane_find_right(wp: *mut window_pane) -> *mut window_pane {
+pub unsafe fn window_pane_find_right(wp: *mut window_pane) -> *mut window_pane {
     if wp.is_null() {
         return null_mut();
     }
@@ -1714,7 +1714,7 @@ pub unsafe extern "C" fn window_pane_find_right(wp: *mut window_pane) -> *mut wi
     }
 }
 
-pub unsafe extern "C" fn window_pane_stack_push(stack: *mut window_panes, wp: *mut window_pane) {
+pub unsafe fn window_pane_stack_push(stack: *mut window_panes, wp: *mut window_pane) {
     unsafe {
         if !wp.is_null() {
             window_pane_stack_remove(stack, wp);
@@ -1724,7 +1724,7 @@ pub unsafe extern "C" fn window_pane_stack_push(stack: *mut window_panes, wp: *m
     }
 }
 
-pub unsafe extern "C" fn window_pane_stack_remove(stack: *mut window_panes, wp: *mut window_pane) {
+pub unsafe fn window_pane_stack_remove(stack: *mut window_panes, wp: *mut window_pane) {
     unsafe {
         if !wp.is_null() && (*wp).flags.intersects(window_pane_flags::PANE_VISITED) {
             tailq_remove::<_, crate::discr_sentry>(stack, wp);
@@ -1735,7 +1735,7 @@ pub unsafe extern "C" fn window_pane_stack_remove(stack: *mut window_panes, wp: 
 
 /* Clear alert flags for a winlink */
 
-pub unsafe extern "C" fn winlink_clear_flags(wl: *mut winlink) {
+pub unsafe fn winlink_clear_flags(wl: *mut winlink) {
     unsafe {
         (*(*wl).window).flags &= !WINDOW_ALERTFLAGS;
         for loop_ in tailq_foreach::<_, crate::discr_wentry>(&raw mut (*(*wl).window).winlinks)
@@ -1751,7 +1751,7 @@ pub unsafe extern "C" fn winlink_clear_flags(wl: *mut winlink) {
 
 /* Shuffle window indexes up. */
 
-pub unsafe extern "C" fn winlink_shuffle_up(
+pub unsafe fn winlink_shuffle_up(
     s: *mut session,
     mut wl: *mut winlink,
     before: i32,
@@ -1791,7 +1791,7 @@ pub unsafe extern "C" fn winlink_shuffle_up(
     }
 }
 
-unsafe extern "C" fn window_pane_input_callback(
+unsafe fn window_pane_input_callback(
     c: *mut client,
     _path: *mut c_char,
     error: i32,
@@ -1822,7 +1822,7 @@ unsafe extern "C" fn window_pane_input_callback(
     }
 }
 
-pub unsafe extern "C" fn window_pane_start_input(
+pub unsafe fn window_pane_start_input(
     wp: *mut window_pane,
     item: *mut cmdq_item,
     cause: *mut *mut c_char,
@@ -1859,7 +1859,7 @@ pub unsafe extern "C" fn window_pane_start_input(
     }
 }
 
-pub unsafe extern "C" fn window_pane_get_new_data(
+pub unsafe fn window_pane_get_new_data(
     wp: *mut window_pane,
     wpo: *mut window_pane_offset,
     size: *mut usize,
@@ -1872,7 +1872,7 @@ pub unsafe extern "C" fn window_pane_get_new_data(
     }
 }
 
-pub unsafe extern "C" fn window_pane_update_used_data(
+pub unsafe fn window_pane_update_used_data(
     wp: *mut window_pane,
     wpo: *mut window_pane_offset,
     mut size: usize,
@@ -1887,7 +1887,7 @@ pub unsafe extern "C" fn window_pane_update_used_data(
     }
 }
 
-pub unsafe extern "C" fn window_set_fill_character(w: NonNull<window>) {
+pub unsafe fn window_set_fill_character(w: NonNull<window>) {
     let w = w.as_ptr();
     //const char		*value;
     //struct utf8_data	*ud;
@@ -1905,7 +1905,7 @@ pub unsafe extern "C" fn window_set_fill_character(w: NonNull<window>) {
     }
 }
 
-pub unsafe extern "C" fn window_pane_default_cursor(wp: *mut window_pane) {
+pub unsafe fn window_pane_default_cursor(wp: *mut window_pane) {
     unsafe {
         let s = (*wp).screen;
 
@@ -1922,7 +1922,7 @@ pub unsafe extern "C" fn window_pane_default_cursor(wp: *mut window_pane) {
     }
 }
 
-pub unsafe extern "C" fn window_pane_mode(wp: *mut window_pane) -> i32 {
+pub unsafe fn window_pane_mode(wp: *mut window_pane) -> i32 {
     unsafe {
         if !tailq_first(&raw mut (*wp).modes).is_null() {
             if (*tailq_first(&raw mut (*wp).modes)).mode.addr()

--- a/src/window_buffer.rs
+++ b/src/window_buffer.rs
@@ -103,7 +103,7 @@ pub struct window_buffer_editdata {
     pub pb: *mut paste_buffer,
 }
 
-pub unsafe extern "C" fn window_buffer_add_item(
+pub unsafe fn window_buffer_add_item(
     data: *mut window_buffer_modedata,
 ) -> *mut window_buffer_itemdata {
     unsafe {
@@ -116,7 +116,7 @@ pub unsafe extern "C" fn window_buffer_add_item(
     }
 }
 
-pub unsafe extern "C" fn window_buffer_free_item(item: *mut window_buffer_itemdata) {
+pub unsafe fn window_buffer_free_item(item: *mut window_buffer_itemdata) {
     unsafe {
         free_((*item).name);
         free_(item);
@@ -150,7 +150,7 @@ pub unsafe extern "C" fn window_buffer_cmp(a0: *const c_void, b0: *const c_void)
     }
 }
 
-pub unsafe extern "C" fn window_buffer_build(
+pub unsafe fn window_buffer_build(
     modedata: NonNull<c_void>,
     sort_crit: *mut mode_tree_sort_criteria,
     tag: *mut u64,
@@ -234,7 +234,7 @@ pub unsafe extern "C" fn window_buffer_build(
     }
 }
 
-pub unsafe extern "C" fn window_buffer_draw(
+pub unsafe fn window_buffer_draw(
     modedata: *mut c_void,
     itemdata: Option<NonNull<c_void>>,
     ctx: *mut screen_write_ctx,
@@ -288,7 +288,7 @@ pub unsafe extern "C" fn window_buffer_draw(
     }
 }
 
-pub unsafe extern "C" fn window_buffer_search(
+pub unsafe fn window_buffer_search(
     modedata: *mut c_void,
     itemdata: NonNull<c_void>,
     ss: *const c_char,
@@ -307,7 +307,7 @@ pub unsafe extern "C" fn window_buffer_search(
     }
 }
 
-pub unsafe extern "C" fn window_buffer_menu(
+pub unsafe fn window_buffer_menu(
     modedata: NonNull<c_void>,
     c: *mut client,
     key: key_code,
@@ -324,7 +324,7 @@ pub unsafe extern "C" fn window_buffer_menu(
     }
 }
 
-pub unsafe extern "C" fn window_buffer_get_key(
+pub unsafe fn window_buffer_get_key(
     modedata: NonNull<c_void>,
     itemdata: NonNull<c_void>,
     line: u32,
@@ -359,7 +359,7 @@ pub unsafe extern "C" fn window_buffer_get_key(
     }
 }
 
-pub unsafe extern "C" fn window_buffer_init(
+pub unsafe fn window_buffer_init(
     wme: NonNull<window_mode_entry>,
     fs: *mut cmd_find_state,
     args: *mut args,
@@ -412,7 +412,7 @@ pub unsafe extern "C" fn window_buffer_init(
     }
 }
 
-pub unsafe extern "C" fn window_buffer_free(wme: NonNull<window_mode_entry>) {
+pub unsafe fn window_buffer_free(wme: NonNull<window_mode_entry>) {
     unsafe {
         let data = (*wme.as_ptr()).data as *mut window_buffer_modedata;
 
@@ -435,14 +435,14 @@ pub unsafe extern "C" fn window_buffer_free(wme: NonNull<window_mode_entry>) {
     }
 }
 
-pub unsafe extern "C" fn window_buffer_resize(wme: NonNull<window_mode_entry>, sx: u32, sy: u32) {
+pub unsafe fn window_buffer_resize(wme: NonNull<window_mode_entry>, sx: u32, sy: u32) {
     unsafe {
         let data = (*wme.as_ptr()).data as *mut window_buffer_modedata;
         mode_tree_resize((*data).data, sx, sy);
     }
 }
 
-pub unsafe extern "C" fn window_buffer_update(wme: NonNull<window_mode_entry>) {
+pub unsafe fn window_buffer_update(wme: NonNull<window_mode_entry>) {
     unsafe {
         let data = (*wme.as_ptr()).data as *mut window_buffer_modedata;
 
@@ -452,7 +452,7 @@ pub unsafe extern "C" fn window_buffer_update(wme: NonNull<window_mode_entry>) {
     }
 }
 
-pub unsafe extern "C" fn window_buffer_do_delete(
+pub unsafe fn window_buffer_do_delete(
     modedata: NonNull<c_void>,
     itemdata: NonNull<c_void>,
     c: *mut client,
@@ -480,7 +480,7 @@ pub unsafe extern "C" fn window_buffer_do_delete(
     }
 }
 
-pub unsafe extern "C" fn window_buffer_do_paste(
+pub unsafe fn window_buffer_do_paste(
     modedata: NonNull<c_void>,
     itemdata: NonNull<c_void>,
     c: *mut client,
@@ -501,14 +501,14 @@ pub unsafe extern "C" fn window_buffer_do_paste(
     }
 }
 
-pub unsafe extern "C" fn window_buffer_finish_edit(ed: *mut window_buffer_editdata) {
+pub unsafe fn window_buffer_finish_edit(ed: *mut window_buffer_editdata) {
     unsafe {
         free_((*ed).name);
         free_(ed);
     }
 }
 
-pub unsafe extern "C" fn window_buffer_edit_close_cb(
+pub unsafe fn window_buffer_edit_close_cb(
     buf: *mut c_char,
     mut len: usize,
     arg: *mut c_void,
@@ -554,7 +554,7 @@ pub unsafe extern "C" fn window_buffer_edit_close_cb(
     }
 }
 
-pub unsafe extern "C" fn window_buffer_start_edit(
+pub unsafe fn window_buffer_start_edit(
     data: *mut window_buffer_modedata,
     item: *mut window_buffer_itemdata,
     c: *mut client,
@@ -583,7 +583,7 @@ pub unsafe extern "C" fn window_buffer_start_edit(
     }
 }
 
-pub unsafe extern "C" fn window_buffer_key(
+pub unsafe fn window_buffer_key(
     wme: NonNull<window_mode_entry>,
     c: *mut client,
     s: *mut session,

--- a/src/window_client.rs
+++ b/src/window_client.rs
@@ -83,7 +83,7 @@ pub struct window_client_modedata {
     item_size: u32,
 }
 
-pub unsafe extern "C" fn window_client_add_item(
+pub unsafe fn window_client_add_item(
     data: *mut window_client_modedata,
 ) -> *mut window_client_itemdata {
     unsafe {
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn window_client_add_item(
     }
 }
 
-pub unsafe extern "C" fn window_client_free_item(item: *mut window_client_itemdata) {
+pub unsafe fn window_client_free_item(item: *mut window_client_itemdata) {
     unsafe {
         server_client_unref((*item).c);
         free_(item);
@@ -159,7 +159,7 @@ pub unsafe extern "C" fn window_client_cmp(a0: *const c_void, b0: *const c_void)
     }
 }
 
-pub unsafe extern "C" fn window_client_build(
+pub unsafe fn window_client_build(
     modedata: NonNull<c_void>,
     sort_crit: *mut mode_tree_sort_criteria,
     _tag: *mut u64,
@@ -231,7 +231,7 @@ pub unsafe extern "C" fn window_client_build(
     }
 }
 
-pub unsafe extern "C" fn window_client_draw(
+pub unsafe fn window_client_draw(
     modedata: *mut c_void,
     itemdata: Option<NonNull<c_void>>,
     ctx: *mut screen_write_ctx,
@@ -276,7 +276,7 @@ pub unsafe extern "C" fn window_client_draw(
     }
 }
 
-pub unsafe extern "C" fn window_client_menu(
+pub unsafe fn window_client_menu(
     modedata: NonNull<c_void>,
     c: *mut client,
     key: key_code,
@@ -293,7 +293,7 @@ pub unsafe extern "C" fn window_client_menu(
     }
 }
 
-pub unsafe extern "C" fn window_client_get_key(
+pub unsafe fn window_client_get_key(
     modedata: NonNull<c_void>,
     itemdata: NonNull<c_void>,
     line: u32,
@@ -314,7 +314,7 @@ pub unsafe extern "C" fn window_client_get_key(
     }
 }
 
-pub unsafe extern "C" fn window_client_init(
+pub unsafe fn window_client_init(
     wme: NonNull<window_mode_entry>,
     _fs: *mut cmd_find_state,
     args: *mut args,
@@ -368,7 +368,7 @@ pub unsafe extern "C" fn window_client_init(
     }
 }
 
-pub unsafe extern "C" fn window_client_free(wme: NonNull<window_mode_entry>) {
+pub unsafe fn window_client_free(wme: NonNull<window_mode_entry>) {
     unsafe {
         let data: *mut window_client_modedata = (*wme.as_ptr()).data as *mut window_client_modedata;
 
@@ -391,7 +391,7 @@ pub unsafe extern "C" fn window_client_free(wme: NonNull<window_mode_entry>) {
     }
 }
 
-pub unsafe extern "C" fn window_client_resize(wme: NonNull<window_mode_entry>, sx: u32, sy: u32) {
+pub unsafe fn window_client_resize(wme: NonNull<window_mode_entry>, sx: u32, sy: u32) {
     unsafe {
         let data = (*wme.as_ptr()).data as *mut window_client_modedata;
 
@@ -399,7 +399,7 @@ pub unsafe extern "C" fn window_client_resize(wme: NonNull<window_mode_entry>, s
     }
 }
 
-pub unsafe extern "C" fn window_client_update(wme: NonNull<window_mode_entry>) {
+pub unsafe fn window_client_update(wme: NonNull<window_mode_entry>) {
     unsafe {
         let data = (*wme.as_ptr()).data as *mut window_client_modedata;
 
@@ -409,7 +409,7 @@ pub unsafe extern "C" fn window_client_update(wme: NonNull<window_mode_entry>) {
     }
 }
 
-pub unsafe extern "C" fn window_client_do_detach(
+pub unsafe fn window_client_do_detach(
     modedata: NonNull<c_void>,
     itemdata: NonNull<c_void>,
     c: *mut client,
@@ -434,7 +434,7 @@ pub unsafe extern "C" fn window_client_do_detach(
     }
 }
 
-pub unsafe extern "C" fn window_client_key(
+pub unsafe fn window_client_key(
     wme: NonNull<window_mode_entry>,
     c: *mut client,
     _: *mut session,

--- a/src/window_clock.rs
+++ b/src/window_clock.rs
@@ -135,7 +135,7 @@ pub static mut window_clock_table: [[[c_char; 5]; 5]; 14] = [
     ],
 ];
 
-pub unsafe extern "C" fn window_clock_timer_callback(fd: i32, events: i16, arg: *mut c_void) {
+pub unsafe fn window_clock_timer_callback(fd: i32, events: i16, arg: *mut c_void) {
     unsafe {
         let wme = arg as *mut window_mode_entry;
         let wp = (*wme).wp;
@@ -168,7 +168,7 @@ pub unsafe extern "C" fn window_clock_timer_callback(fd: i32, events: i16, arg: 
     }
 }
 
-pub unsafe extern "C" fn window_clock_init(
+pub unsafe fn window_clock_init(
     wme: NonNull<window_mode_entry>,
     _fs: *mut cmd_find_state,
     args: *mut args,
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn window_clock_init(
     }
 }
 
-pub unsafe extern "C" fn window_clock_free(wme: NonNull<window_mode_entry>) {
+pub unsafe fn window_clock_free(wme: NonNull<window_mode_entry>) {
     unsafe {
         let data = (*wme.as_ptr()).data as *mut window_clock_mode_data;
 
@@ -216,7 +216,7 @@ pub unsafe extern "C" fn window_clock_free(wme: NonNull<window_mode_entry>) {
     }
 }
 
-pub unsafe extern "C" fn window_clock_resize(wme: NonNull<window_mode_entry>, sx: u32, sy: u32) {
+pub unsafe fn window_clock_resize(wme: NonNull<window_mode_entry>, sx: u32, sy: u32) {
     unsafe {
         let data = (*wme.as_ptr()).data as *mut window_clock_mode_data;
         let s = &raw mut (*data).screen;
@@ -226,7 +226,7 @@ pub unsafe extern "C" fn window_clock_resize(wme: NonNull<window_mode_entry>, sx
     }
 }
 
-pub unsafe extern "C" fn window_clock_key(
+pub unsafe fn window_clock_key(
     wme: NonNull<window_mode_entry>,
     c: *mut client,
     s: *mut session,
@@ -239,7 +239,7 @@ pub unsafe extern "C" fn window_clock_key(
     }
 }
 
-pub unsafe extern "C" fn window_clock_draw_screen(wme: NonNull<window_mode_entry>) {
+pub unsafe fn window_clock_draw_screen(wme: NonNull<window_mode_entry>) {
     unsafe {
         let wp = (*wme.as_ptr()).wp;
         let data = (*wme.as_ptr()).data as *mut window_clock_mode_data;

--- a/src/window_clock.rs
+++ b/src/window_clock.rs
@@ -135,7 +135,7 @@ pub static mut window_clock_table: [[[c_char; 5]; 5]; 14] = [
     ],
 ];
 
-pub unsafe fn window_clock_timer_callback(fd: i32, events: i16, arg: *mut c_void) {
+pub unsafe extern "C" fn window_clock_timer_callback(fd: i32, events: i16, arg: *mut c_void) {
     unsafe {
         let wme = arg as *mut window_mode_entry;
         let wp = (*wme).wp;

--- a/src/window_copy.rs
+++ b/src/window_copy.rs
@@ -210,7 +210,7 @@ pub struct window_copy_mode_data {
     dragtimer: event,
 }
 
-pub unsafe extern "C" fn window_copy_scroll_timer(_fd: i32, _events: i16, arg: *mut c_void) {
+pub unsafe fn window_copy_scroll_timer(_fd: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let wme: *mut window_mode_entry = arg.cast();
         let wp: *mut window_pane = (*wme).wp;
@@ -236,7 +236,7 @@ pub unsafe extern "C" fn window_copy_scroll_timer(_fd: i32, _events: i16, arg: *
     }
 }
 
-pub unsafe extern "C" fn window_copy_clone_screen(
+pub unsafe fn window_copy_clone_screen(
     src: *mut screen,
     hint: *mut screen,
     cx: *mut u32,
@@ -302,7 +302,7 @@ pub unsafe extern "C" fn window_copy_clone_screen(
     }
 }
 
-pub unsafe extern "C" fn window_copy_common_init(
+pub unsafe fn window_copy_common_init(
     wme: *mut window_mode_entry,
 ) -> *mut window_copy_mode_data {
     unsafe {
@@ -353,7 +353,7 @@ pub unsafe extern "C" fn window_copy_common_init(
     }
 }
 
-pub unsafe extern "C" fn window_copy_init(
+pub unsafe fn window_copy_init(
     wme: NonNull<window_mode_entry>,
     _fs: *mut cmd_find_state,
     args: *mut args,
@@ -408,7 +408,7 @@ pub unsafe extern "C" fn window_copy_init(
     }
 }
 
-pub unsafe extern "C" fn window_copy_view_init(
+pub unsafe fn window_copy_view_init(
     wme: NonNull<window_mode_entry>,
     fs: *mut cmd_find_state,
     args: *mut args,
@@ -436,7 +436,7 @@ pub unsafe extern "C" fn window_copy_view_init(
     }
 }
 
-pub unsafe extern "C" fn window_copy_free(wme: NonNull<window_mode_entry>) {
+pub unsafe fn window_copy_free(wme: NonNull<window_mode_entry>) {
     unsafe {
         let wme = wme.as_ptr();
         let data: *mut window_copy_mode_data = (*wme).data.cast();
@@ -469,7 +469,7 @@ macro_rules! window_copy_add {
 }
 pub(crate) use window_copy_add;
 
-pub unsafe extern "C" fn window_copy_init_ctx_cb(ctx: *mut screen_write_ctx, ttyctx: *mut tty_ctx) {
+pub unsafe fn window_copy_init_ctx_cb(ctx: *mut screen_write_ctx, ttyctx: *mut tty_ctx) {
     unsafe {
         memcpy__(&raw mut (*ttyctx).defaults, &raw const grid_default_cell);
         (*ttyctx).palette = null_mut();
@@ -550,13 +550,13 @@ pub unsafe fn window_copy_vadd(wp: *mut window_pane, parse: i32, args: std::fmt:
     }
 }
 
-pub unsafe extern "C" fn window_copy_pageup(wp: *mut window_pane, half_page: i32) {
+pub unsafe fn window_copy_pageup(wp: *mut window_pane, half_page: i32) {
     unsafe {
         window_copy_pageup1(tailq_first(&raw mut (*wp).modes), half_page);
     }
 }
 
-pub unsafe extern "C" fn window_copy_pageup1(wme: *mut window_mode_entry, half_page: i32) {
+pub unsafe fn window_copy_pageup1(wme: *mut window_mode_entry, half_page: i32) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let s: *mut screen = &raw mut (*data).screen;
@@ -607,7 +607,7 @@ pub unsafe extern "C" fn window_copy_pageup1(wme: *mut window_mode_entry, half_p
     }
 }
 
-pub unsafe extern "C" fn window_copy_pagedown(
+pub unsafe fn window_copy_pagedown(
     wp: *mut window_pane,
     half_page: i32,
     scroll_exit: i32,
@@ -619,7 +619,7 @@ pub unsafe extern "C" fn window_copy_pagedown(
     }
 }
 
-pub unsafe extern "C" fn window_copy_pagedown1(
+pub unsafe fn window_copy_pagedown1(
     wme: *mut window_mode_entry,
     half_page: i32,
     scroll_exit: i32,
@@ -678,7 +678,7 @@ pub unsafe extern "C" fn window_copy_pagedown1(
     }
 }
 
-pub unsafe extern "C" fn window_copy_previous_paragraph(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_previous_paragraph(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
 
@@ -696,7 +696,7 @@ pub unsafe extern "C" fn window_copy_previous_paragraph(wme: *mut window_mode_en
     }
 }
 
-pub unsafe extern "C" fn window_copy_next_paragraph(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_next_paragraph(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let s: *mut screen = &raw mut (*data).screen;
@@ -717,7 +717,7 @@ pub unsafe extern "C" fn window_copy_next_paragraph(wme: *mut window_mode_entry)
     }
 }
 
-pub unsafe extern "C" fn window_copy_get_word(wp: *mut window_pane, x: u32, y: u32) -> *mut c_char {
+pub unsafe fn window_copy_get_word(wp: *mut window_pane, x: u32, y: u32) -> *mut c_char {
     unsafe {
         let wme: *mut window_mode_entry = tailq_first(&raw mut (*wp).modes);
         let data: *mut window_copy_mode_data = (*wme).data.cast();
@@ -727,7 +727,7 @@ pub unsafe extern "C" fn window_copy_get_word(wp: *mut window_pane, x: u32, y: u
     }
 }
 
-pub unsafe extern "C" fn window_copy_get_line(wp: *mut window_pane, y: u32) -> *mut c_char {
+pub unsafe fn window_copy_get_line(wp: *mut window_pane, y: u32) -> *mut c_char {
     unsafe {
         let wme: *mut window_mode_entry = tailq_first(&raw mut (*wp).modes);
         let data: *mut window_copy_mode_data = (*wme).data.cast();
@@ -737,7 +737,7 @@ pub unsafe extern "C" fn window_copy_get_line(wp: *mut window_pane, y: u32) -> *
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_hyperlink_cb(ft: *mut format_tree) -> *mut c_void {
+pub unsafe fn window_copy_cursor_hyperlink_cb(ft: *mut format_tree) -> *mut c_void {
     unsafe {
         let wp = format_get_pane(ft);
         let wme = tailq_first(&raw mut (*wp).modes);
@@ -754,7 +754,7 @@ pub unsafe extern "C" fn window_copy_cursor_hyperlink_cb(ft: *mut format_tree) -
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_word_cb(ft: *mut format_tree) -> *mut c_void {
+pub unsafe fn window_copy_cursor_word_cb(ft: *mut format_tree) -> *mut c_void {
     unsafe {
         let wp: *mut window_pane = format_get_pane(ft);
         let wme: *mut window_mode_entry = tailq_first(&raw mut (*wp).modes);
@@ -764,7 +764,7 @@ pub unsafe extern "C" fn window_copy_cursor_word_cb(ft: *mut format_tree) -> *mu
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_line_cb(ft: *mut format_tree) -> *mut c_void {
+pub unsafe fn window_copy_cursor_line_cb(ft: *mut format_tree) -> *mut c_void {
     unsafe {
         let wp: *mut window_pane = format_get_pane(ft);
         let wme: *mut window_mode_entry = tailq_first(&raw mut (*wp).modes);
@@ -774,7 +774,7 @@ pub unsafe extern "C" fn window_copy_cursor_line_cb(ft: *mut format_tree) -> *mu
     }
 }
 
-pub unsafe extern "C" fn window_copy_search_match_cb(ft: *mut format_tree) -> *mut c_void {
+pub unsafe fn window_copy_search_match_cb(ft: *mut format_tree) -> *mut c_void {
     unsafe {
         let wp: *mut window_pane = format_get_pane(ft);
         let wme: *mut window_mode_entry = tailq_first(&raw mut (*wp).modes);
@@ -784,7 +784,7 @@ pub unsafe extern "C" fn window_copy_search_match_cb(ft: *mut format_tree) -> *m
     }
 }
 
-pub unsafe extern "C" fn window_copy_formats(wme: *mut window_mode_entry, ft: *mut format_tree) {
+pub unsafe fn window_copy_formats(wme: *mut window_mode_entry, ft: *mut format_tree) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
 
@@ -854,7 +854,7 @@ pub unsafe extern "C" fn window_copy_formats(wme: *mut window_mode_entry, ft: *m
     }
 }
 
-pub unsafe extern "C" fn window_copy_size_changed(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_size_changed(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let s: *mut screen = &raw mut (*data).screen;
@@ -877,7 +877,7 @@ pub unsafe extern "C" fn window_copy_size_changed(wme: *mut window_mode_entry) {
     }
 }
 
-pub unsafe extern "C" fn window_copy_resize(wme: NonNull<window_mode_entry>, sx: u32, sy: u32) {
+pub unsafe fn window_copy_resize(wme: NonNull<window_mode_entry>, sx: u32, sy: u32) {
     unsafe {
         let wme = wme.as_ptr();
         let data: *mut window_copy_mode_data = (*wme).data.cast();
@@ -913,7 +913,7 @@ pub unsafe extern "C" fn window_copy_resize(wme: NonNull<window_mode_entry>, sx:
     }
 }
 
-pub unsafe extern "C" fn window_copy_key_table(wme: *mut window_mode_entry) -> *const c_char {
+pub unsafe fn window_copy_key_table(wme: *mut window_mode_entry) -> *const c_char {
     unsafe {
         if matches!(
             modekey::try_from(
@@ -928,7 +928,7 @@ pub unsafe extern "C" fn window_copy_key_table(wme: *mut window_mode_entry) -> *
     }
 }
 
-pub unsafe extern "C" fn window_copy_expand_search_string(cs: *mut window_copy_cmd_state) -> i32 {
+pub unsafe fn window_copy_expand_search_string(cs: *mut window_copy_cmd_state) -> i32 {
     unsafe {
         let wme: *mut window_mode_entry = (*cs).wme;
         let data: *mut window_copy_mode_data = (*wme).data.cast();
@@ -961,7 +961,7 @@ pub unsafe extern "C" fn window_copy_expand_search_string(cs: *mut window_copy_c
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_append_selection(
+pub unsafe fn window_copy_cmd_append_selection(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -976,7 +976,7 @@ pub unsafe extern "C" fn window_copy_cmd_append_selection(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_append_selection_and_cancel(
+pub unsafe fn window_copy_cmd_append_selection_and_cancel(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -991,7 +991,7 @@ pub unsafe extern "C" fn window_copy_cmd_append_selection_and_cancel(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_back_to_indentation(
+pub unsafe fn window_copy_cmd_back_to_indentation(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1000,7 +1000,7 @@ pub unsafe extern "C" fn window_copy_cmd_back_to_indentation(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_begin_selection(
+pub unsafe fn window_copy_cmd_begin_selection(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1021,7 +1021,7 @@ pub unsafe extern "C" fn window_copy_cmd_begin_selection(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_stop_selection(
+pub unsafe fn window_copy_cmd_stop_selection(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1035,7 +1035,7 @@ pub unsafe extern "C" fn window_copy_cmd_stop_selection(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_bottom_line(
+pub unsafe fn window_copy_cmd_bottom_line(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1050,13 +1050,13 @@ pub unsafe extern "C" fn window_copy_cmd_bottom_line(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_cancel(
+pub unsafe fn window_copy_cmd_cancel(
     _cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe { window_copy_cmd_action::WINDOW_COPY_CMD_CANCEL }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_clear_selection(
+pub unsafe fn window_copy_cmd_clear_selection(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1067,7 +1067,7 @@ pub unsafe extern "C" fn window_copy_cmd_clear_selection(
     }
 }
 
-pub unsafe extern "C" fn window_copy_do_copy_end_of_line(
+pub unsafe fn window_copy_do_copy_end_of_line(
     cs: *mut window_copy_cmd_state,
     pipe: i32,
     cancel: i32,
@@ -1133,31 +1133,31 @@ pub unsafe extern "C" fn window_copy_do_copy_end_of_line(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_end_of_line(
+pub unsafe fn window_copy_cmd_copy_end_of_line(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe { window_copy_do_copy_end_of_line(cs, 0, 0) }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_end_of_line_and_cancel(
+pub unsafe fn window_copy_cmd_copy_end_of_line_and_cancel(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe { window_copy_do_copy_end_of_line(cs, 0, 1) }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_pipe_end_of_line(
+pub unsafe fn window_copy_cmd_copy_pipe_end_of_line(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe { window_copy_do_copy_end_of_line(cs, 1, 0) }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_pipe_end_of_line_and_cancel(
+pub unsafe fn window_copy_cmd_copy_pipe_end_of_line_and_cancel(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe { window_copy_do_copy_end_of_line(cs, 1, 1) }
 }
 
-pub unsafe extern "C" fn window_copy_do_copy_line(
+pub unsafe fn window_copy_do_copy_line(
     cs: *mut window_copy_cmd_state,
     pipe: i32,
     cancel: i32,
@@ -1227,31 +1227,31 @@ pub unsafe extern "C" fn window_copy_do_copy_line(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_line(
+pub unsafe fn window_copy_cmd_copy_line(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe { window_copy_do_copy_line(cs, 0, 0) }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_line_and_cancel(
+pub unsafe fn window_copy_cmd_copy_line_and_cancel(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe { window_copy_do_copy_line(cs, 0, 1) }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_pipe_line(
+pub unsafe fn window_copy_cmd_copy_pipe_line(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe { window_copy_do_copy_line(cs, 1, 0) }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_pipe_line_and_cancel(
+pub unsafe fn window_copy_cmd_copy_pipe_line_and_cancel(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe { window_copy_do_copy_line(cs, 1, 1) }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_selection_no_clear(
+pub unsafe fn window_copy_cmd_copy_selection_no_clear(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1276,7 +1276,7 @@ pub unsafe extern "C" fn window_copy_cmd_copy_selection_no_clear(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_selection(
+pub unsafe fn window_copy_cmd_copy_selection(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1288,7 +1288,7 @@ pub unsafe extern "C" fn window_copy_cmd_copy_selection(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_selection_and_cancel(
+pub unsafe fn window_copy_cmd_copy_selection_and_cancel(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1300,7 +1300,7 @@ pub unsafe extern "C" fn window_copy_cmd_copy_selection_and_cancel(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_cursor_down(
+pub unsafe fn window_copy_cmd_cursor_down(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1315,7 +1315,7 @@ pub unsafe extern "C" fn window_copy_cmd_cursor_down(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_cursor_down_and_cancel(
+pub unsafe fn window_copy_cmd_cursor_down_and_cancel(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1337,7 +1337,7 @@ pub unsafe extern "C" fn window_copy_cmd_cursor_down_and_cancel(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_cursor_left(
+pub unsafe fn window_copy_cmd_cursor_left(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1352,7 +1352,7 @@ pub unsafe extern "C" fn window_copy_cmd_cursor_left(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_cursor_right(
+pub unsafe fn window_copy_cmd_cursor_right(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1373,7 +1373,7 @@ pub unsafe extern "C" fn window_copy_cmd_cursor_right(
 
 /* Scroll line containing the cursor to the given position. */
 
-pub unsafe extern "C" fn window_copy_cmd_scroll_to(
+pub unsafe fn window_copy_cmd_scroll_to(
     cs: *mut window_copy_cmd_state,
     to: u32,
 ) -> window_copy_cmd_action {
@@ -1403,7 +1403,7 @@ pub unsafe extern "C" fn window_copy_cmd_scroll_to(
 
 /* Scroll line containing the cursor to the bottom. */
 
-pub unsafe extern "C" fn window_copy_cmd_scroll_bottom(
+pub unsafe fn window_copy_cmd_scroll_bottom(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1416,7 +1416,7 @@ pub unsafe extern "C" fn window_copy_cmd_scroll_bottom(
 
 /* Scroll line containing the cursor to the middle. */
 
-pub unsafe extern "C" fn window_copy_cmd_scroll_middle(
+pub unsafe fn window_copy_cmd_scroll_middle(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1428,13 +1428,13 @@ pub unsafe extern "C" fn window_copy_cmd_scroll_middle(
 
 /* Scroll line containing the cursor to the top. */
 
-pub unsafe extern "C" fn window_copy_cmd_scroll_top(
+pub unsafe fn window_copy_cmd_scroll_top(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe { window_copy_cmd_scroll_to(cs, 0) }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_cursor_up(
+pub unsafe fn window_copy_cmd_cursor_up(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1449,7 +1449,7 @@ pub unsafe extern "C" fn window_copy_cmd_cursor_up(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_end_of_line(
+pub unsafe fn window_copy_cmd_end_of_line(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1460,7 +1460,7 @@ pub unsafe extern "C" fn window_copy_cmd_end_of_line(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_halfpage_down(
+pub unsafe fn window_copy_cmd_halfpage_down(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1478,7 +1478,7 @@ pub unsafe extern "C" fn window_copy_cmd_halfpage_down(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_halfpage_down_and_cancel(
+pub unsafe fn window_copy_cmd_halfpage_down_and_cancel(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1495,7 +1495,7 @@ pub unsafe extern "C" fn window_copy_cmd_halfpage_down_and_cancel(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_halfpage_up(
+pub unsafe fn window_copy_cmd_halfpage_up(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1510,7 +1510,7 @@ pub unsafe extern "C" fn window_copy_cmd_halfpage_up(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_toggle_position(
+pub unsafe fn window_copy_cmd_toggle_position(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1522,7 +1522,7 @@ pub unsafe extern "C" fn window_copy_cmd_toggle_position(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_history_bottom(
+pub unsafe fn window_copy_cmd_history_bottom(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1547,7 +1547,7 @@ pub unsafe extern "C" fn window_copy_cmd_history_bottom(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_history_top(
+pub unsafe fn window_copy_cmd_history_top(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1571,7 +1571,7 @@ pub unsafe extern "C" fn window_copy_cmd_history_top(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_jump_again(
+pub unsafe fn window_copy_cmd_jump_again(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1610,7 +1610,7 @@ pub unsafe extern "C" fn window_copy_cmd_jump_again(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_jump_reverse(
+pub unsafe fn window_copy_cmd_jump_reverse(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1649,7 +1649,7 @@ pub unsafe extern "C" fn window_copy_cmd_jump_reverse(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_middle_line(
+pub unsafe fn window_copy_cmd_middle_line(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1664,7 +1664,7 @@ pub unsafe extern "C" fn window_copy_cmd_middle_line(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_previous_matching_bracket(
+pub unsafe fn window_copy_cmd_previous_matching_bracket(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1771,7 +1771,7 @@ pub unsafe extern "C" fn window_copy_cmd_previous_matching_bracket(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_next_matching_bracket(
+pub unsafe fn window_copy_cmd_next_matching_bracket(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1919,7 +1919,7 @@ pub unsafe extern "C" fn window_copy_cmd_next_matching_bracket(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_next_paragraph(
+pub unsafe fn window_copy_cmd_next_paragraph(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1934,7 +1934,7 @@ pub unsafe extern "C" fn window_copy_cmd_next_paragraph(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_next_space(
+pub unsafe fn window_copy_cmd_next_space(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1949,7 +1949,7 @@ pub unsafe extern "C" fn window_copy_cmd_next_space(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_next_space_end(
+pub unsafe fn window_copy_cmd_next_space_end(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1964,7 +1964,7 @@ pub unsafe extern "C" fn window_copy_cmd_next_space_end(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_next_word(
+pub unsafe fn window_copy_cmd_next_word(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1981,7 +1981,7 @@ pub unsafe extern "C" fn window_copy_cmd_next_word(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_next_word_end(
+pub unsafe fn window_copy_cmd_next_word_end(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -1998,7 +1998,7 @@ pub unsafe extern "C" fn window_copy_cmd_next_word_end(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_other_end(
+pub unsafe fn window_copy_cmd_other_end(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2014,7 +2014,7 @@ pub unsafe extern "C" fn window_copy_cmd_other_end(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_page_down(
+pub unsafe fn window_copy_cmd_page_down(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2032,7 +2032,7 @@ pub unsafe extern "C" fn window_copy_cmd_page_down(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_page_down_and_cancel(
+pub unsafe fn window_copy_cmd_page_down_and_cancel(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2049,7 +2049,7 @@ pub unsafe extern "C" fn window_copy_cmd_page_down_and_cancel(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_page_up(
+pub unsafe fn window_copy_cmd_page_up(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2064,7 +2064,7 @@ pub unsafe extern "C" fn window_copy_cmd_page_up(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_previous_paragraph(
+pub unsafe fn window_copy_cmd_previous_paragraph(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2079,7 +2079,7 @@ pub unsafe extern "C" fn window_copy_cmd_previous_paragraph(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_previous_space(
+pub unsafe fn window_copy_cmd_previous_space(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2094,7 +2094,7 @@ pub unsafe extern "C" fn window_copy_cmd_previous_space(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_previous_word(
+pub unsafe fn window_copy_cmd_previous_word(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2111,7 +2111,7 @@ pub unsafe extern "C" fn window_copy_cmd_previous_word(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_rectangle_on(
+pub unsafe fn window_copy_cmd_rectangle_on(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2125,7 +2125,7 @@ pub unsafe extern "C" fn window_copy_cmd_rectangle_on(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_rectangle_off(
+pub unsafe fn window_copy_cmd_rectangle_off(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2139,7 +2139,7 @@ pub unsafe extern "C" fn window_copy_cmd_rectangle_off(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_rectangle_toggle(
+pub unsafe fn window_copy_cmd_rectangle_toggle(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2153,7 +2153,7 @@ pub unsafe extern "C" fn window_copy_cmd_rectangle_toggle(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_scroll_down(
+pub unsafe fn window_copy_cmd_scroll_down(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2173,7 +2173,7 @@ pub unsafe extern "C" fn window_copy_cmd_scroll_down(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_scroll_down_and_cancel(
+pub unsafe fn window_copy_cmd_scroll_down_and_cancel(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2193,7 +2193,7 @@ pub unsafe extern "C" fn window_copy_cmd_scroll_down_and_cancel(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_scroll_up(
+pub unsafe fn window_copy_cmd_scroll_up(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2208,7 +2208,7 @@ pub unsafe extern "C" fn window_copy_cmd_scroll_up(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_search_again(
+pub unsafe fn window_copy_cmd_search_again(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2231,7 +2231,7 @@ pub unsafe extern "C" fn window_copy_cmd_search_again(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_search_reverse(
+pub unsafe fn window_copy_cmd_search_reverse(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2254,7 +2254,7 @@ pub unsafe extern "C" fn window_copy_cmd_search_reverse(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_select_line(
+pub unsafe fn window_copy_cmd_select_line(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2286,7 +2286,7 @@ pub unsafe extern "C" fn window_copy_cmd_select_line(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_select_word(
+pub unsafe fn window_copy_cmd_select_word(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2343,7 +2343,7 @@ pub unsafe extern "C" fn window_copy_cmd_select_word(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_set_mark(
+pub unsafe fn window_copy_cmd_set_mark(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2356,7 +2356,7 @@ pub unsafe extern "C" fn window_copy_cmd_set_mark(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_start_of_line(
+pub unsafe fn window_copy_cmd_start_of_line(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2365,7 +2365,7 @@ pub unsafe extern "C" fn window_copy_cmd_start_of_line(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_top_line(
+pub unsafe fn window_copy_cmd_top_line(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2380,7 +2380,7 @@ pub unsafe extern "C" fn window_copy_cmd_top_line(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_pipe_no_clear(
+pub unsafe fn window_copy_cmd_copy_pipe_no_clear(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2409,7 +2409,7 @@ pub unsafe extern "C" fn window_copy_cmd_copy_pipe_no_clear(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_pipe(
+pub unsafe fn window_copy_cmd_copy_pipe(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2421,7 +2421,7 @@ pub unsafe extern "C" fn window_copy_cmd_copy_pipe(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_copy_pipe_and_cancel(
+pub unsafe fn window_copy_cmd_copy_pipe_and_cancel(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2433,7 +2433,7 @@ pub unsafe extern "C" fn window_copy_cmd_copy_pipe_and_cancel(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_pipe_no_clear(
+pub unsafe fn window_copy_cmd_pipe_no_clear(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2455,7 +2455,7 @@ pub unsafe extern "C" fn window_copy_cmd_pipe_no_clear(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_pipe(
+pub unsafe fn window_copy_cmd_pipe(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2467,7 +2467,7 @@ pub unsafe extern "C" fn window_copy_cmd_pipe(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_pipe_and_cancel(
+pub unsafe fn window_copy_cmd_pipe_and_cancel(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2479,7 +2479,7 @@ pub unsafe extern "C" fn window_copy_cmd_pipe_and_cancel(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_goto_line(
+pub unsafe fn window_copy_cmd_goto_line(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2493,7 +2493,7 @@ pub unsafe extern "C" fn window_copy_cmd_goto_line(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_jump_backward(
+pub unsafe fn window_copy_cmd_jump_backward(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2515,7 +2515,7 @@ pub unsafe extern "C" fn window_copy_cmd_jump_backward(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_jump_forward(
+pub unsafe fn window_copy_cmd_jump_forward(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2537,7 +2537,7 @@ pub unsafe extern "C" fn window_copy_cmd_jump_forward(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_jump_to_backward(
+pub unsafe fn window_copy_cmd_jump_to_backward(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2559,7 +2559,7 @@ pub unsafe extern "C" fn window_copy_cmd_jump_to_backward(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_jump_to_forward(
+pub unsafe fn window_copy_cmd_jump_to_forward(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2581,7 +2581,7 @@ pub unsafe extern "C" fn window_copy_cmd_jump_to_forward(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_jump_to_mark(
+pub unsafe fn window_copy_cmd_jump_to_mark(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2592,7 +2592,7 @@ pub unsafe extern "C" fn window_copy_cmd_jump_to_mark(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_next_prompt(
+pub unsafe fn window_copy_cmd_next_prompt(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2604,7 +2604,7 @@ pub unsafe extern "C" fn window_copy_cmd_next_prompt(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_previous_prompt(
+pub unsafe fn window_copy_cmd_previous_prompt(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2616,7 +2616,7 @@ pub unsafe extern "C" fn window_copy_cmd_previous_prompt(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_search_backward(
+pub unsafe fn window_copy_cmd_search_backward(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2641,7 +2641,7 @@ pub unsafe extern "C" fn window_copy_cmd_search_backward(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_search_backward_text(
+pub unsafe fn window_copy_cmd_search_backward_text(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2666,7 +2666,7 @@ pub unsafe extern "C" fn window_copy_cmd_search_backward_text(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_search_forward(
+pub unsafe fn window_copy_cmd_search_forward(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2691,7 +2691,7 @@ pub unsafe extern "C" fn window_copy_cmd_search_forward(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_search_forward_text(
+pub unsafe fn window_copy_cmd_search_forward_text(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2716,7 +2716,7 @@ pub unsafe extern "C" fn window_copy_cmd_search_forward_text(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_search_backward_incremental(
+pub unsafe fn window_copy_cmd_search_backward_incremental(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2773,7 +2773,7 @@ pub unsafe extern "C" fn window_copy_cmd_search_backward_incremental(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_search_forward_incremental(
+pub unsafe fn window_copy_cmd_search_forward_incremental(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2830,7 +2830,7 @@ pub unsafe extern "C" fn window_copy_cmd_search_forward_incremental(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cmd_refresh_from_pane(
+pub unsafe fn window_copy_cmd_refresh_from_pane(
     cs: *mut window_copy_cmd_state,
 ) -> window_copy_cmd_action {
     unsafe {
@@ -2863,7 +2863,7 @@ struct window_copy_cmd_table_entry {
     minargs: u32,
     maxargs: u32,
     clear: window_copy_cmd_clear,
-    f: unsafe extern "C" fn(*mut window_copy_cmd_state) -> window_copy_cmd_action,
+    f: unsafe fn(*mut window_copy_cmd_state) -> window_copy_cmd_action,
 }
 
 static window_copy_cmd_table: [window_copy_cmd_table_entry; 85] = [
@@ -3464,7 +3464,7 @@ static window_copy_cmd_table: [window_copy_cmd_table_entry; 85] = [
     },
 ];
 
-pub unsafe extern "C" fn window_copy_command(
+pub unsafe fn window_copy_command(
     wme: NonNull<window_mode_entry>,
     c: *mut client,
     s: *mut session,
@@ -3540,7 +3540,7 @@ pub unsafe extern "C" fn window_copy_command(
     }
 }
 
-pub unsafe extern "C" fn window_copy_scroll_to(
+pub unsafe fn window_copy_scroll_to(
     wme: *mut window_mode_entry,
     px: u32,
     py: u32,
@@ -3580,7 +3580,7 @@ pub unsafe extern "C" fn window_copy_scroll_to(
     }
 }
 
-pub unsafe extern "C" fn window_copy_search_compare(
+pub unsafe fn window_copy_search_compare(
     gd: *mut grid,
     px: u32,
     py: u32,
@@ -3612,7 +3612,7 @@ pub unsafe extern "C" fn window_copy_search_compare(
     }
 }
 
-pub unsafe extern "C" fn window_copy_search_lr(
+pub unsafe fn window_copy_search_lr(
     gd: *mut grid,
     sgd: *mut grid,
     ppx: *mut u32,
@@ -3660,7 +3660,7 @@ pub unsafe extern "C" fn window_copy_search_lr(
     }
 }
 
-pub unsafe extern "C" fn window_copy_search_rl(
+pub unsafe fn window_copy_search_rl(
     gd: *mut grid,
     sgd: *mut grid,
     ppx: *mut u32,
@@ -3711,7 +3711,7 @@ pub unsafe extern "C" fn window_copy_search_rl(
     }
 }
 
-pub unsafe extern "C" fn window_copy_search_lr_regex(
+pub unsafe fn window_copy_search_lr_regex(
     gd: *mut grid,
     ppx: *mut u32,
     psx: *mut u32,
@@ -3799,7 +3799,7 @@ pub unsafe extern "C" fn window_copy_search_lr_regex(
     }
 }
 
-pub unsafe extern "C" fn window_copy_search_rl_regex(
+pub unsafe fn window_copy_search_rl_regex(
     gd: *mut grid,
     ppx: *mut u32,
     psx: *mut u32,
@@ -3849,7 +3849,7 @@ pub unsafe extern "C" fn window_copy_search_rl_regex(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cellstring(
+pub unsafe fn window_copy_cellstring(
     gl: *mut grid_line,
     px: u32,
     size: *mut usize,
@@ -3898,7 +3898,7 @@ pub unsafe extern "C" fn window_copy_cellstring(
 
 /* Find last match in given range. */
 
-pub unsafe extern "C" fn window_copy_last_regex(
+pub unsafe fn window_copy_last_regex(
     gd: *mut grid,
     py: u32,
     first: u32,
@@ -3974,7 +3974,7 @@ pub unsafe extern "C" fn window_copy_last_regex(
 
 /* Stringify line and append to input buffer. Caller frees. */
 
-pub unsafe extern "C" fn window_copy_stringify(
+pub unsafe fn window_copy_stringify(
     gd: *mut grid,
     py: u32,
     first: u32,
@@ -4026,7 +4026,7 @@ pub unsafe extern "C" fn window_copy_stringify(
 
 /* Map start of C string containing UTF-8 data to grid cell position. */
 
-pub unsafe extern "C" fn window_copy_cstrtocellpos(
+pub unsafe fn window_copy_cstrtocellpos(
     gd: *mut grid,
     ncells: u32,
     ppx: *mut u32,
@@ -4133,7 +4133,7 @@ pub unsafe extern "C" fn window_copy_cstrtocellpos(
     }
 }
 
-pub unsafe extern "C" fn window_copy_move_left(
+pub unsafe fn window_copy_move_left(
     s: *mut screen,
     fx: *mut u32,
     fy: *mut u32,
@@ -4158,7 +4158,7 @@ pub unsafe extern "C" fn window_copy_move_left(
     }
 }
 
-pub unsafe extern "C" fn window_copy_move_right(
+pub unsafe fn window_copy_move_right(
     s: *mut screen,
     fx: *mut u32,
     fy: *mut u32,
@@ -4183,7 +4183,7 @@ pub unsafe extern "C" fn window_copy_move_right(
     }
 }
 
-pub unsafe extern "C" fn window_copy_is_lowercase(mut ptr: *const c_char) -> bool {
+pub unsafe fn window_copy_is_lowercase(mut ptr: *const c_char) -> bool {
     unsafe {
         while *ptr != b'\0' as i8 {
             if *ptr as u8 != (*ptr as u8).to_ascii_lowercase() {
@@ -4200,7 +4200,7 @@ pub unsafe extern "C" fn window_copy_is_lowercase(mut ptr: *const c_char) -> boo
  * find the longest overlapping match from previous wrapped lines.
  */
 
-pub unsafe extern "C" fn window_copy_search_back_overlap(
+pub unsafe fn window_copy_search_back_overlap(
     gd: *mut grid,
     preg: *mut libc::regex_t,
     ppx: *mut u32,
@@ -4271,7 +4271,7 @@ pub unsafe extern "C" fn window_copy_search_back_overlap(
  * not found.
  */
 
-pub unsafe extern "C" fn window_copy_search_jump(
+pub unsafe fn window_copy_search_jump(
     wme: *mut window_mode_entry,
     gd: *mut grid,
     sgd: *mut grid,
@@ -4398,7 +4398,7 @@ pub unsafe extern "C" fn window_copy_search_jump(
     }
 }
 
-pub unsafe extern "C" fn window_copy_move_after_search_mark(
+pub unsafe fn window_copy_move_after_search_mark(
     data: *mut window_copy_mode_data,
     fx: *mut u32,
     fy: *mut u32,
@@ -4435,7 +4435,7 @@ pub unsafe extern "C" fn window_copy_move_after_search_mark(
  * down.
  */
 
-pub unsafe extern "C" fn window_copy_search(
+pub unsafe fn window_copy_search(
     wme: *mut window_mode_entry,
     direction: i32,
     mut regex: i32,
@@ -4597,7 +4597,7 @@ pub unsafe extern "C" fn window_copy_search(
     }
 }
 
-pub unsafe extern "C" fn window_copy_visible_lines(
+pub unsafe fn window_copy_visible_lines(
     data: *mut window_copy_mode_data,
     start: *mut u32,
     end: *mut u32,
@@ -4618,7 +4618,7 @@ pub unsafe extern "C" fn window_copy_visible_lines(
     }
 }
 
-pub unsafe extern "C" fn window_copy_search_mark_at(
+pub unsafe fn window_copy_search_mark_at(
     data: *mut window_copy_mode_data,
     px: u32,
     py: u32,
@@ -4639,7 +4639,7 @@ pub unsafe extern "C" fn window_copy_search_mark_at(
     }
 }
 
-pub unsafe extern "C" fn window_copy_search_marks(
+pub unsafe fn window_copy_search_marks(
     wme: *mut window_mode_entry,
     mut ssp: *mut screen,
     regex: i32,
@@ -4832,7 +4832,7 @@ pub unsafe extern "C" fn window_copy_search_marks(
     }
 }
 
-pub unsafe extern "C" fn window_copy_clear_marks(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_clear_marks(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
 
@@ -4841,15 +4841,15 @@ pub unsafe extern "C" fn window_copy_clear_marks(wme: *mut window_mode_entry) {
     }
 }
 
-pub unsafe extern "C" fn window_copy_search_up(wme: *mut window_mode_entry, regex: i32) -> i32 {
+pub unsafe fn window_copy_search_up(wme: *mut window_mode_entry, regex: i32) -> i32 {
     unsafe { window_copy_search(wme, 0, regex) }
 }
 
-pub unsafe extern "C" fn window_copy_search_down(wme: *mut window_mode_entry, regex: i32) -> i32 {
+pub unsafe fn window_copy_search_down(wme: *mut window_mode_entry, regex: i32) -> i32 {
     unsafe { window_copy_search(wme, 1, regex) }
 }
 
-pub unsafe extern "C" fn window_copy_goto_line(
+pub unsafe fn window_copy_goto_line(
     wme: *mut window_mode_entry,
     linestr: *const c_char,
 ) {
@@ -4870,7 +4870,7 @@ pub unsafe extern "C" fn window_copy_goto_line(
     }
 }
 
-pub unsafe extern "C" fn window_copy_match_start_end(
+pub unsafe fn window_copy_match_start_end(
     data: *mut window_copy_mode_data,
     at: u32,
     start: *mut u32,
@@ -4898,7 +4898,7 @@ pub unsafe extern "C" fn window_copy_match_start_end(
     }
 }
 
-pub unsafe extern "C" fn window_copy_match_at_cursor(
+pub unsafe fn window_copy_match_at_cursor(
     data: *mut window_copy_mode_data,
 ) -> *mut c_char {
     unsafe {
@@ -4959,7 +4959,7 @@ pub unsafe extern "C" fn window_copy_match_at_cursor(
     }
 }
 
-pub unsafe extern "C" fn window_copy_update_style(
+pub unsafe fn window_copy_update_style(
     wme: *mut window_mode_entry,
     fx: u32,
     fy: u32,
@@ -5046,7 +5046,7 @@ pub unsafe extern "C" fn window_copy_update_style(
     }
 }
 
-pub unsafe extern "C" fn window_copy_write_one(
+pub unsafe fn window_copy_write_one(
     wme: *mut window_mode_entry,
     ctx: *mut screen_write_ctx,
     py: u32,
@@ -5072,7 +5072,7 @@ pub unsafe extern "C" fn window_copy_write_one(
     }
 }
 
-pub unsafe extern "C" fn window_copy_write_line(
+pub unsafe fn window_copy_write_line(
     wme: *mut window_mode_entry,
     ctx: *mut screen_write_ctx,
     py: u32,
@@ -5190,7 +5190,7 @@ pub unsafe extern "C" fn window_copy_write_line(
     }
 }
 
-pub unsafe extern "C" fn window_copy_write_lines(
+pub unsafe fn window_copy_write_lines(
     wme: *mut window_mode_entry,
     ctx: *mut screen_write_ctx,
     py: u32,
@@ -5203,7 +5203,7 @@ pub unsafe extern "C" fn window_copy_write_lines(
     }
 }
 
-pub unsafe extern "C" fn window_copy_redraw_selection(wme: *mut window_mode_entry, old_y: u32) {
+pub unsafe fn window_copy_redraw_selection(wme: *mut window_mode_entry, old_y: u32) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let gd: *mut grid = (*(*data).backing).grid;
@@ -5226,7 +5226,7 @@ pub unsafe extern "C" fn window_copy_redraw_selection(wme: *mut window_mode_entr
     }
 }
 
-pub unsafe extern "C" fn window_copy_redraw_lines(wme: *mut window_mode_entry, py: u32, ny: u32) {
+pub unsafe fn window_copy_redraw_lines(wme: *mut window_mode_entry, py: u32, ny: u32) {
     unsafe {
         let wp: *mut window_pane = (*wme).wp;
         let data: *mut window_copy_mode_data = (*wme).data.cast();
@@ -5241,7 +5241,7 @@ pub unsafe extern "C" fn window_copy_redraw_lines(wme: *mut window_mode_entry, p
     }
 }
 
-pub unsafe extern "C" fn window_copy_redraw_screen(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_redraw_screen(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
 
@@ -5249,7 +5249,7 @@ pub unsafe extern "C" fn window_copy_redraw_screen(wme: *mut window_mode_entry) 
     }
 }
 
-pub unsafe extern "C" fn window_copy_synchronize_cursor_end(
+pub unsafe fn window_copy_synchronize_cursor_end(
     wme: *mut window_mode_entry,
     mut begin: i32,
     no_reset: i32,
@@ -5331,7 +5331,7 @@ pub unsafe extern "C" fn window_copy_synchronize_cursor_end(
     }
 }
 
-pub unsafe extern "C" fn window_copy_synchronize_cursor(
+pub unsafe fn window_copy_synchronize_cursor(
     wme: *mut window_mode_entry,
     no_reset: i32,
 ) {
@@ -5346,7 +5346,7 @@ pub unsafe extern "C" fn window_copy_synchronize_cursor(
     }
 }
 
-pub unsafe extern "C" fn window_copy_update_cursor(wme: *mut window_mode_entry, cx: u32, cy: u32) {
+pub unsafe fn window_copy_update_cursor(wme: *mut window_mode_entry, cx: u32, cy: u32) {
     unsafe {
         let wp: *mut window_pane = (*wme).wp;
         let data: *mut window_copy_mode_data = (*wme).data.cast();
@@ -5370,7 +5370,7 @@ pub unsafe extern "C" fn window_copy_update_cursor(wme: *mut window_mode_entry, 
     }
 }
 
-pub unsafe extern "C" fn window_copy_start_selection(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_start_selection(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
 
@@ -5386,7 +5386,7 @@ pub unsafe extern "C" fn window_copy_start_selection(wme: *mut window_mode_entry
     }
 }
 
-pub unsafe extern "C" fn window_copy_adjust_selection(
+pub unsafe fn window_copy_adjust_selection(
     wme: *mut window_mode_entry,
     selx: *mut u32,
     sely: *mut u32,
@@ -5423,7 +5423,7 @@ pub unsafe extern "C" fn window_copy_adjust_selection(
     }
 }
 
-pub unsafe extern "C" fn window_copy_update_selection(
+pub unsafe fn window_copy_update_selection(
     wme: *mut window_mode_entry,
     may_redraw: i32,
     no_reset: i32,
@@ -5439,7 +5439,7 @@ pub unsafe extern "C" fn window_copy_update_selection(
     }
 }
 
-pub unsafe extern "C" fn window_copy_set_selection(
+pub unsafe fn window_copy_set_selection(
     wme: *mut window_mode_entry,
     may_redraw: i32,
     no_reset: i32,
@@ -5511,7 +5511,7 @@ pub unsafe extern "C" fn window_copy_set_selection(
     }
 }
 
-pub unsafe extern "C" fn window_copy_get_selection(
+pub unsafe fn window_copy_get_selection(
     wme: *mut window_mode_entry,
     len: *mut usize,
 ) -> *mut c_char {
@@ -5654,7 +5654,7 @@ pub unsafe extern "C" fn window_copy_get_selection(
     }
 }
 
-pub unsafe extern "C" fn window_copy_copy_buffer(
+pub unsafe fn window_copy_copy_buffer(
     wme: *mut window_mode_entry,
     prefix: *const c_char,
     buf: *mut c_void,
@@ -5675,7 +5675,7 @@ pub unsafe extern "C" fn window_copy_copy_buffer(
     }
 }
 
-pub unsafe extern "C" fn window_copy_pipe_run(
+pub unsafe fn window_copy_pipe_run(
     wme: *mut window_mode_entry,
     s: *mut session,
     mut cmd: *const c_char,
@@ -5708,7 +5708,7 @@ pub unsafe extern "C" fn window_copy_pipe_run(
     }
 }
 
-pub unsafe extern "C" fn window_copy_pipe(
+pub unsafe fn window_copy_pipe(
     wme: *mut window_mode_entry,
     s: *mut session,
     cmd: *const c_char,
@@ -5720,7 +5720,7 @@ pub unsafe extern "C" fn window_copy_pipe(
     }
 }
 
-pub unsafe extern "C" fn window_copy_copy_pipe(
+pub unsafe fn window_copy_copy_pipe(
     wme: *mut window_mode_entry,
     s: *mut session,
     prefix: *const c_char,
@@ -5735,7 +5735,7 @@ pub unsafe extern "C" fn window_copy_copy_pipe(
     }
 }
 
-pub unsafe extern "C" fn window_copy_copy_selection(
+pub unsafe fn window_copy_copy_selection(
     wme: *mut window_mode_entry,
     prefix: *const c_char,
 ) {
@@ -5748,7 +5748,7 @@ pub unsafe extern "C" fn window_copy_copy_selection(
     }
 }
 
-pub unsafe extern "C" fn window_copy_append_selection(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_append_selection(wme: *mut window_mode_entry) {
     unsafe {
         let wp: *mut window_pane = (*wme).wp;
         let mut pb: *mut paste_buffer = null_mut();
@@ -5783,7 +5783,7 @@ pub unsafe extern "C" fn window_copy_append_selection(wme: *mut window_mode_entr
     }
 }
 
-pub unsafe extern "C" fn window_copy_copy_line(
+pub unsafe fn window_copy_copy_line(
     wme: *mut window_mode_entry,
     buf: *mut *mut c_char,
     off: *mut usize,
@@ -5862,7 +5862,7 @@ pub unsafe extern "C" fn window_copy_copy_line(
     }
 }
 
-pub unsafe extern "C" fn window_copy_clear_selection(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_clear_selection(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
 
@@ -5880,7 +5880,7 @@ pub unsafe extern "C" fn window_copy_clear_selection(wme: *mut window_mode_entry
     }
 }
 
-pub unsafe extern "C" fn window_copy_in_set(
+pub unsafe fn window_copy_in_set(
     wme: *mut window_mode_entry,
     px: u32,
     py: u32,
@@ -5898,7 +5898,7 @@ pub unsafe extern "C" fn window_copy_in_set(
     }
 }
 
-pub unsafe extern "C" fn window_copy_find_length(wme: *mut window_mode_entry, py: u32) -> u32 {
+pub unsafe fn window_copy_find_length(wme: *mut window_mode_entry, py: u32) -> u32 {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
 
@@ -5906,7 +5906,7 @@ pub unsafe extern "C" fn window_copy_find_length(wme: *mut window_mode_entry, py
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_start_of_line(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_cursor_start_of_line(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let back_s: *mut screen = (*data).backing;
@@ -5924,7 +5924,7 @@ pub unsafe extern "C" fn window_copy_cursor_start_of_line(wme: *mut window_mode_
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_back_to_indentation(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_cursor_back_to_indentation(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let back_s: *mut screen = (*data).backing;
@@ -5942,7 +5942,7 @@ pub unsafe extern "C" fn window_copy_cursor_back_to_indentation(wme: *mut window
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_end_of_line(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_cursor_end_of_line(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let back_s: *mut screen = (*data).backing;
@@ -5973,7 +5973,7 @@ pub unsafe extern "C" fn window_copy_cursor_end_of_line(wme: *mut window_mode_en
     }
 }
 
-pub unsafe extern "C" fn window_copy_other_end(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_other_end(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let s: *mut screen = &raw mut (*data).screen;
@@ -6026,7 +6026,7 @@ pub unsafe extern "C" fn window_copy_other_end(wme: *mut window_mode_entry) {
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_left(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_cursor_left(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let back_s: *mut screen = (*data).backing;
@@ -6044,7 +6044,7 @@ pub unsafe extern "C" fn window_copy_cursor_left(wme: *mut window_mode_entry) {
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_right(wme: *mut window_mode_entry, all: i32) {
+pub unsafe fn window_copy_cursor_right(wme: *mut window_mode_entry, all: i32) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let back_s: *mut screen = (*data).backing;
@@ -6071,7 +6071,7 @@ pub unsafe extern "C" fn window_copy_cursor_right(wme: *mut window_mode_entry, a
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_up(wme: *mut window_mode_entry, scroll_only: i32) {
+pub unsafe fn window_copy_cursor_up(wme: *mut window_mode_entry, scroll_only: i32) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let s: *mut screen = &raw mut (*data).screen;
@@ -6148,7 +6148,7 @@ pub unsafe extern "C" fn window_copy_cursor_up(wme: *mut window_mode_entry, scro
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_down(wme: *mut window_mode_entry, scroll_only: i32) {
+pub unsafe fn window_copy_cursor_down(wme: *mut window_mode_entry, scroll_only: i32) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let s: *mut screen = &raw mut (*data).screen;
@@ -6217,7 +6217,7 @@ pub unsafe extern "C" fn window_copy_cursor_down(wme: *mut window_mode_entry, sc
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_jump(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_cursor_jump(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let back_s: *mut screen = (*data).backing;
@@ -6245,7 +6245,7 @@ pub unsafe extern "C" fn window_copy_cursor_jump(wme: *mut window_mode_entry) {
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_jump_back(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_cursor_jump_back(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let back_s: *mut screen = (*data).backing;
@@ -6265,7 +6265,7 @@ pub unsafe extern "C" fn window_copy_cursor_jump_back(wme: *mut window_mode_entr
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_jump_to(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_cursor_jump_to(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let back_s: *mut screen = (*data).backing;
@@ -6294,7 +6294,7 @@ pub unsafe extern "C" fn window_copy_cursor_jump_to(wme: *mut window_mode_entry)
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_jump_to_back(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_cursor_jump_to_back(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let back_s: *mut screen = (*data).backing;
@@ -6316,7 +6316,7 @@ pub unsafe extern "C" fn window_copy_cursor_jump_to_back(wme: *mut window_mode_e
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_next_word(
+pub unsafe fn window_copy_cursor_next_word(
     wme: *mut window_mode_entry,
     separators: *const c_char,
 ) {
@@ -6348,7 +6348,7 @@ pub unsafe extern "C" fn window_copy_cursor_next_word(
 
 /* Compute the next place where a word ends. */
 
-pub unsafe extern "C" fn window_copy_cursor_next_word_end_pos(
+pub unsafe fn window_copy_cursor_next_word_end_pos(
     wme: *mut window_mode_entry,
     separators: *const c_char,
     ppx: *mut u32,
@@ -6385,7 +6385,7 @@ pub unsafe extern "C" fn window_copy_cursor_next_word_end_pos(
 
 /* Move to the next place where a word ends. */
 
-pub unsafe extern "C" fn window_copy_cursor_next_word_end(
+pub unsafe fn window_copy_cursor_next_word_end(
     wme: *mut window_mode_entry,
     separators: *const c_char,
     no_reset: i32,
@@ -6430,7 +6430,7 @@ pub unsafe extern "C" fn window_copy_cursor_next_word_end(
 
 /* Compute the previous place where a word begins. */
 
-pub unsafe extern "C" fn window_copy_cursor_previous_word_pos(
+pub unsafe fn window_copy_cursor_previous_word_pos(
     wme: *mut window_mode_entry,
     separators: *const c_char,
     ppx: *mut u32,
@@ -6460,7 +6460,7 @@ pub unsafe extern "C" fn window_copy_cursor_previous_word_pos(
 
 /* Move to the previous place where a word begins. */
 
-pub unsafe extern "C" fn window_copy_cursor_previous_word(
+pub unsafe fn window_copy_cursor_previous_word(
     wme: *mut window_mode_entry,
     separators: *const c_char,
     already: i32,
@@ -6492,7 +6492,7 @@ pub unsafe extern "C" fn window_copy_cursor_previous_word(
     }
 }
 
-pub unsafe extern "C" fn window_copy_cursor_prompt(
+pub unsafe fn window_copy_cursor_prompt(
     wme: *mut window_mode_entry,
     direction: i32,
     args: *const c_char,
@@ -6549,7 +6549,7 @@ pub unsafe extern "C" fn window_copy_cursor_prompt(
     }
 }
 
-pub unsafe extern "C" fn window_copy_scroll_up(wme: *mut window_mode_entry, mut ny: u32) {
+pub unsafe fn window_copy_scroll_up(wme: *mut window_mode_entry, mut ny: u32) {
     unsafe {
         let wp: *mut window_pane = (*wme).wp;
         let data: *mut window_copy_mode_data = (*wme).data.cast();
@@ -6588,7 +6588,7 @@ pub unsafe extern "C" fn window_copy_scroll_up(wme: *mut window_mode_entry, mut 
     }
 }
 
-pub unsafe extern "C" fn window_copy_scroll_down(wme: *mut window_mode_entry, mut ny: u32) {
+pub unsafe fn window_copy_scroll_down(wme: *mut window_mode_entry, mut ny: u32) {
     unsafe {
         let wp: *mut window_pane = (*wme).wp;
         let data: *mut window_copy_mode_data = (*wme).data.cast();
@@ -6626,7 +6626,7 @@ pub unsafe extern "C" fn window_copy_scroll_down(wme: *mut window_mode_entry, mu
     }
 }
 
-pub unsafe extern "C" fn window_copy_rectangle_set(wme: *mut window_mode_entry, rectflag: i32) {
+pub unsafe fn window_copy_rectangle_set(wme: *mut window_mode_entry, rectflag: i32) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
 
@@ -6643,7 +6643,7 @@ pub unsafe extern "C" fn window_copy_rectangle_set(wme: *mut window_mode_entry, 
     }
 }
 
-pub unsafe extern "C" fn window_copy_move_mouse(m: *mut mouse_event) {
+pub unsafe fn window_copy_move_mouse(m: *mut mouse_event) {
     unsafe {
         let Some(wp) = cmd_mouse_pane(m, null_mut(), null_mut()) else {
             return;
@@ -6666,7 +6666,7 @@ pub unsafe extern "C" fn window_copy_move_mouse(m: *mut mouse_event) {
     }
 }
 
-pub unsafe extern "C" fn window_copy_start_drag(c: *mut client, m: *mut mouse_event) {
+pub unsafe fn window_copy_start_drag(c: *mut client, m: *mut mouse_event) {
     unsafe {
         let mut wp: *mut window_pane;
         let mut wme: *mut window_mode_entry;
@@ -6726,7 +6726,7 @@ pub unsafe extern "C" fn window_copy_start_drag(c: *mut client, m: *mut mouse_ev
     }
 }
 
-pub unsafe extern "C" fn window_copy_drag_update(c: *mut client, m: *mut mouse_event) {
+pub unsafe fn window_copy_drag_update(c: *mut client, m: *mut mouse_event) {
     unsafe {
         let mut wp: *mut window_pane;
         let mut x: u32 = 0;
@@ -6777,7 +6777,7 @@ pub unsafe extern "C" fn window_copy_drag_update(c: *mut client, m: *mut mouse_e
     }
 }
 
-pub unsafe extern "C" fn window_copy_drag_release(c: *mut client, m: *mut mouse_event) {
+pub unsafe fn window_copy_drag_release(c: *mut client, m: *mut mouse_event) {
     unsafe {
         if c.is_null() {
             return;
@@ -6800,7 +6800,7 @@ pub unsafe extern "C" fn window_copy_drag_release(c: *mut client, m: *mut mouse_
     }
 }
 
-pub unsafe extern "C" fn window_copy_jump_to_mark(wme: *mut window_mode_entry) {
+pub unsafe fn window_copy_jump_to_mark(wme: *mut window_mode_entry) {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
 
@@ -6824,7 +6824,7 @@ pub unsafe extern "C" fn window_copy_jump_to_mark(wme: *mut window_mode_entry) {
 
 /* Scroll up if the cursor went off the visible screen. */
 
-pub unsafe extern "C" fn window_copy_acquire_cursor_up(
+pub unsafe fn window_copy_acquire_cursor_up(
     wme: *mut window_mode_entry,
     hsize: u32,
     oy: u32,
@@ -6859,7 +6859,7 @@ pub unsafe extern "C" fn window_copy_acquire_cursor_up(
 
 /* Scroll down if the cursor went off the visible screen. */
 
-pub unsafe extern "C" fn window_copy_acquire_cursor_down(
+pub unsafe fn window_copy_acquire_cursor_down(
     wme: *mut window_mode_entry,
     hsize: u32,
     sy: u32,

--- a/src/window_copy.rs
+++ b/src/window_copy.rs
@@ -210,7 +210,7 @@ pub struct window_copy_mode_data {
     dragtimer: event,
 }
 
-pub unsafe fn window_copy_scroll_timer(_fd: i32, _events: i16, arg: *mut c_void) {
+pub unsafe extern "C" fn window_copy_scroll_timer(_fd: i32, _events: i16, arg: *mut c_void) {
     unsafe {
         let wme: *mut window_mode_entry = arg.cast();
         let wp: *mut window_pane = (*wme).wp;

--- a/src/window_customize.rs
+++ b/src/window_customize.rs
@@ -99,7 +99,7 @@ pub struct window_customize_modedata {
     change: window_customize_change,
 }
 
-unsafe extern "C" fn window_customize_get_tag(
+unsafe fn window_customize_get_tag(
     o: *mut options_entry,
     idx: i32,
     oe: *const options_table_entry,
@@ -116,7 +116,7 @@ unsafe extern "C" fn window_customize_get_tag(
     }
 }
 
-unsafe extern "C" fn window_customize_get_tree(
+unsafe fn window_customize_get_tree(
     scope: window_customize_scope,
     fs: *mut cmd_find_state,
 ) -> *mut options {
@@ -134,7 +134,7 @@ unsafe extern "C" fn window_customize_get_tree(
     }
 }
 
-unsafe extern "C" fn window_customize_check_item(
+unsafe fn window_customize_check_item(
     data: *mut window_customize_modedata,
     item: *mut window_customize_itemdata,
     mut fsp: *mut cmd_find_state,
@@ -156,7 +156,7 @@ unsafe extern "C" fn window_customize_check_item(
     }
 }
 
-unsafe extern "C" fn window_customize_get_key(
+unsafe fn window_customize_get_key(
     item: *mut window_customize_itemdata,
     ktp: *mut *mut key_table,
     bdp: *mut *mut key_binding,
@@ -180,7 +180,7 @@ unsafe extern "C" fn window_customize_get_key(
     }
 }
 
-unsafe extern "C" fn window_customize_scope_text(
+unsafe fn window_customize_scope_text(
     scope: window_customize_scope,
     fs: *mut cmd_find_state,
 ) -> *mut c_char {
@@ -204,7 +204,7 @@ unsafe extern "C" fn window_customize_scope_text(
     }
 }
 
-unsafe extern "C" fn window_customize_add_item(
+unsafe fn window_customize_add_item(
     data: *mut window_customize_modedata,
 ) -> *mut window_customize_itemdata {
     unsafe {
@@ -220,7 +220,7 @@ unsafe extern "C" fn window_customize_add_item(
     }
 }
 
-unsafe extern "C" fn window_customize_free_item(item: *mut window_customize_itemdata) {
+unsafe fn window_customize_free_item(item: *mut window_customize_itemdata) {
     unsafe {
         free_((*item).table);
         free_((*item).name);
@@ -228,7 +228,7 @@ unsafe extern "C" fn window_customize_free_item(item: *mut window_customize_item
     }
 }
 
-unsafe extern "C" fn window_customize_build_array(
+unsafe fn window_customize_build_array(
     data: *mut window_customize_modedata,
     top: *mut mode_tree_item,
     scope: window_customize_scope,
@@ -268,7 +268,7 @@ unsafe extern "C" fn window_customize_build_array(
     }
 }
 
-unsafe extern "C" fn window_customize_build_option(
+unsafe fn window_customize_build_option(
     data: *mut window_customize_modedata,
     top: *mut mode_tree_item,
     scope: window_customize_scope,
@@ -351,7 +351,7 @@ unsafe extern "C" fn window_customize_build_option(
     }
 }
 
-unsafe extern "C" fn window_customize_find_user_options(
+unsafe fn window_customize_find_user_options(
     oo: *mut options,
     list: *mut *mut *const c_char,
     size: *mut u32,
@@ -384,7 +384,7 @@ unsafe extern "C" fn window_customize_find_user_options(
     }
 }
 
-unsafe extern "C" fn window_customize_build_options(
+unsafe fn window_customize_build_options(
     data: *mut window_customize_modedata,
     title: *const c_char,
     tag: u64,
@@ -474,7 +474,7 @@ unsafe extern "C" fn window_customize_build_options(
     }
 }
 
-unsafe extern "C" fn window_customize_build_keys(
+unsafe fn window_customize_build_keys(
     data: *mut window_customize_modedata,
     kt: *mut key_table,
     mut ft: *mut format_tree,
@@ -608,7 +608,7 @@ unsafe extern "C" fn window_customize_build_keys(
     }
 }
 
-unsafe extern "C" fn window_customize_build(
+unsafe fn window_customize_build(
     modedata: NonNull<c_void>,
     _: *mut mode_tree_sort_criteria,
     _: *mut u64,
@@ -699,7 +699,7 @@ unsafe extern "C" fn window_customize_build(
     }
 }
 
-unsafe extern "C" fn window_customize_draw_key(
+unsafe fn window_customize_draw_key(
     _: *mut window_customize_modedata,
     item: *mut window_customize_itemdata,
     ctx: *mut screen_write_ctx,
@@ -816,7 +816,7 @@ unsafe extern "C" fn window_customize_draw_key(
     }
 }
 
-unsafe extern "C" fn window_customize_draw_option(
+unsafe fn window_customize_draw_option(
     data: *mut window_customize_modedata,
     item: *mut window_customize_itemdata,
     ctx: *mut screen_write_ctx,
@@ -1138,7 +1138,7 @@ unsafe extern "C" fn window_customize_draw_option(
     }
 }
 
-unsafe extern "C" fn window_customize_draw(
+unsafe fn window_customize_draw(
     modedata: *mut c_void,
     itemdata: Option<NonNull<c_void>>,
     ctx: *mut screen_write_ctx,
@@ -1161,7 +1161,7 @@ unsafe extern "C" fn window_customize_draw(
     }
 }
 
-unsafe extern "C" fn window_customize_menu(
+unsafe fn window_customize_menu(
     modedata: NonNull<c_void>,
     c: *mut client,
     key: key_code,
@@ -1182,11 +1182,11 @@ unsafe extern "C" fn window_customize_menu(
     }
 }
 
-unsafe extern "C" fn window_customize_height(_modedata: *mut c_void, _height: u32) -> u32 {
+unsafe fn window_customize_height(_modedata: *mut c_void, _height: u32) -> u32 {
     12
 }
 
-pub unsafe extern "C" fn window_customize_init(
+pub unsafe fn window_customize_init(
     wme: NonNull<window_mode_entry>,
     fs: *mut cmd_find_state,
     args: *mut args,
@@ -1232,7 +1232,7 @@ pub unsafe extern "C" fn window_customize_init(
     }
 }
 
-pub unsafe extern "C" fn window_customize_destroy(data: *mut window_customize_modedata) {
+pub unsafe fn window_customize_destroy(data: *mut window_customize_modedata) {
     unsafe {
         (*data).references -= 1;
         if (*data).references != 0 {
@@ -1250,7 +1250,7 @@ pub unsafe extern "C" fn window_customize_destroy(data: *mut window_customize_mo
     }
 }
 
-pub unsafe extern "C" fn window_customize_free(wme: NonNull<window_mode_entry>) {
+pub unsafe fn window_customize_free(wme: NonNull<window_mode_entry>) {
     unsafe {
         let data: *mut window_customize_modedata = (*wme.as_ptr()).data.cast();
 
@@ -1264,7 +1264,7 @@ pub unsafe extern "C" fn window_customize_free(wme: NonNull<window_mode_entry>) 
     }
 }
 
-pub unsafe extern "C" fn window_customize_resize(
+pub unsafe fn window_customize_resize(
     wme: NonNull<window_mode_entry>,
     sx: u32,
     sy: u32,
@@ -1276,13 +1276,13 @@ pub unsafe extern "C" fn window_customize_resize(
     }
 }
 
-pub unsafe extern "C" fn window_customize_free_callback(modedata: NonNull<c_void>) {
+pub unsafe fn window_customize_free_callback(modedata: NonNull<c_void>) {
     unsafe {
         window_customize_destroy(modedata.cast().as_ptr());
     }
 }
 
-pub unsafe extern "C" fn window_customize_free_item_callback(itemdata: NonNull<c_void>) {
+pub unsafe fn window_customize_free_item_callback(itemdata: NonNull<c_void>) {
     unsafe {
         let item: NonNull<window_customize_itemdata> = itemdata.cast();
         let data: *mut window_customize_modedata = (*item.as_ptr()).data;
@@ -1292,7 +1292,7 @@ pub unsafe extern "C" fn window_customize_free_item_callback(itemdata: NonNull<c
     }
 }
 
-pub unsafe extern "C" fn window_customize_set_option_callback(
+pub unsafe fn window_customize_set_option_callback(
     c: *mut client,
     itemdata: NonNull<c_void>,
     s: *const c_char,
@@ -1352,7 +1352,7 @@ pub unsafe extern "C" fn window_customize_set_option_callback(
     }
 }
 
-pub unsafe extern "C" fn window_customize_set_option(
+pub unsafe fn window_customize_set_option(
     c: *mut client,
     data: *mut window_customize_modedata,
     item: *mut window_customize_itemdata,
@@ -1503,7 +1503,7 @@ pub unsafe extern "C" fn window_customize_set_option(
     }
 }
 
-pub unsafe extern "C" fn window_customize_unset_option(
+pub unsafe fn window_customize_unset_option(
     data: *mut window_customize_modedata,
     item: *mut window_customize_itemdata,
 ) {
@@ -1523,7 +1523,7 @@ pub unsafe extern "C" fn window_customize_unset_option(
     }
 }
 
-pub unsafe extern "C" fn window_customize_reset_option(
+pub unsafe fn window_customize_reset_option(
     data: *mut window_customize_modedata,
     item: *mut window_customize_itemdata,
 ) {
@@ -1546,7 +1546,7 @@ pub unsafe extern "C" fn window_customize_reset_option(
     }
 }
 
-pub unsafe extern "C" fn window_customize_set_command_callback(
+pub unsafe fn window_customize_set_command_callback(
     c: *mut client,
     itemdata: NonNull<c_void>,
     s: *const c_char,
@@ -1591,7 +1591,7 @@ pub unsafe extern "C" fn window_customize_set_command_callback(
     }
 }
 
-pub unsafe extern "C" fn window_customize_set_note_callback(
+pub unsafe fn window_customize_set_note_callback(
     _c: *mut client,
     itemdata: NonNull<c_void>,
     s: *const c_char,
@@ -1621,7 +1621,7 @@ pub unsafe extern "C" fn window_customize_set_note_callback(
     }
 }
 
-pub unsafe extern "C" fn window_customize_set_key(
+pub unsafe fn window_customize_set_key(
     c: *mut client,
     data: *mut window_customize_modedata,
     item: *mut window_customize_itemdata,
@@ -1695,7 +1695,7 @@ pub unsafe extern "C" fn window_customize_set_key(
     }
 }
 
-pub unsafe extern "C" fn window_customize_unset_key(
+pub unsafe fn window_customize_unset_key(
     data: *mut window_customize_modedata,
     item: *mut window_customize_itemdata,
 ) {
@@ -1715,7 +1715,7 @@ pub unsafe extern "C" fn window_customize_unset_key(
     }
 }
 
-pub unsafe extern "C" fn window_customize_reset_key(
+pub unsafe fn window_customize_reset_key(
     data: *mut window_customize_modedata,
     item: *mut window_customize_itemdata,
 ) {
@@ -1739,7 +1739,7 @@ pub unsafe extern "C" fn window_customize_reset_key(
     }
 }
 
-pub unsafe extern "C" fn window_customize_change_each(
+pub unsafe fn window_customize_change_each(
     modedata: NonNull<c_void>,
     itemdata: NonNull<c_void>,
     _c: *mut client,
@@ -1774,7 +1774,7 @@ pub unsafe extern "C" fn window_customize_change_each(
     }
 }
 
-pub unsafe extern "C" fn window_customize_change_current_callback(
+pub unsafe fn window_customize_change_current_callback(
     c: *mut client,
     modedata: NonNull<c_void>,
     s: *const c_char,
@@ -1819,7 +1819,7 @@ pub unsafe extern "C" fn window_customize_change_current_callback(
     }
 }
 
-pub unsafe extern "C" fn window_customize_change_tagged_callback(
+pub unsafe fn window_customize_change_tagged_callback(
     c: *mut client,
     modedata: NonNull<c_void>,
     s: *const c_char,
@@ -1850,7 +1850,7 @@ pub unsafe extern "C" fn window_customize_change_tagged_callback(
     }
 }
 
-pub unsafe extern "C" fn window_customize_key(
+pub unsafe fn window_customize_key(
     wme: NonNull<window_mode_entry>,
     c: *mut client,
     s: *mut session,

--- a/src/window_tree.rs
+++ b/src/window_tree.rs
@@ -144,7 +144,7 @@ struct window_tree_modedata {
     each: u32,
 }
 
-unsafe extern "C" fn window_tree_pull_item(
+unsafe fn window_tree_pull_item(
     item: NonNull<window_tree_itemdata>,
     sp: *mut Option<NonNull<session>>,
     wlp: *mut Option<NonNull<winlink>>,
@@ -198,7 +198,7 @@ unsafe extern "C" fn window_tree_pull_item(
     }
 }
 
-unsafe extern "C" fn window_tree_add_item(
+unsafe fn window_tree_add_item(
     data: NonNull<window_tree_modedata>,
 ) -> *mut window_tree_itemdata {
     unsafe {
@@ -212,7 +212,7 @@ unsafe extern "C" fn window_tree_add_item(
     }
 }
 
-unsafe extern "C" fn window_tree_free_item(item: *mut window_tree_itemdata) {
+unsafe fn window_tree_free_item(item: *mut window_tree_itemdata) {
     unsafe {
         free_(item);
     }
@@ -318,7 +318,7 @@ unsafe extern "C" fn window_tree_cmp_pane(a0: *const c_void, b0: *const c_void) 
     }
 }
 
-unsafe extern "C" fn window_tree_build_pane(
+unsafe fn window_tree_build_pane(
     s: *mut session,
     wl: *mut winlink,
     wp: *mut window_pane,
@@ -356,7 +356,7 @@ unsafe extern "C" fn window_tree_build_pane(
     }
 }
 
-unsafe extern "C" fn window_tree_filter_pane(
+unsafe fn window_tree_filter_pane(
     s: *mut session,
     wl: *mut winlink,
     wp: *mut window_pane,
@@ -375,7 +375,7 @@ unsafe extern "C" fn window_tree_filter_pane(
     }
 }
 
-unsafe extern "C" fn window_tree_build_window(
+unsafe fn window_tree_build_window(
     s: *mut session,
     wl: *mut winlink,
     modedata: NonNull<c_void>,
@@ -488,7 +488,7 @@ unsafe extern "C" fn window_tree_build_window(
     }
 }
 
-unsafe extern "C" fn window_tree_build_session(
+unsafe fn window_tree_build_session(
     s: *mut session,
     modedata: NonNull<c_void>,
     sort_crit: *mut mode_tree_sort_criteria,
@@ -568,7 +568,7 @@ unsafe extern "C" fn window_tree_build_session(
     }
 }
 
-unsafe extern "C" fn window_tree_build(
+unsafe fn window_tree_build(
     modedata: NonNull<c_void>,
     sort_crit: *mut mode_tree_sort_criteria,
     tag: *mut u64,
@@ -636,7 +636,7 @@ unsafe extern "C" fn window_tree_build(
     }
 }
 
-unsafe extern "C" fn window_tree_draw_label(
+unsafe fn window_tree_draw_label(
     ctx: *mut screen_write_ctx,
     px: u32,
     py: u32,
@@ -669,7 +669,7 @@ unsafe extern "C" fn window_tree_draw_label(
     }
 }
 
-unsafe extern "C" fn window_tree_draw_session(
+unsafe fn window_tree_draw_session(
     data: *mut window_tree_modedata,
     s: *mut session,
     ctx: *mut screen_write_ctx,
@@ -833,7 +833,7 @@ unsafe extern "C" fn window_tree_draw_session(
     }
 }
 
-unsafe extern "C" fn window_tree_draw_window(
+unsafe fn window_tree_draw_window(
     data: *mut window_tree_modedata,
     s: *mut session,
     w: *mut window,
@@ -986,7 +986,7 @@ unsafe extern "C" fn window_tree_draw_window(
     }
 }
 
-unsafe extern "C" fn window_tree_draw(
+unsafe fn window_tree_draw(
     modedata: *mut c_void,
     itemdata: Option<NonNull<c_void>>,
     ctx: *mut screen_write_ctx,
@@ -1024,7 +1024,7 @@ unsafe extern "C" fn window_tree_draw(
     }
 }
 
-unsafe extern "C" fn window_tree_search(
+unsafe fn window_tree_search(
     _modedata: *mut c_void,
     itemdata: NonNull<c_void>,
     ss: *const c_char,
@@ -1072,7 +1072,7 @@ unsafe extern "C" fn window_tree_search(
     }
 }
 
-unsafe extern "C" fn window_tree_menu(modedata: NonNull<c_void>, c: *mut client, key: key_code) {
+unsafe fn window_tree_menu(modedata: NonNull<c_void>, c: *mut client, key: key_code) {
     unsafe {
         let data: NonNull<window_tree_modedata> = modedata.cast();
         let wp: NonNull<window_pane> = NonNull::new_unchecked((*data.as_ptr()).wp);
@@ -1084,7 +1084,7 @@ unsafe extern "C" fn window_tree_menu(modedata: NonNull<c_void>, c: *mut client,
     }
 }
 
-unsafe extern "C" fn window_tree_get_key(
+unsafe fn window_tree_get_key(
     modedata: NonNull<c_void>,
     itemdata: NonNull<c_void>,
     line: u32,
@@ -1117,7 +1117,7 @@ unsafe extern "C" fn window_tree_get_key(
     }
 }
 
-unsafe extern "C" fn window_tree_init(
+unsafe fn window_tree_init(
     wme: NonNull<window_mode_entry>,
     fs: *mut cmd_find_state,
     args: *mut args,
@@ -1185,7 +1185,7 @@ unsafe extern "C" fn window_tree_init(
     }
 }
 
-unsafe extern "C" fn window_tree_destroy(data: NonNull<window_tree_modedata>) {
+unsafe fn window_tree_destroy(data: NonNull<window_tree_modedata>) {
     unsafe {
         let data = data.as_ptr();
         (*data).references -= 1;
@@ -1206,7 +1206,7 @@ unsafe extern "C" fn window_tree_destroy(data: NonNull<window_tree_modedata>) {
     }
 }
 
-unsafe extern "C" fn window_tree_free(wme: NonNull<window_mode_entry>) {
+unsafe fn window_tree_free(wme: NonNull<window_mode_entry>) {
     unsafe {
         if let Some(data) = NonNull::new((*wme.as_ptr()).data.cast::<window_tree_modedata>()) {
             (*data.as_ptr()).dead = 1;
@@ -1216,14 +1216,14 @@ unsafe extern "C" fn window_tree_free(wme: NonNull<window_mode_entry>) {
     }
 }
 
-unsafe extern "C" fn window_tree_resize(wme: NonNull<window_mode_entry>, sx: u32, sy: u32) {
+unsafe fn window_tree_resize(wme: NonNull<window_mode_entry>, sx: u32, sy: u32) {
     unsafe {
         let data: *mut window_tree_modedata = (*wme.as_ptr()).data.cast();
         mode_tree_resize((*data).data, sx, sy);
     }
 }
 
-unsafe extern "C" fn window_tree_update(wme: NonNull<window_mode_entry>) {
+unsafe fn window_tree_update(wme: NonNull<window_mode_entry>) {
     unsafe {
         let data: *mut window_tree_modedata = (*wme.as_ptr()).data.cast();
 
@@ -1233,7 +1233,7 @@ unsafe extern "C" fn window_tree_update(wme: NonNull<window_mode_entry>) {
     }
 }
 
-unsafe extern "C" fn window_tree_get_target(
+unsafe fn window_tree_get_target(
     item: NonNull<window_tree_itemdata>,
     fs: *mut cmd_find_state,
 ) -> *mut c_char {
@@ -1284,7 +1284,7 @@ unsafe extern "C" fn window_tree_get_target(
     }
 }
 
-unsafe extern "C" fn window_tree_command_each(
+unsafe fn window_tree_command_each(
     modedata: NonNull<c_void>,
     itemdata: NonNull<c_void>,
     c: *mut client,
@@ -1302,7 +1302,7 @@ unsafe extern "C" fn window_tree_command_each(
     }
 }
 
-unsafe extern "C" fn window_tree_command_done(
+unsafe fn window_tree_command_done(
     _: *mut cmdq_item,
     modedata: *mut c_void,
 ) -> cmd_retval {
@@ -1320,7 +1320,7 @@ unsafe extern "C" fn window_tree_command_done(
     }
 }
 
-unsafe extern "C" fn window_tree_command_callback(
+unsafe fn window_tree_command_callback(
     c: *mut client,
     modedata: NonNull<c_void>,
     s: *const c_char,
@@ -1354,13 +1354,13 @@ unsafe extern "C" fn window_tree_command_callback(
     }
 }
 
-unsafe extern "C" fn window_tree_command_free(modedata: NonNull<c_void>) {
+unsafe fn window_tree_command_free(modedata: NonNull<c_void>) {
     unsafe {
         window_tree_destroy(modedata.cast());
     }
 }
 
-unsafe extern "C" fn window_tree_kill_each(
+unsafe fn window_tree_kill_each(
     _: NonNull<c_void>,
     itemdata: NonNull<c_void>,
     _: *mut client,
@@ -1396,7 +1396,7 @@ unsafe extern "C" fn window_tree_kill_each(
     }
 }
 
-unsafe extern "C" fn window_tree_kill_current_callback(
+unsafe fn window_tree_kill_current_callback(
     c: *mut client,
     modedata: NonNull<c_void>,
     s: *const c_char,
@@ -1426,7 +1426,7 @@ unsafe extern "C" fn window_tree_kill_current_callback(
     }
 }
 
-unsafe extern "C" fn window_tree_kill_tagged_callback(
+unsafe fn window_tree_kill_tagged_callback(
     c: *mut client,
     modedata: NonNull<c_void>,
     s: *const c_char,
@@ -1461,7 +1461,7 @@ unsafe extern "C" fn window_tree_kill_tagged_callback(
     }
 }
 
-unsafe extern "C" fn window_tree_mouse(
+unsafe fn window_tree_mouse(
     data: *mut window_tree_modedata,
     key: key_code,
     mut x: u32,
@@ -1537,7 +1537,7 @@ unsafe extern "C" fn window_tree_mouse(
     }
 }
 
-unsafe extern "C" fn window_tree_key(
+unsafe fn window_tree_key(
     wme: NonNull<window_mode_entry>,
     c: *mut client,
     _: *mut session,

--- a/src/xmalloc.rs
+++ b/src/xmalloc.rs
@@ -88,7 +88,7 @@ pub fn xcalloc1__<'a, T>() -> &'a mut MaybeUninit<T> {
     unsafe { &mut *ptr.cast::<MaybeUninit<T>>() }
 }
 
-pub unsafe extern "C" fn xrealloc(ptr: *mut c_void, size: usize) -> NonNull<c_void> {
+pub unsafe fn xrealloc(ptr: *mut c_void, size: usize) -> NonNull<c_void> {
     unsafe { xrealloc_(ptr, size) }
 }
 
@@ -96,7 +96,7 @@ pub unsafe fn xrealloc_<T>(ptr: *mut T, size: usize) -> NonNull<T> {
     unsafe { xreallocarray_old(ptr, 1, size) }
 }
 
-pub unsafe extern "C" fn xreallocarray(
+pub unsafe fn xreallocarray(
     ptr: *mut c_void,
     nmemb: usize,
     size: usize,
@@ -131,7 +131,7 @@ pub unsafe fn xreallocarray_<T>(ptr: *mut T, nmemb: usize) -> NonNull<T> {
     }
 }
 
-pub unsafe extern "C" fn xrecallocarray(
+pub unsafe fn xrecallocarray(
     ptr: *mut c_void,
     oldnmemb: usize,
     nmemb: usize,
@@ -166,7 +166,7 @@ pub unsafe fn xrecallocarray__<T>(ptr: *mut T, oldnmemb: usize, nmemb: usize) ->
         .cast()
 }
 
-pub unsafe extern "C" fn xstrdup(str: *const c_char) -> NonNull<c_char> {
+pub unsafe fn xstrdup(str: *const c_char) -> NonNull<c_char> {
     NonNull::new(unsafe { strdup(str) }).unwrap()
 }
 
@@ -178,12 +178,12 @@ pub fn xstrdup__<'a>(str: &CStr) -> &'a CStr {
     unsafe { CStr::from_ptr(xstrdup(str.as_ptr()).as_ptr()) }
 }
 
-pub unsafe extern "C" fn xstrndup(str: *const c_char, maxlen: usize) -> NonNull<c_char> {
+pub unsafe fn xstrndup(str: *const c_char, maxlen: usize) -> NonNull<c_char> {
     NonNull::new(unsafe { strndup(str, maxlen) }).unwrap()
 }
 
 // #[allow(improper_ctypes_definitions, reason = "must be extern C to use c variadics")]
-// pub unsafe extern "C" fn xasprintf__(args: std::fmt::Arguments<'_>) -> NonNull<c_char> {}
+// pub unsafe fn xasprintf__(args: std::fmt::Arguments<'_>) -> NonNull<c_char> {}
 
 macro_rules! format_nul {
    ($fmt:literal $(, $args:expr)* $(,)?) => {


### PR DESCRIPTION
This should be reviewed very carefully.

I removed the majority of `extern "C"` prefixes from functions. Since most (all?) internal functions are only called from other Rust functions (and do not need to be exported for them to link against C functions), we can safely remove them. 

There are some cases where I kept them:

- functions that are passed (as pointer) to `libc` functions such as `qsort` or `bsearch`
- a few other ones where I wasn't sure

I ran this and it seems to work. 