### PR TITLE
Make fn fatal safe in log.rs

### DIFF
--- a/src/client_.rs
+++ b/src/client_.rs
@@ -570,13 +570,13 @@ unsafe fn client_send_identify(
 
         let fd = dup(STDIN_FILENO);
         if fd == -1 {
-            fatal(c"dup failed".as_ptr());
+            fatal("dup failed");
         }
         proc_send(client_peer, msgtype::MSG_IDENTIFY_STDIN, fd, null_mut(), 0);
 
         let fd = dup(STDOUT_FILENO);
         if fd == -1 {
-            fatal(c"dup failed".as_ptr());
+            fatal("dup failed");
         }
         proc_send(client_peer, msgtype::MSG_IDENTIFY_STDOUT, fd, null_mut(), 0);
 
@@ -628,7 +628,7 @@ unsafe fn client_exec(shell: *mut c_char, shellcmd: *mut c_char) {
         closefrom(STDERR_FILENO + 1);
 
         execl(shell, argv0, c"-c".as_ptr(), shellcmd, null_mut::<c_void>());
-        fatal(c"execl failed".as_ptr());
+        fatal("execl failed");
     }
 }
 
@@ -679,7 +679,7 @@ unsafe fn client_signal(sig: i32) {
                     sigact.sa_flags = SA_RESTART;
                     sigact.sa_sigaction = SIG_IGN;
                     if sigaction(SIGTSTP, &raw mut sigact, null_mut()) != 0 {
-                        fatal(c"sigaction failed".as_ptr());
+                        fatal("sigaction failed");
                     }
                     proc_send(client_peer, msgtype::MSG_WAKEUP, -1, null_mut(), 0);
                     client_suspended = 0;
@@ -943,7 +943,7 @@ unsafe fn client_dispatch_attached(imsg: *mut imsg) {
                 sigact.sa_flags = SA_RESTART;
                 sigact.sa_sigaction = SIG_DFL;
                 if sigaction(SIGTSTP, &raw mut sigact, null_mut()) != 0 {
-                    fatal(c"sigaction failed".as_ptr());
+                    fatal("sigaction failed");
                 }
                 client_suspended = 1;
                 kill(std::process::id() as i32, SIGTSTP);

--- a/src/cmd_/cmd_new_session.rs
+++ b/src/cmd_/cmd_new_session.rs
@@ -202,7 +202,7 @@ unsafe fn cmd_new_session_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_ret
                     break 'fail;
                 }
                 if tcgetattr((*c).fd, &raw mut tio) != 0 {
-                    fatal(c"tcgetattr failed".as_ptr());
+                    fatal("tcgetattr failed");
                 }
                 tiop = &raw mut tio;
             } else {

--- a/src/job_.rs
+++ b/src/job_.rs
@@ -186,7 +186,7 @@ pub unsafe fn job_run(
                         }) || chdir(home) != 0)
                         && chdir(c"/".as_ptr()) != 0
                     {
-                        fatal(c"chdir failed".as_ptr());
+                        fatal("chdir failed");
                     }
 
                     environ_push(env);
