### PR TITLE
Reduce static mut usage, make some proc functions safe

### DIFF
--- a/src/client_.rs
+++ b/src/client_.rs
@@ -12,6 +12,8 @@
 // IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
 // OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use std::sync::atomic;
+
 use crate::*;
 
 use libc::{
@@ -36,7 +38,7 @@ unsafe extern "C" {
     fn ttyname(fd: i32) -> *mut c_char;
 }
 
-pub static mut client_proc: *mut tmuxproc = null_mut();
+pub static client_proc: atomic::AtomicPtr<tmuxproc> = atomic::AtomicPtr::new(null_mut());
 
 pub static mut client_peer: *mut tmuxpeer = null_mut();
 
@@ -173,7 +175,7 @@ pub unsafe fn client_connect(
                         close(lockfd);
                         return -1;
                     }
-                    fd = server_start(client_proc, flags, base, lockfd, lockfile);
+                    fd = server_start(&mut *client_proc.load(atomic::Ordering::Relaxed), flags, base, lockfd, lockfile);
                 }
 
                 break 'retry;
@@ -244,7 +246,7 @@ pub unsafe fn client_exit_message() -> *const c_char {
 unsafe fn client_exit() {
     unsafe {
         if file_write_left(&raw mut client_files) == 0 {
-            proc_exit(client_proc);
+            proc_exit(&mut *client_proc.load(atomic::Ordering::Relaxed));
         }
     }
 }
@@ -298,8 +300,8 @@ pub unsafe extern "C-unwind" fn client_main(
             free_(values);
         }
 
-        client_proc = proc_start("client");
-        proc_set_signals(client_proc, Some(client_signal));
+        client_proc.store(proc_start("client"), atomic::Ordering::Release);
+        proc_set_signals(&mut *client_proc.load(atomic::Ordering::Relaxed), Some(client_signal));
 
         client_flags = flags;
         log_debug!(
@@ -336,7 +338,7 @@ pub unsafe extern "C-unwind" fn client_main(
             }
             return 1;
         }
-        client_peer = proc_add_peer(client_proc, fd, Some(client_dispatch), null_mut());
+        client_peer = proc_add_peer(&mut *client_proc.load(atomic::Ordering::Relaxed), fd, Some(client_dispatch), null_mut());
 
         cwd = find_cwd();
         if cwd.is_null()
@@ -444,7 +446,7 @@ pub unsafe extern "C-unwind" fn client_main(
             proc_send(client_peer, msg, -1, null_mut(), 0);
         }
 
-        proc_loop(client_proc, None);
+        proc_loop(&mut *client_proc.load(atomic::Ordering::Relaxed), None);
 
         if client_exittype == msgtype::MSG_EXEC {
             if (*&raw const client_flags).intersects(client_flag::CONTROLCONTROL) {
@@ -620,7 +622,7 @@ unsafe fn client_exec(shell: *mut c_char, shellcmd: *mut c_char) {
         );
         setenv(c"SHELL".as_ptr(), shell, 1);
 
-        proc_clear_signals(client_proc, 1);
+        proc_clear_signals(&mut *client_proc.load(atomic::Ordering::Relaxed), 1);
 
         setblocking(STDIN_FILENO, 1);
         setblocking(STDOUT_FILENO, 1);
@@ -654,7 +656,7 @@ unsafe fn client_signal(sig: i32) {
             }
         } else if client_attached == 0 {
             if sig == SIGTERM || sig == SIGHUP {
-                proc_exit(client_proc);
+                proc_exit(&mut *client_proc.load(atomic::Ordering::Relaxed));
             }
         } else {
             match sig {
@@ -712,7 +714,7 @@ unsafe fn client_dispatch(imsg: *mut imsg, _arg: *mut c_void) {
                 client_exitreason = client_exitreason::CLIENT_EXIT_LOST_SERVER;
                 client_exitval = 1;
             }
-            proc_exit(client_proc);
+            proc_exit(&mut *client_proc.load(atomic::Ordering::Relaxed));
             return;
         }
 
@@ -796,7 +798,7 @@ unsafe fn client_dispatch_wait(imsg: *mut imsg) {
                     (*imsg).hdr.peerid & 0xff,
                 );
                 client_exitval = 1;
-                proc_exit(client_proc);
+                proc_exit(&mut *client_proc.load(atomic::Ordering::Relaxed));
             }
             msgtype::MSG_FLAGS => {
                 if datalen != size_of::<u64>() {
@@ -823,7 +825,7 @@ unsafe fn client_dispatch_wait(imsg: *mut imsg) {
             msgtype::MSG_DETACH | msgtype::MSG_DETACHKILL => {
                 proc_send(client_peer, msgtype::MSG_EXITING, -1, null_mut(), 0);
             }
-            msgtype::MSG_EXITED => proc_exit(client_proc),
+            msgtype::MSG_EXITED => proc_exit(&mut *client_proc.load(atomic::Ordering::Relaxed)),
             msgtype::MSG_READ_OPEN => {
                 file_read_open(
                     &raw mut client_files,
@@ -851,7 +853,7 @@ unsafe fn client_dispatch_wait(imsg: *mut imsg) {
             msgtype::MSG_WRITE_CLOSE => file_write_close(&raw mut client_files, imsg),
             msgtype::MSG_OLDSTDERR | msgtype::MSG_OLDSTDIN | msgtype::MSG_OLDSTDOUT => {
                 fprintf(stderr, c"server version is too old for client\n".as_ptr());
-                proc_exit(client_proc);
+                proc_exit(&mut *client_proc.load(atomic::Ordering::Relaxed));
             }
             _ => (), // TODO
         }
@@ -922,7 +924,7 @@ unsafe fn client_dispatch_attached(imsg: *mut imsg) {
                     fatalx(c"bad MSG_EXITED size");
                 }
 
-                proc_exit(client_proc);
+                proc_exit(&mut *client_proc.load(atomic::Ordering::Relaxed));
             }
             msgtype::MSG_SHUTDOWN => {
                 if datalen != 0 {

--- a/src/client_.rs
+++ b/src/client_.rs
@@ -298,7 +298,7 @@ pub unsafe extern "C-unwind" fn client_main(
             free_(values);
         }
 
-        client_proc = proc_start(c"client");
+        client_proc = proc_start("client");
         proc_set_signals(client_proc, Some(client_signal));
 
         client_flags = flags;

--- a/src/cmd_/cmd_pipe_pane.rs
+++ b/src/cmd_/cmd_pipe_pane.rs
@@ -12,6 +12,8 @@
 // IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
 // OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use std::sync::atomic;
+
 use crate::*;
 
 use libc::{
@@ -127,7 +129,7 @@ pub unsafe fn cmd_pipe_pane_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_r
                 cmd_retval::CMD_RETURN_ERROR
             }
             0 => {
-                proc_clear_signals(server_proc, 1);
+                proc_clear_signals(&mut *server_proc.load(atomic::Ordering::Relaxed), 1);
                 sigprocmask(SIG_SETMASK, &oldset, null_mut());
                 close(pipe_fd[0]);
 

--- a/src/cmd_/cmd_queue.rs
+++ b/src/cmd_/cmd_queue.rs
@@ -588,7 +588,7 @@ pub unsafe fn cmdq_add_message(item: *mut cmdq_item) {
 
         let tmp = cmd_print((*item).cmd);
         if !c.is_null() {
-            let uid = proc_get_peer_uid((*c).peer);
+            let uid = proc_get_peer_uid(&*(*c).peer);
             if uid != -1i32 as uid_t && uid != getuid() {
                 let pw = getpwuid(uid);
                 if !pw.is_null() {

--- a/src/cmd_/cmd_server_access.rs
+++ b/src/cmd_/cmd_server_access.rs
@@ -37,7 +37,7 @@ unsafe fn cmd_server_access_deny(item: *mut cmdq_item, pw: *mut libc::passwd) ->
             return cmd_retval::CMD_RETURN_ERROR;
         }
         for loop_ in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
-            let uid = proc_get_peer_uid((*loop_).peer);
+            let uid = proc_get_peer_uid(&*(*loop_).peer);
             if uid == server_acl_get_uid(user) {
                 (*loop_).exit_message = xstrdup_(c"access not allowed").as_ptr();
                 (*loop_).flags |= client_flag::EXIT;

--- a/src/format.rs
+++ b/src/format.rs
@@ -1601,7 +1601,7 @@ pub unsafe fn format_cb_client_tty(ft: *mut format_tree) -> *mut c_void {
 pub unsafe fn format_cb_client_uid(ft: *mut format_tree) -> *mut c_void {
     unsafe {
         if !(*ft).c.is_null() {
-            let uid = proc_get_peer_uid((*(*ft).c).peer);
+            let uid = proc_get_peer_uid(&*(*(*ft).c).peer);
             if uid != -1_i32 as uid_t {
                 return format_printf!("{}", uid as c_long).cast();
             }
@@ -1613,7 +1613,7 @@ pub unsafe fn format_cb_client_uid(ft: *mut format_tree) -> *mut c_void {
 pub unsafe fn format_cb_client_user(ft: *mut format_tree) -> *mut c_void {
     unsafe {
         if !(*ft).c.is_null() {
-            let uid = proc_get_peer_uid((*(*ft).c).peer);
+            let uid = proc_get_peer_uid(&*(*(*ft).c).peer);
             if uid != -1_i32 as uid_t
                 && let Some(pw) = NonNull::new(libc::getpwuid(uid))
             {

--- a/src/job_.rs
+++ b/src/job_.rs
@@ -12,6 +12,8 @@
 // IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
 // OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use std::sync::atomic;
+
 use crate::*;
 
 use libc::{
@@ -176,7 +178,7 @@ pub unsafe fn job_run(
                     break 'fail;
                 }
                 0 => {
-                    proc_clear_signals(server_proc, 1);
+                    proc_clear_signals(&mut *server_proc.load(atomic::Ordering::Relaxed), 1);
                     sigprocmask(SIG_SETMASK, oldset.as_mut_ptr(), null_mut());
 
                     if (cwd.is_null() || chdir(cwd) != 0)

--- a/src/log.rs
+++ b/src/log.rs
@@ -54,7 +54,7 @@ pub fn log_get_level() -> i32 {
     log_level.load(DEFAULT_ORDERING)
 }
 
-pub fn log_open(name: &CStr) {
+pub fn log_open(name: &str) {
     if log_level.load(DEFAULT_ORDERING) == 0 {
         return;
     }
@@ -66,7 +66,7 @@ pub fn log_open(name: &CStr) {
         .write(true)
         .append(true)
         .create(true)
-        .open(format!("tmux-{}-{}.log", name.to_str().unwrap(), pid))
+        .open(format!("tmux-{name}-{pid}.log"))
     else {
         return;
     };
@@ -75,7 +75,7 @@ pub fn log_open(name: &CStr) {
     unsafe { event_set_log_callback(Some(log_event_cb)) };
 }
 
-pub fn log_toggle(name: &CStr) {
+pub fn log_toggle(name: &str) {
     if log_level.fetch_xor(1, DEFAULT_ORDERING) == 0 {
         log_open(name);
         log_debug!("log opened");

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -11,6 +11,9 @@
 // WHATSOEVER RESULTING FROM LOSS OF MIND, USE, DATA OR PROFITS, WHETHER
 // IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
 // OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use std::sync::atomic;
+
 use crate::*;
 
 use libc::{
@@ -245,21 +248,21 @@ pub unsafe fn proc_start(name: &str) -> *mut tmuxproc {
     }
 }
 
-pub unsafe fn proc_loop(tp: *mut tmuxproc, loopcb: Option<unsafe fn() -> i32>) {
+pub fn proc_loop(tp: &mut tmuxproc, loopcb: Option<unsafe fn() -> i32>) {
     unsafe {
-        log_debug!("{} loop enter", (*tp).name);
+        log_debug!("{} loop enter", tp.name);
         match loopcb {
             None => loop {
                 event_loop(EVLOOP_ONCE);
 
-                if (*tp).exit != 0 {
+                if tp.exit != 0 {
                     break;
                 }
             },
             Some(loopcb) => loop {
                 event_loop(EVLOOP_ONCE);
 
-                if (*tp).exit != 0 {
+                if tp.exit != 0 {
                     break;
                 }
 
@@ -268,24 +271,24 @@ pub unsafe fn proc_loop(tp: *mut tmuxproc, loopcb: Option<unsafe fn() -> i32>) {
                 }
             },
         }
-        log_debug!("{} loop exit", (*tp).name);
+        log_debug!("{} loop exit", tp.name);
     }
 }
 
-pub unsafe fn proc_exit(tp: *mut tmuxproc) {
+pub fn proc_exit(tp: &mut tmuxproc) {
     unsafe {
-        for peer in tailq_foreach(&raw mut (*tp).peers).map(NonNull::as_ptr) {
+        for peer in tailq_foreach(&raw mut tp.peers).map(NonNull::as_ptr) {
             imsg_flush(&raw mut (*peer).ibuf);
         }
-        (*tp).exit = 1;
+        tp.exit = 1;
     }
 }
 
-pub unsafe fn proc_set_signals(tp: *mut tmuxproc, signalcb: Option<unsafe fn(i32)>) {
+pub fn proc_set_signals(tp: &mut tmuxproc, signalcb: Option<unsafe fn(i32)>) {
     unsafe {
         let mut sa: sigaction = zeroed();
 
-        (*tp).signalcb = signalcb;
+        tp.signalcb = signalcb;
 
         sigemptyset(&raw mut sa.sa_mask);
         sa.sa_flags = SA_RESTART;
@@ -298,65 +301,65 @@ pub unsafe fn proc_set_signals(tp: *mut tmuxproc, signalcb: Option<unsafe fn(i32
         sigaction(SIGQUIT, &sa, null_mut());
 
         signal_set(
-            &raw mut (*tp).ev_sigint,
+            &raw mut tp.ev_sigint,
             SIGINT,
             Some(proc_signal_cb),
-            tp.cast(),
+            (tp as *mut tmuxproc).cast(),
         );
-        signal_add(&raw mut (*tp).ev_sigint, null_mut());
+        signal_add(&raw mut tp.ev_sigint, null_mut());
         signal_set(
-            &raw mut (*tp).ev_sighup,
+            &raw mut tp.ev_sighup,
             SIGHUP,
             Some(proc_signal_cb),
-            tp.cast(),
+            (tp as *mut tmuxproc).cast(),
         );
-        signal_add(&raw mut (*tp).ev_sighup, null_mut());
+        signal_add(&raw mut tp.ev_sighup, null_mut());
         signal_set(
-            &raw mut (*tp).ev_sigchld,
+            &raw mut tp.ev_sigchld,
             SIGCHLD,
             Some(proc_signal_cb),
-            tp.cast(),
+            (tp as *mut tmuxproc).cast(),
         );
-        signal_add(&raw mut (*tp).ev_sigchld, null_mut());
+        signal_add(&raw mut tp.ev_sigchld, null_mut());
         signal_set(
-            &raw mut (*tp).ev_sigcont,
+            &raw mut tp.ev_sigcont,
             SIGCONT,
             Some(proc_signal_cb),
-            tp.cast(),
+            (tp as *mut tmuxproc).cast(),
         );
-        signal_add(&raw mut (*tp).ev_sigcont, null_mut());
+        signal_add(&raw mut tp.ev_sigcont, null_mut());
         signal_set(
-            &raw mut (*tp).ev_sigterm,
+            &raw mut tp.ev_sigterm,
             SIGTERM,
             Some(proc_signal_cb),
-            tp.cast(),
+            (tp as *mut tmuxproc).cast(),
         );
-        signal_add(&raw mut (*tp).ev_sigterm, null_mut());
+        signal_add(&raw mut tp.ev_sigterm, null_mut());
         signal_set(
-            &raw mut (*tp).ev_sigusr1,
+            &raw mut tp.ev_sigusr1,
             SIGUSR1,
             Some(proc_signal_cb),
-            tp.cast(),
+            (tp as *mut tmuxproc).cast(),
         );
-        signal_add(&raw mut (*tp).ev_sigusr1, null_mut());
+        signal_add(&raw mut tp.ev_sigusr1, null_mut());
         signal_set(
-            &raw mut (*tp).ev_sigusr2,
+            &raw mut tp.ev_sigusr2,
             SIGUSR2,
             Some(proc_signal_cb),
-            tp.cast(),
+            (tp as *mut tmuxproc).cast(),
         );
-        signal_add(&raw mut (*tp).ev_sigusr2, null_mut());
+        signal_add(&raw mut tp.ev_sigusr2, null_mut());
         signal_set(
-            &raw mut (*tp).ev_sigwinch,
+            &raw mut tp.ev_sigwinch,
             SIGWINCH,
             Some(proc_signal_cb),
-            tp.cast(),
+            (tp as *mut tmuxproc).cast(),
         );
-        signal_add(&raw mut (*tp).ev_sigwinch, null_mut());
+        signal_add(&raw mut tp.ev_sigwinch, null_mut());
     }
 }
 
-pub unsafe fn proc_clear_signals(tp: *mut tmuxproc, defaults: i32) {
+pub fn proc_clear_signals(tp: &mut tmuxproc, defaults: i32) {
     unsafe {
         let mut sa: sigaction = zeroed();
 
@@ -367,14 +370,14 @@ pub unsafe fn proc_clear_signals(tp: *mut tmuxproc, defaults: i32) {
         sigaction(SIGPIPE, &raw mut sa, null_mut());
         sigaction(SIGTSTP, &raw mut sa, null_mut());
 
-        event_del(&raw mut (*tp).ev_sigint);
-        event_del(&raw mut (*tp).ev_sighup);
-        event_del(&raw mut (*tp).ev_sigchld);
-        event_del(&raw mut (*tp).ev_sigcont);
-        event_del(&raw mut (*tp).ev_sigterm);
-        event_del(&raw mut (*tp).ev_sigusr1);
-        event_del(&raw mut (*tp).ev_sigusr2);
-        event_del(&raw mut (*tp).ev_sigwinch);
+        event_del(&raw mut tp.ev_sigint);
+        event_del(&raw mut tp.ev_sighup);
+        event_del(&raw mut tp.ev_sigchld);
+        event_del(&raw mut tp.ev_sigcont);
+        event_del(&raw mut tp.ev_sigterm);
+        event_del(&raw mut tp.ev_sigusr1);
+        event_del(&raw mut tp.ev_sigusr2);
+        event_del(&raw mut tp.ev_sigwinch);
 
         if defaults != 0 {
             sigaction(SIGINT, &sa, null_mut());
@@ -391,7 +394,7 @@ pub unsafe fn proc_clear_signals(tp: *mut tmuxproc, defaults: i32) {
 }
 
 pub unsafe fn proc_add_peer(
-    tp: *mut tmuxproc,
+    tp: &mut tmuxproc,
     fd: i32,
     dispatchcb: Option<unsafe fn(*mut imsg, *mut c_void)>,
     arg: *mut c_void,
@@ -418,7 +421,7 @@ pub unsafe fn proc_add_peer(
         }
 
         log_debug!("add peer {:p}: {} ({:p})", peer, fd, arg);
-        tailq_insert_tail(&raw mut (*tp).peers, peer);
+        tailq_insert_tail(&raw mut tp.peers, peer);
 
         proc_update_event(peer);
         peer
@@ -438,10 +441,8 @@ pub unsafe fn proc_remove_peer(peer: *mut tmuxpeer) {
     }
 }
 
-pub unsafe fn proc_kill_peer(peer: *mut tmuxpeer) {
-    unsafe {
-        (*peer).flags |= PEER_BAD;
-    }
+pub fn proc_kill_peer(peer: &mut tmuxpeer) {
+    peer.flags |= PEER_BAD;
 }
 
 pub unsafe fn proc_flush_peer(peer: *mut tmuxpeer) {
@@ -450,10 +451,8 @@ pub unsafe fn proc_flush_peer(peer: *mut tmuxpeer) {
     }
 }
 
-pub unsafe fn proc_toggle_log(tp: *mut tmuxproc) {
-    unsafe {
-        log_toggle(&(*tp).name);
-    }
+pub fn proc_toggle_log(tp: &tmuxproc) {
+        log_toggle(&tp.name);
 }
 
 #[cfg_attr(target_os = "macos", expect(deprecated))]
@@ -491,6 +490,6 @@ pub unsafe fn proc_fork_and_daemon(fd: *mut i32) -> pid_t {
     }
 }
 
-pub unsafe fn proc_get_peer_uid(peer: *const tmuxpeer) -> uid_t {
-    unsafe { (*peer).uid }
+pub fn proc_get_peer_uid(peer: &tmuxpeer) -> uid_t {
+    peer.uid
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -217,7 +217,7 @@ pub unsafe fn server_start(
         if event_reinit(base) != 0 {
             fatalx(c"event_reinit failed");
         }
-        server_proc = proc_start(c"server");
+        server_proc = proc_start("server");
 
         proc_set_signals(server_proc, Some(server_signal));
         sigprocmask(SIG_SETMASK, &raw mut oldset, null_mut());

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,9 @@
 // WHATSOEVER RESULTING FROM LOSS OF MIND, USE, DATA OR PROFITS, WHETHER
 // IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
 // OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use std::sync::atomic;
+
 use crate::*;
 
 use libc::{
@@ -28,9 +31,11 @@ use crate::compat::{
     tree::{rb_empty, rb_foreach, rb_init},
 };
 
+
 pub static mut clients: clients = unsafe { zeroed() };
 
-pub static mut server_proc: *mut tmuxproc = null_mut();
+pub static server_proc: atomic::AtomicPtr<tmuxproc> = atomic::AtomicPtr::new(null_mut());
+
 // TODO remove
 pub static mut server_fd: c_int = -1;
 // TODO remove
@@ -171,7 +176,7 @@ unsafe extern "C" fn server_tidy_event(_fd: i32, _events: i16, _data: *mut c_voi
 }
 
 pub unsafe fn server_start(
-    client: *mut tmuxproc,
+    client: &mut tmuxproc,
     flags: client_flag,
     base: *mut event_base,
     lockfd: c_int,
@@ -217,9 +222,12 @@ pub unsafe fn server_start(
         if event_reinit(base) != 0 {
             fatalx(c"event_reinit failed");
         }
-        server_proc = proc_start("server");
+        server_proc.store(proc_start("server"), atomic::Ordering::Release);
 
-        proc_set_signals(server_proc, Some(server_signal));
+        proc_set_signals(
+            &mut *server_proc.load(atomic::Ordering::Relaxed),
+            Some(server_signal),
+        );
         sigprocmask(SIG_SETMASK, &raw mut oldset, null_mut());
 
         if log_get_level() > 1 {
@@ -275,7 +283,10 @@ pub unsafe fn server_start(
         server_acl_init();
 
         server_add_accept(0);
-        proc_loop(server_proc, Some(server_loop));
+        proc_loop(
+            &mut *server_proc.load(atomic::Ordering::Relaxed),
+            Some(server_loop),
+        );
 
         job_kill_all();
         status_prompt_save_history();
@@ -489,7 +500,7 @@ unsafe fn server_signal(sig: i32) {
                 }
                 server_add_accept(0);
             }
-            libc::SIGUSR2 => proc_toggle_log(server_proc),
+            libc::SIGUSR2 => proc_toggle_log(&*server_proc.load(atomic::Ordering::Relaxed)),
             _ => {
                 // nop
             }

--- a/src/server_acl.rs
+++ b/src/server_acl.rs
@@ -128,7 +128,7 @@ pub unsafe fn server_acl_user_allow_write(mut uid: uid_t) {
         (*user).flags &= !server_acl_user_flags::SERVER_ACL_READONLY;
 
         for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
-            uid = proc_get_peer_uid((*c).peer);
+            uid = proc_get_peer_uid(&*(*c).peer);
             if uid != -1i32 as uid_t && uid == (*user).uid {
                 (*c).flags &= !client_flag::READONLY;
             }
@@ -146,7 +146,7 @@ pub unsafe fn server_acl_user_deny_write(mut uid: uid_t) {
             (*user).flags |= server_acl_user_flags::SERVER_ACL_READONLY;
 
             for c in tailq_foreach(&raw mut clients).map(NonNull::as_ptr) {
-                uid = proc_get_peer_uid((*c).peer);
+                uid = proc_get_peer_uid(&*(*c).peer);
                 if uid != -1i32 as uid_t && uid == (*user).uid {
                     (*c).flags &= !client_flag::READONLY;
                 }
@@ -157,7 +157,7 @@ pub unsafe fn server_acl_user_deny_write(mut uid: uid_t) {
 
 pub unsafe fn server_acl_join(c: *mut client) -> c_int {
     unsafe {
-        let uid = proc_get_peer_uid((*c).peer);
+        let uid = proc_get_peer_uid(&*(*c).peer);
         if uid == -1i32 as uid_t {
             return 0;
         }

--- a/src/server_client.rs
+++ b/src/server_client.rs
@@ -11,6 +11,8 @@
 // WHATSOEVER RESULTING FROM LOSS OF MIND, USE, DATA OR PROFITS, WHETHER
 // IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
 // OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+use std::sync::atomic;
+
 use crate::*;
 
 use crate::{
@@ -252,7 +254,7 @@ pub unsafe fn server_client_create(fd: i32) -> *mut client {
 
         let c: *mut client = xcalloc1();
         (*c).references = 1;
-        (*c).peer = proc_add_peer(server_proc, fd, Some(server_client_dispatch), c.cast());
+        (*c).peer = proc_add_peer(&mut *server_proc.load(atomic::Ordering::Relaxed), fd, Some(server_client_dispatch), c.cast());
 
         if libc::gettimeofday(&raw mut (*c).creation_time, null_mut()) != 0 {
             fatal("gettimeofday failed");
@@ -3254,7 +3256,7 @@ pub unsafe fn server_client_dispatch_shell(c: *mut client) {
             strlen(shell) + 1,
         );
 
-        proc_kill_peer((*c).peer);
+        proc_kill_peer(&mut *(*c).peer);
     }
 }
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -12,6 +12,8 @@
 // IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
 // OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use std::sync::atomic;
+
 use crate::*;
 
 use crate::compat::{
@@ -512,7 +514,7 @@ pub unsafe fn spawn_pane(sc: *mut spawn_context, cause: *mut *mut c_char) -> *mu
             }
 
             /* Clean up file descriptors and signals and update the environment. */
-            proc_clear_signals(server_proc, 1);
+            proc_clear_signals(&mut *server_proc.load(atomic::Ordering::Relaxed), 1);
             closefrom(STDERR_FILENO + 1);
             sigprocmask(SIG_SETMASK, &raw mut oldset, null_mut());
             log_close();


### PR DESCRIPTION
Depends on #25 

- Changed `server_proc` and `client_proc` into `AtomicPtr`
- Modified some `proc_` functions to take references rather than pointers

I am unfamiliar with the atomic ordering, would appreciate guidance