### PR TITLE
Make cmp function in GetEntry safe

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -54,8 +54,8 @@ pub struct args_command_state<'a> {
 
 crate::compat::RB_GENERATE!(args_tree, args_entry, entry, discr_entry, args_cmp);
 
-unsafe fn args_cmp(a1: *const args_entry, a2: *const args_entry) -> Ordering {
-    unsafe { ((*a1).flag).cmp(&(*a2).flag) }
+fn args_cmp(a1: &args_entry, a2: &args_entry) -> Ordering {
+    a1.flag.cmp(&a2.flag)
 }
 
 pub unsafe fn args_find(args: *mut args, flag: c_uchar) -> *mut args_entry {

--- a/src/cmd_/cmd_wait_for.rs
+++ b/src/cmd_/cmd_wait_for.rs
@@ -64,8 +64,8 @@ RB_GENERATE!(
     wait_channel_cmp
 );
 
-pub unsafe fn wait_channel_cmp(wc1: *const wait_channel, wc2: *const wait_channel) -> Ordering {
-    unsafe { i32_to_ordering(libc::strcmp((*wc1).name, (*wc2).name)) }
+pub fn wait_channel_cmp(wc1: &wait_channel, wc2: &wait_channel) -> Ordering {
+    unsafe { i32_to_ordering(libc::strcmp(wc1.name, wc2.name)) }
 }
 
 pub unsafe fn cmd_wait_for_add(name: *const c_char) -> *mut wait_channel {

--- a/src/control.rs
+++ b/src/control.rs
@@ -136,8 +136,8 @@ pub const CONTROL_MAXIMUM_AGE: u64 = 300000;
 pub const CONTROL_IGNORE_FLAGS: client_flag =
     client_flag::CONTROL_NOOUTPUT.union(CLIENT_UNATTACHEDFLAGS);
 
-pub unsafe fn control_pane_cmp(cp1: *const control_pane, cp2: *const control_pane) -> Ordering {
-    unsafe { (*cp1).pane.cmp(&(*cp2).pane) }
+pub fn control_pane_cmp(cp1: &control_pane, cp2: &control_pane) -> Ordering {
+    cp1.pane.cmp(&cp2.pane)
 }
 RB_GENERATE!(
     control_panes,
@@ -147,11 +147,8 @@ RB_GENERATE!(
     control_pane_cmp
 );
 
-pub unsafe fn control_sub_cmp(
-    csub1: *const control_sub,
-    csub2: *const control_sub,
-) -> std::cmp::Ordering {
-    unsafe { i32_to_ordering(libc::strcmp((*csub1).name, (*csub2).name)) }
+pub fn control_sub_cmp(csub1: &control_sub, csub2: &control_sub) -> std::cmp::Ordering {
+    unsafe { i32_to_ordering(libc::strcmp(csub1.name, csub2.name)) }
 }
 RB_GENERATE!(
     control_subs,
@@ -161,16 +158,13 @@ RB_GENERATE!(
     control_sub_cmp
 );
 
-pub unsafe fn control_sub_pane_cmp(
-    csp1: *const control_sub_pane,
-    csp2: *const control_sub_pane,
+pub fn control_sub_pane_cmp(
+    csp1: &control_sub_pane,
+    csp2: &control_sub_pane,
 ) -> std::cmp::Ordering {
-    unsafe {
-        (*csp1)
-            .pane
-            .cmp(&(*csp2).pane)
-            .then_with(|| (*csp1).idx.cmp(&(*csp2).idx))
-    }
+    csp1.pane
+        .cmp(&csp2.pane)
+        .then_with(|| csp1.idx.cmp(&csp2.idx))
 }
 RB_GENERATE!(
     control_sub_panes,
@@ -180,16 +174,10 @@ RB_GENERATE!(
     control_sub_pane_cmp
 );
 
-pub unsafe fn control_sub_window_cmp(
-    csw1: *const control_sub_window,
-    csw2: *const control_sub_window,
-) -> Ordering {
-    unsafe {
-        (*csw1)
-            .window
-            .cmp(&(*csw2).window)
-            .then_with(|| (*csw1).idx.cmp(&(*csw2).idx))
-    }
+pub fn control_sub_window_cmp(csw1: &control_sub_window, csw2: &control_sub_window) -> Ordering {
+    csw1.window
+        .cmp(&csw2.window)
+        .then_with(|| csw1.idx.cmp(&csw2.idx))
 }
 RB_GENERATE!(
     control_sub_windows,

--- a/src/environ_.rs
+++ b/src/environ_.rs
@@ -22,14 +22,14 @@ use crate::xmalloc::xcalloc_;
 pub type environ = rb_head<environ_entry>;
 RB_GENERATE!(environ, environ_entry, entry, discr_entry, environ_cmp);
 
-pub unsafe fn environ_cmp(
-    envent1: *const environ_entry,
-    envent2: *const environ_entry,
+pub fn environ_cmp(
+    envent1: &environ_entry,
+    envent2: &environ_entry,
 ) -> std::cmp::Ordering {
     unsafe {
         i32_to_ordering(libc::strcmp(
-            transmute_ptr((*envent1).name),
-            transmute_ptr((*envent2).name),
+            transmute_ptr(envent1.name),
+            transmute_ptr(envent2.name),
         ))
     }
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -41,8 +41,8 @@ pub unsafe fn file_get_path(c: *mut client, file: *const c_char) -> NonNull<c_ch
     }
 }
 
-pub unsafe fn file_cmp(cf1: *const client_file, cf2: *const client_file) -> std::cmp::Ordering {
-    unsafe { (*cf1).stream.cmp(&(*cf2).stream) }
+pub fn file_cmp(cf1: &client_file, cf2: &client_file) -> std::cmp::Ordering {
+    unsafe { cf1.stream.cmp(&cf2.stream) }
 }
 
 pub unsafe fn file_create_with_peer(

--- a/src/format.rs
+++ b/src/format.rs
@@ -80,12 +80,12 @@ RB_GENERATE!(
 );
 
 // Format job tree comparison function.
-pub unsafe fn format_job_cmp(fj1: *const format_job, fj2: *const format_job) -> Ordering {
+pub fn format_job_cmp(fj1: &format_job, fj2: &format_job) -> Ordering {
     unsafe {
-        (*fj1)
+        fj1
             .tag
-            .cmp(&(*fj2).tag)
-            .then_with(|| i32_to_ordering(strcmp((*fj1).cmd, (*fj2).cmd)))
+            .cmp(&fj2.tag)
+            .then_with(|| i32_to_ordering(strcmp(fj1.cmd, fj2.cmd)))
     }
 }
 
@@ -197,8 +197,8 @@ pub struct format_modifier {
 }
 
 /// Format entry tree comparison function.
-unsafe fn format_entry_cmp(fe1: *const format_entry, fe2: *const format_entry) -> Ordering {
-    unsafe { i32_to_ordering(strcmp((*fe1).key, (*fe2).key)) }
+fn format_entry_cmp(fe1: &format_entry, fe2: &format_entry) -> Ordering {
+    unsafe { i32_to_ordering(strcmp(fe1.key, fe2.key)) }
 }
 
 /// Single-character uppercase aliases.

--- a/src/hyperlinks_.rs
+++ b/src/hyperlinks_.rs
@@ -59,23 +59,20 @@ pub struct hyperlinks {
     pub references: u32,
 }
 
-unsafe fn hyperlinks_by_uri_cmp(
-    left: *const hyperlinks_uri,
-    right: *const hyperlinks_uri,
-) -> std::cmp::Ordering {
+fn hyperlinks_by_uri_cmp(left: &hyperlinks_uri, right: &hyperlinks_uri) -> std::cmp::Ordering {
     unsafe {
-        if *(*left).internal_id == b'\0' as _ || *(*right).internal_id == b'\0' as _ {
-            if *(*left).internal_id != b'\0' as _ {
+        if *left.internal_id == b'\0' as _ || *right.internal_id == b'\0' as _ {
+            if *left.internal_id != b'\0' as _ {
                 return Ordering::Less;
             }
-            if *(*right).internal_id != b'\0' as _ {
+            if *right.internal_id != b'\0' as _ {
                 return Ordering::Greater;
             }
-            return (*left).inner.cmp(&(*right).inner);
+            return left.inner.cmp(&right.inner);
         }
 
-        i32_to_ordering(libc::strcmp((*left).internal_id, (*right).internal_id))
-            .then_with(|| i32_to_ordering(libc::strcmp((*left).uri, (*right).uri)))
+        i32_to_ordering(libc::strcmp(left.internal_id, right.internal_id))
+            .then_with(|| i32_to_ordering(libc::strcmp(left.uri, right.uri)))
     }
 }
 
@@ -87,11 +84,8 @@ RB_GENERATE!(
     hyperlinks_by_uri_cmp
 );
 
-unsafe fn hyperlinks_by_inner_cmp(
-    left: *const hyperlinks_uri,
-    right: *const hyperlinks_uri,
-) -> Ordering {
-    unsafe { (*left).inner.cmp(&(*right).inner) }
+fn hyperlinks_by_inner_cmp(left: &hyperlinks_uri, right: &hyperlinks_uri) -> Ordering {
+    left.inner.cmp(&right.inner)
 }
 
 RB_GENERATE!(

--- a/src/input_keys.rs
+++ b/src/input_keys.rs
@@ -41,11 +41,8 @@ impl input_key_entry {
 }
 
 /// Input key comparison function.
-pub unsafe fn input_key_cmp(
-    ike1: *const input_key_entry,
-    ike2: *const input_key_entry,
-) -> Ordering {
-    unsafe { (*ike1).key.cmp(&(*ike2).key) }
+pub fn input_key_cmp(ike1: &input_key_entry, ike2: &input_key_entry) -> Ordering {
+    ike1.key.cmp(&ike2.key)
 }
 
 RB_GENERATE!(

--- a/src/key_bindings_.rs
+++ b/src/key_bindings_.rs
@@ -99,12 +99,12 @@ RB_GENERATE!(
 RB_GENERATE!(key_tables, key_table, entry, discr_entry, key_table_cmp);
 static mut key_tables: key_tables = rb_initializer();
 
-pub unsafe fn key_table_cmp(table1: *const key_table, table2: *const key_table) -> Ordering {
-    unsafe { i32_to_ordering(strcmp((*table1).name, (*table2).name)) }
+pub fn key_table_cmp(table1: &key_table, table2: &key_table) -> Ordering {
+    unsafe { i32_to_ordering(strcmp(table1.name, table2.name)) }
 }
 
-pub unsafe fn key_bindings_cmp(bd1: *const key_binding, bd2: *const key_binding) -> Ordering {
-    unsafe { (*bd1).key.cmp(&(*bd2).key) }
+pub fn key_bindings_cmp(bd1: &key_binding, bd2: &key_binding) -> Ordering {
+    bd1.key.cmp(&bd2.key)
 }
 
 pub unsafe fn key_bindings_free(bd: *mut key_binding) {

--- a/src/options_.rs
+++ b/src/options_.rs
@@ -37,11 +37,8 @@ pub struct options_array_item {
     pub entry: rb_entry<options_array_item>,
 }
 
-pub unsafe fn options_array_cmp(
-    a1: *const options_array_item,
-    a2: *const options_array_item,
-) -> Ordering {
-    unsafe { (*a1).index.cmp(&(*a2).index) }
+pub fn options_array_cmp(a1: &options_array_item, a2: &options_array_item) -> Ordering {
+    a1.index.cmp(&a2.index)
 }
 RB_GENERATE!(
     options_array,
@@ -109,8 +106,8 @@ pub fn OPTIONS_IS_ARRAY(o: *const options_entry) -> bool {
 
 RB_GENERATE!(options_tree, options_entry, entry, discr_entry, options_cmp);
 
-pub unsafe fn options_cmp(lhs: *const options_entry, rhs: *const options_entry) -> Ordering {
-    unsafe { i32_to_ordering(libc::strcmp((*lhs).name, (*rhs).name)) }
+pub fn options_cmp(lhs: &options_entry, rhs: &options_entry) -> Ordering {
+    unsafe { i32_to_ordering(libc::strcmp(lhs.name, rhs.name)) }
 }
 
 pub unsafe fn options_map_name(name: *const c_char) -> *const c_char {

--- a/src/server_acl.rs
+++ b/src/server_acl.rs
@@ -40,11 +40,11 @@ pub struct server_acl_user {
     pub entry: rb_entry<server_acl_user>,
 }
 
-pub unsafe fn server_acl_cmp(
-    user1: *const server_acl_user,
-    user2: *const server_acl_user,
+pub fn server_acl_cmp(
+    user1: &server_acl_user,
+    user2: &server_acl_user,
 ) -> Ordering {
-    unsafe { (*user1).uid.cmp(&(*user2).uid) }
+    user1.uid.cmp(&user2.uid)
 }
 
 pub type server_acl_entries = rb_head<server_acl_user>;

--- a/src/server_client.rs
+++ b/src/server_client.rs
@@ -24,11 +24,8 @@ use crate::{
 };
 
 /// Compare client windows.
-pub unsafe fn server_client_window_cmp(
-    cw1: *const client_window,
-    cw2: *const client_window,
-) -> std::cmp::Ordering {
-    unsafe { (*cw1).window.cmp(&(*cw2).window) }
+pub fn server_client_window_cmp(cw1: &client_window, cw2: &client_window) -> std::cmp::Ordering {
+    cw1.window.cmp(&cw2.window)
 }
 
 /// Number of attached clients.

--- a/src/session_.rs
+++ b/src/session_.rs
@@ -39,12 +39,12 @@ pub static mut next_session_id: u32 = 0;
 
 pub static mut session_groups: session_groups = rb_initializer();
 
-pub unsafe fn session_cmp(s1: *const session, s2: *const session) -> Ordering {
-    unsafe { i32_to_ordering(libc::strcmp((*s1).name, (*s2).name)) }
+pub fn session_cmp(s1: &session, s2: &session) -> Ordering {
+    unsafe { i32_to_ordering(libc::strcmp(s1.name, s2.name)) }
 }
 
-pub unsafe fn session_group_cmp(s1: *const session_group, s2: *const session_group) -> Ordering {
-    unsafe { i32_to_ordering(libc::strcmp((*s1).name, (*s2).name)) }
+pub fn session_group_cmp(s1: &session_group, s2: &session_group) -> Ordering {
+    unsafe { i32_to_ordering(libc::strcmp(s1.name, s2.name)) }
 }
 
 pub unsafe fn session_alive(s: *mut session) -> bool {

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -59,16 +59,10 @@ pub struct utf8_item {
     pub size: c_uchar,
 }
 
-pub unsafe fn utf8_data_cmp(ui1: *const utf8_item, ui2: *const utf8_item) -> std::cmp::Ordering {
-    unsafe {
-        (*ui1).size.cmp(&(*ui2).size).then_with(|| {
-            i32_to_ordering(memcmp(
-                (*ui1).data.as_ptr().cast(),
-                (*ui2).data.as_ptr().cast(),
-                (*ui1).size as usize,
-            ))
-        })
-    }
+pub fn utf8_data_cmp(ui1: &utf8_item, ui2: &utf8_item) -> std::cmp::Ordering {
+    ui1.size
+        .cmp(&ui2.size)
+        .then_with(|| ui1.data[..ui1.size as usize].cmp(&ui2.data[..ui2.size as usize]))
 }
 pub type utf8_data_tree = rb_head<utf8_item>;
 RB_GENERATE!(
@@ -80,8 +74,8 @@ RB_GENERATE!(
 );
 static mut utf8_data_tree: utf8_data_tree = rb_initializer();
 
-pub unsafe fn utf8_index_cmp(ui1: *const utf8_item, ui2: *const utf8_item) -> std::cmp::Ordering {
-    unsafe { (*ui1).index.cmp(&(*ui2).index) }
+pub fn utf8_index_cmp(ui1: &utf8_item, ui2: &utf8_item) -> std::cmp::Ordering {
+    ui1.index.cmp(&ui2.index)
 }
 pub type utf8_index_tree = rb_head<utf8_item>;
 RB_GENERATE!(

--- a/src/window_.rs
+++ b/src/window_.rs
@@ -58,16 +58,16 @@ RB_GENERATE!(
     window_pane_cmp
 );
 
-pub unsafe fn window_cmp(w1: *const window, w2: *const window) -> cmp::Ordering {
-    unsafe { (*w1).id.cmp(&(*w2).id) }
+pub fn window_cmp(w1: &window, w2: &window) -> cmp::Ordering {
+    w1.id.cmp(&w2.id)
 }
 
-pub unsafe fn winlink_cmp(wl1: *const winlink, wl2: *const winlink) -> cmp::Ordering {
-    unsafe { (*wl1).idx.cmp(&(*wl2).idx) }
+pub fn winlink_cmp(wl1: &winlink, wl2: &winlink) -> cmp::Ordering {
+    wl1.idx.cmp(&wl2.idx)
 }
 
-pub unsafe fn window_pane_cmp(wp1: *const window_pane, wp2: *const window_pane) -> cmp::Ordering {
-    unsafe { (*wp1).id.cmp(&(*wp2).id) }
+pub fn window_pane_cmp(wp1: &window_pane, wp2: &window_pane) -> cmp::Ordering {
+    wp1.id.cmp(&wp2.id)
 }
 
 pub unsafe fn winlink_find_by_window(


### PR DESCRIPTION
Make the `cmp` function inside `GetEntry` trait safe and update usages accordingly.

Was playing around with the repo and this looked like a low-hanging fruit