### PR TITLE
nix: add some tools to the developer shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,9 @@
         devShells.default = craneLib.devShell {
           checks = self.checks.${system};
           packages = [
+            pkgs.rust-analyzer
+            pkgs.clippy
+            pkgs.rustfmt
           ];
         };
       }


### PR DESCRIPTION
Hello :wave: 

I didn't review #14 properly, and I missed the fact that there was no tooling installed in the devShell. This commit add `rust-analyzer`, `clippy`, and `rustfmt` to the devShell to make development easier for nix users.

@xfbs I never used crane before, so you may want to give this a look and tell me if it's alright or if there's some default that crane provide I don't know about and could use instead of specifying the different tools. :)