@@ -194,10 +194,10 @@ pub unsafe fn job_run(
 
                     if !flags.intersects(job_flag::JOB_PTY) {
                         if dup2(out[1], STDIN_FILENO) == -1 {
-                            fatal(c"dup2 failed".as_ptr());
+                            fatal("dup2 failed");
                         }
                         if dup2(out[1], STDOUT_FILENO) == -1 {
-                            fatal(c"dup2 failed".as_ptr());
+                            fatal("dup2 failed");
                         }
                         if out[1] != STDIN_FILENO && out[1] != STDOUT_FILENO {
                             close(out[1]);
@@ -206,10 +206,10 @@ pub unsafe fn job_run(
 
                         nullfd = open(_PATH_DEVNULL, O_RDWR);
                         if nullfd == -1 {
-                            fatal(c"open failed".as_ptr());
+                            fatal("open failed");
                         }
                         if dup2(nullfd, STDERR_FILENO) == -1 {
-                            fatal(c"dup2 failed".as_ptr());
+                            fatal("dup2 failed");
                         }
                         if nullfd != STDERR_FILENO {
                             close(nullfd);
@@ -220,11 +220,11 @@ pub unsafe fn job_run(
                     if !cmd.is_null() {
                         setenv(c"SHELL".as_ptr(), shell, 1);
                         execl(shell, argv0, c"-c".as_ptr(), cmd, null_mut::<c_void>());
-                        fatal(c"execl failed".as_ptr());
+                        fatal("execl failed");
                     } else {
                         argvp = cmd_copy_argv(argc, argv);
                         execvp(*argvp, argvp as *const *const i8);
-                        fatal(c"execvp failed".as_ptr());
+                        fatal("execvp failed");
                     }
                 }
                 _ => (),
@@ -359,7 +359,7 @@ pub unsafe fn job_resize(job: *mut job, sx: c_uint, sy: c_uint) {
         (*ws).ws_row = sy as u16;
 
         if ioctl((*job).fd, TIOCSWINSZ, ws) == -1 {
-            fatal(c"ioctl failed".as_ptr());
+            fatal("ioctl failed");
         }
     }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -163,29 +163,15 @@ fn log_vwrite_rs(args: std::fmt::Arguments, prefix: &str) {
     }
 }
 
-pub unsafe fn fatal(msg: *const c_char) -> ! {
-    unsafe {
-        let mut tmp: [c_char; 256] = [0; 256];
+pub fn fatal(msg: &str) -> ! {
+    let os_error = std::io::Error::last_os_error();
+    let error_msg = os_error.to_string();
 
-        if snprintf(
-            tmp.as_mut_ptr(),
-            size_of_val(&tmp),
-            c"fatal: %s: ".as_ptr(),
-            strerror(errno!()),
-        ) < 0
-        {
-            std::process::exit(1);
-        }
+    let prefix = format!("fatal: {error_msg}: ");
 
-        log_vwrite_rs(
-            format_args!("{}", _s(msg)),
-            CStr::from_ptr(tmp.as_ptr())
-                .to_str()
-                .expect("fatal: invalid utf8"),
-        );
+    log_vwrite_rs(format_args!("{msg}"), &prefix);
 
-        std::process::exit(1)
-    }
+    std::process::exit(1)
 }
 
 macro_rules! fatalx_ {

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -469,16 +469,16 @@ pub unsafe fn proc_fork_and_daemon(fd: *mut i32) -> pid_t {
             &raw mut pair as *mut i32,
         ) != 0
         {
-            fatal(c"socketpair failed".as_ptr());
+            fatal("socketpair failed");
         }
 
         match libc::fork() {
-            -1 => fatal(c"fork failed".as_ptr()),
+            -1 => fatal("fork failed"),
             0 => {
                 close(pair[0]);
                 *fd = pair[1];
                 if libc::daemon(1, 0) != 0 {
-                    fatal(c"daemon failed".as_ptr());
+                    fatal("daemon failed");
                 }
                 0
             }

--- a/src/screen_.rs
+++ b/src/screen_.rs
@@ -176,7 +176,7 @@ pub unsafe fn screen_reset_tabs(s: *mut screen) {
 
         (*s).tabs = bit_alloc(screen_size_x(s));
         if (*s).tabs.is_null() {
-            fatal(c"bit_alloc failed".as_ptr() as *const c_char);
+            fatal("bit_alloc failed");
         }
 
         let mut i = 8;

--- a/src/server.rs
+++ b/src/server.rs
@@ -413,7 +413,7 @@ unsafe extern "C" fn server_accept(fd: i32, events: i16, _data: *mut c_void) {
                     server_add_accept(1);
                     return;
                 }
-                _ => fatal(c"accept failed".as_ptr()),
+                _ => fatal("accept failed"),
             }
         }
 
@@ -513,7 +513,7 @@ unsafe fn server_child_signal() {
                     if errno!() == ECHILD {
                         return;
                     }
-                    fatal(c"waitpid failed".as_ptr());
+                    fatal("waitpid failed");
                 }
                 0 => return,
                 _ => {

--- a/src/server_client.rs
+++ b/src/server_client.rs
@@ -207,7 +207,7 @@ pub unsafe fn server_client_set_key_table(c: *mut client, mut name: *const c_cha
         (*c).keytable = key_bindings_get_table(name, 1);
         (*(*c).keytable).references += 1;
         if libc::gettimeofday(&raw mut (*(*c).keytable).activity_time, null_mut()) != 0 {
-            fatal(c"gettimeofday failed".as_ptr());
+            fatal("gettimeofday failed");
         }
     }
 }
@@ -255,7 +255,7 @@ pub unsafe fn server_client_create(fd: i32) -> *mut client {
         (*c).peer = proc_add_peer(server_proc, fd, Some(server_client_dispatch), c.cast());
 
         if libc::gettimeofday(&raw mut (*c).creation_time, null_mut()) != 0 {
-            fatal(c"gettimeofday failed".as_ptr());
+            fatal("gettimeofday failed");
         }
         memcpy__(&raw mut (*c).activity_time, &raw mut (*c).creation_time);
 
@@ -1832,7 +1832,7 @@ pub unsafe fn server_client_key_callback(item: *mut cmdq_item, data: *mut c_void
 
                 /* Update the activity timer. */
                 if libc::gettimeofday(&raw mut (*c).activity_time, null_mut()) != 0 {
-                    fatal(c"gettimeofday failed".as_ptr());
+                    fatal("gettimeofday failed");
                 }
                 session_update_activity(s, &raw mut (*c).activity_time);
 
@@ -2941,7 +2941,7 @@ pub unsafe fn server_client_dispatch(imsg: *mut imsg, arg: *mut c_void) {
                 let s = (*c).session;
 
                 if libc::gettimeofday(&raw mut (*c).activity_time, null_mut()) != 0 {
-                    fatal(c"gettimeofday failed".as_ptr());
+                    fatal("gettimeofday failed");
                 }
 
                 tty_start_tty(&raw mut (*c).tty);

--- a/src/session_.rs
+++ b/src/session_.rs
@@ -137,7 +137,7 @@ impl session {
             log_debug!("new session {} ${}", _s(s.name), s.id);
 
             if libc::gettimeofday(&raw mut s.creation_time, null_mut()) != 0 {
-                fatal(c"gettimeofday failed".as_ptr());
+                fatal("gettimeofday failed");
             }
             session_update_activity(s.as_mut(), &raw mut s.creation_time);
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -484,7 +484,7 @@ pub unsafe fn spawn_pane(sc: *mut spawn_context, cause: *mut *mut c_char) -> *mu
             } else if chdir(c"/".as_ptr()) == 0 {
                 environ_set!(child, c"PWD".as_ptr(), 0, "/");
             } else {
-                fatal(c"chdir failed".as_ptr());
+                fatal("chdir failed");
             }
 
             /*

--- a/src/tty_.rs
+++ b/src/tty_.rs
@@ -61,7 +61,7 @@ pub unsafe fn tty_create_log() {
             0o644,
         );
         if tty_log_fd != -1 && libc::fcntl(tty_log_fd, libc::F_SETFD, libc::FD_CLOEXEC) == -1 {
-            fatal(c"fcntl failed".as_ptr());
+            fatal("fcntl failed");
         }
     }
 }
@@ -277,7 +277,7 @@ pub unsafe fn tty_open(tty: *mut tty, cause: *mut *mut c_char) -> i32 {
         );
         (*tty).in_ = evbuffer_new();
         if (*tty).in_.is_null() {
-            fatal(c"out of memory".as_ptr());
+            fatal("out of memory");
         }
 
         event_set(
@@ -289,7 +289,7 @@ pub unsafe fn tty_open(tty: *mut tty, cause: *mut *mut c_char) -> i32 {
         );
         (*tty).out = evbuffer_new();
         if (*tty).out.is_null() {
-            fatal(c"out of memory".as_ptr());
+            fatal("out of memory");
         }
 
         evtimer_set(&raw mut (*tty).timer, Some(tty_timer_callback), tty.cast());

--- a/src/window_.rs
+++ b/src/window_.rs
@@ -494,7 +494,7 @@ pub unsafe fn window_pane_send_resize(wp: *mut window_pane, sx: u32, sy: u32) {
         // TODO sun ifdef
 
         if ioctl((*wp).fd, TIOCSWINSZ, &ws) == -1 {
-            fatal(c"ioctl failed".as_ptr());
+            fatal("ioctl failed");
         }
     }
 }


### PR DESCRIPTION
Make `fatal` in `log.rs` safe and update usages accordingly