### PR TITLE
Fix parsing of the blue component in hex color notation

### DIFF
--- a/src/colour.rs
+++ b/src/colour.rs
@@ -180,7 +180,7 @@ pub fn colour_fromstring_(s: &str) -> c_int {
         }
         if let Ok(r) = u8::from_str_radix(&s[1..3], 16)
             && let Ok(g) = u8::from_str_radix(&s[3..5], 16)
-            && let Ok(b) = u8::from_str_radix(&s[5..6], 16)
+            && let Ok(b) = u8::from_str_radix(&s[5..7], 16)
         {
             return colour_join_rgb(r, g, b);
         } else {


### PR DESCRIPTION
Closes #66

Full disclosure: there are still inaccuracies in the color rendering, but they are minor. For instance, #002030 renders as dark grey, not as dark blue-green. Maybe tmux-rs doesn't understand that my terminal is true color capable.

However, this PR is obviously correct and fixes a major inaccuracy.