### PR TITLE
Use pkg-config to search for libevent library on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +408,7 @@ dependencies = [
  "lalrpop-util",
  "libc",
  "paste",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ paste        = { version = "1.0.15" }
 [build-dependencies]
 lalrpop      = { version = "0.22.2", default-features = false }
 
+[target.'cfg(target_os = "macos")'.build-dependencies]
+pkg-config   = { version = "0.3.32" }
+
 # https://doc.rust-lang.org/rustc/lints/index.html
 [lints.rust]
 unpredictable_function_pointer_comparisons = "allow" # FIXME

--- a/build.rs
+++ b/build.rs
@@ -3,4 +3,10 @@ fn main() {
     lalrpop::process_root().unwrap();
 
     // ncurses and event_core referenced through #[link] on extern block
+
+    // Look for libevent_core using pkg-config
+    #[cfg(target_os = "macos")]
+    if pkg_config::probe_library("libevent_core").is_err() {
+        println!("cargo::warning=Could not find libevent_core using pkg-config");
+    }
 }


### PR DESCRIPTION
This adds the necessary linker flags automatically. Print a warning from build.rs if libevent is not found.

In particular, this is useful on macOS, where libevent is commonly installed by homebrew to a location that linkers don't use by default.