### PR TITLE
Lower MSRV to 1.87, stop using let chains

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ include      = ["/src", "COPYING", "README.md", "build.rs"]
 keywords     = ["tmux"]
 license      = "ISC"
 repository   = "https://github.com/richardscollin/tmux-rs"
-rust-version = "1.88" # let chains
+rust-version = "1.87"
 description  = "A Rust port of tmux"
 
 # Note: none of these features are supported yet

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -862,7 +862,7 @@ pub unsafe fn args_make_commands_free(state: *mut args_command_state) {
                 .pi
                 .file
                 .map(|p| p.as_ptr())
-                .unwrap_or_default()
+                .unwrap_or(null_mut())
                 .cast_mut(),
         ); // TODO casting away const
         free_((*state).cmd);

--- a/src/cmd_/cmd_command_prompt.rs
+++ b/src/cmd_/cmd_command_prompt.rs
@@ -33,7 +33,6 @@ struct cmd_command_prompt_prompt {
     prompt: *mut u8,
 }
 
-#[derive(Default)]
 struct cmd_command_prompt_cdata<'a> {
     item: *mut cmdq_item,
     state: *mut args_command_state<'a>,
@@ -47,6 +46,22 @@ struct cmd_command_prompt_cdata<'a> {
 
     argc: i32,
     argv: *mut *mut u8,
+}
+
+impl<'a> Default for cmd_command_prompt_cdata<'a> {
+    fn default() -> Self {
+        Self {
+            item: null_mut(),
+            state: null_mut(),
+            flags: 0,
+            prompt_type: prompt_type::default(),
+            prompts: null_mut(),
+            count: 0,
+            current: 0,
+            argc: 0,
+            argv: null_mut(),
+        }
+    }
 }
 
 fn cmd_command_prompt_args_parse(

--- a/src/cmd_/cmd_confirm_before.rs
+++ b/src/cmd_/cmd_confirm_before.rs
@@ -26,12 +26,22 @@ pub static CMD_CONFIRM_BEFORE_ENTRY: cmd_entry = cmd_entry {
     target: cmd_entry_flag::zeroed(),
 };
 
-#[derive(Default)]
 pub struct cmd_confirm_before_data {
     item: *mut cmdq_item,
     cmdlist: *mut cmd_list,
     confirm_key: u8,
     default_yes: i32,
+}
+
+impl Default for cmd_confirm_before_data {
+    fn default() -> Self {
+        Self {
+            item: null_mut(),
+            cmdlist: null_mut(),
+            confirm_key: 0,
+            default_yes: 0,
+        }
+    }
 }
 
 unsafe fn cmd_confirm_before_args_parse(_: *mut args, _: u32, _: *mut *mut u8) -> args_parse_type {

--- a/src/cmd_/cmd_set_buffer.rs
+++ b/src/cmd_/cmd_set_buffer.rs
@@ -104,12 +104,12 @@ unsafe fn cmd_set_buffer_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_retv
         let mut bufsize = 0;
         let mut bufdata = null_mut();
 
-        if let Some(pb_non_null) = NonNull::new(pb)
-            && args_has_(args, 'a')
-        {
-            olddata = paste_buffer_data_(pb_non_null, &mut bufsize);
-            bufdata = xmalloc(bufsize).as_ptr().cast();
-            memcpy_(bufdata, olddata, bufsize);
+        if let Some(pb_non_null) = NonNull::new(pb) {
+            if args_has_(args, 'a') {
+                olddata = paste_buffer_data_(pb_non_null, &mut bufsize);
+                bufdata = xmalloc(bufsize).as_ptr().cast();
+                memcpy_(bufdata, olddata, bufsize);
+            }
         }
 
         bufdata = xrealloc_(bufdata, bufsize + newsize).as_ptr();

--- a/src/cmd_parse.lalrpop
+++ b/src/cmd_parse.lalrpop
@@ -66,7 +66,7 @@ pub Format: NonNull<u8> = {
 
 pub Expanded: NonNull<u8> = {
     <arg1:Format> => unsafe {
-      let pi = (*ps.as_ptr()).input.as_mut().map(|e|&raw mut *e).unwrap_or_default();
+      let pi = (*ps.as_ptr()).input.as_mut().map(|e|&raw mut *e).unwrap_or(null_mut());
       let c = (*pi).c;
       let flags = format_flags::FORMAT_NOJOBS;
 
@@ -130,7 +130,7 @@ pub IfElse: () = {
       let scope = xcalloc1::<cmd_parse_scope>();
       scope.flag = !(*ps.as_ptr()).scope.as_ref().unwrap().flag;
 
-      free_((*ps.as_ptr()).scope.take().map(|p|p as *mut cmd_parse_scope).unwrap_or_default());
+      free_((*ps.as_ptr()).scope.take().map(|p|p as *mut cmd_parse_scope).unwrap_or(null_mut()));
       (*ps.as_ptr()).scope = Some(scope);
     }
 };
@@ -142,7 +142,7 @@ pub IfElif: i32 = {
       scope.flag = value;
       free_(arg2.as_ptr());
 
-      free_((*ps.as_ptr()).scope.take().map(|p|p as *mut cmd_parse_scope).unwrap_or_default());
+      free_((*ps.as_ptr()).scope.take().map(|p|p as *mut cmd_parse_scope).unwrap_or(null_mut()));
       (*ps.as_ptr()).scope = Some(scope);
 
       value
@@ -151,7 +151,7 @@ pub IfElif: i32 = {
 
 pub IfClose: () = {
     "%endif" => unsafe {
-      free_((*ps.as_ptr()).scope.take().map(|p|p as *mut cmd_parse_scope).unwrap_or_default());
+      free_((*ps.as_ptr()).scope.take().map(|p|p as *mut cmd_parse_scope).unwrap_or(null_mut()));
 
       // TODO this breaks aliasing rules
       let scope = tailq_first(&mut (*ps.as_ptr()).stack);

--- a/src/colour.rs
+++ b/src/colour.rs
@@ -172,10 +172,11 @@ pub fn colour_fromstring_(s: &str) -> i32 {
         if s.len() < 7 {
             return -1;
         }
-        if let Ok(r) = u8::from_str_radix(&s[1..3], 16)
-            && let Ok(g) = u8::from_str_radix(&s[3..5], 16)
-            && let Ok(b) = u8::from_str_radix(&s[5..7], 16)
-        {
+        if let (Ok(r), Ok(g), Ok(b)) = (
+            u8::from_str_radix(&s[1..3], 16),
+            u8::from_str_radix(&s[3..5], 16),
+            u8::from_str_radix(&s[5..7], 16),
+        ) {
             return colour_join_rgb(r, g, b);
         } else {
             return -1;

--- a/src/compat/tree.rs
+++ b/src/compat/tree.rs
@@ -315,11 +315,12 @@ where
     T: GetEntry<T, D>,
 {
     unsafe {
-        while let Some(parent) = NonNull::new(rb_parent(elm))
-            && rb_color(parent.as_ptr()) == rb_color::RB_RED
-        {
+        while let Some(parent) = NonNull::new(rb_parent(elm)) {
             #[expect(clippy::shadow_reuse)]
             let mut parent = parent.as_ptr();
+            if rb_color(parent) != rb_color::RB_RED {
+                break;
+            }
             let gparent = rb_parent(parent);
             if parent == rb_left(gparent) {
                 let mut tmp = rb_right(gparent);

--- a/src/file.rs
+++ b/src/file.rs
@@ -131,10 +131,10 @@ pub unsafe extern "C-unwind" fn file_fire_done_cb(_fd: i32, _events: i16, arg: *
         let cf: *mut client_file = arg as _;
         let c: *mut client = (*cf).c;
 
-        if let Some(cb) = (*cf).cb
-            && ((*cf).closed != 0 || c.is_null() || !(*c).flags.intersects(client_flag::DEAD))
-        {
-            cb(c, (*cf).path, (*cf).error, 1, (*cf).buffer, (*cf).data);
+        if let Some(cb) = (*cf).cb {
+            if (*cf).closed != 0 || c.is_null() || !(*c).flags.intersects(client_flag::DEAD) {
+                cb(c, (*cf).path, (*cf).error, 1, (*cf).buffer, (*cf).data);
+            }
         }
         file_free(cf);
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1561,10 +1561,10 @@ pub unsafe fn format_cb_client_user(ft: *mut format_tree) -> *mut c_void {
     unsafe {
         if !(*ft).c.is_null() {
             let uid = proc_get_peer_uid((*(*ft).c).peer);
-            if uid != -1_i32 as uid_t
-                && let Some(pw) = NonNull::new(libc::getpwuid(uid))
-            {
-                return xstrdup((*pw.as_ptr()).pw_name.cast()).as_ptr().cast();
+            if uid != -1_i32 as uid_t {
+                if let Some(pw) = NonNull::new(libc::getpwuid(uid)) {
+                    return xstrdup((*pw.as_ptr()).pw_name.cast()).as_ptr().cast();
+                }
             }
         }
         null_mut()
@@ -1813,10 +1813,10 @@ pub unsafe fn format_cb_mouse_x(ft: *mut format_tree) -> *mut c_void {
         let wp = cmd_mouse_pane(&raw mut (*ft).m, null_mut(), null_mut());
         let mut x: u32 = 0;
         let mut y: u32 = 0;
-        if let Some(wp) = wp
-            && cmd_mouse_at(wp.as_ptr(), &raw mut (*ft).m, &mut x, &mut y, 0) == 0
-        {
-            return format_printf!("{}", x).cast();
+        if let Some(wp) = wp {
+            if cmd_mouse_at(wp.as_ptr(), &raw mut (*ft).m, &mut x, &mut y, 0) == 0 {
+                return format_printf!("{}", x).cast();
+            }
         }
         if !(*ft).c.is_null() && (*(*ft).c).tty.flags.intersects(tty_flags::TTY_STARTED) {
             if (*ft).m.statusat == 0 && (*ft).m.y < (*ft).m.statuslines {
@@ -1839,10 +1839,10 @@ pub unsafe fn format_cb_mouse_y(ft: *mut format_tree) -> *mut c_void {
         let wp = cmd_mouse_pane(&raw mut (*ft).m, null_mut(), null_mut());
         let mut x: u32 = 0;
         let mut y: u32 = 0;
-        if let Some(wp) = wp
-            && cmd_mouse_at(wp.as_ptr(), &raw mut (*ft).m, &mut x, &mut y, 0) == 0
-        {
-            return format_printf!("{}", y).cast();
+        if let Some(wp) = wp {
+            if cmd_mouse_at(wp.as_ptr(), &raw mut (*ft).m, &mut x, &mut y, 0) == 0 {
+                return format_printf!("{}", y).cast();
+            }
         }
         if !(*ft).c.is_null() && (*(*ft).c).tty.flags.intersects(tty_flags::TTY_STARTED) {
             if (*ft).m.statusat == 0 && (*ft).m.y < (*ft).m.statuslines {
@@ -5307,10 +5307,10 @@ pub unsafe fn format_defaults_pane(ft: *mut format_tree, wp: *mut window_pane) {
         }
         (*ft).wp = wp;
 
-        if let Some(wme) = NonNull::new(tailq_first(&raw mut (*wp).modes))
-            && let Some(formats) = (*(*wme.as_ptr()).mode).formats
-        {
-            formats(wme.as_ptr(), ft);
+        if let Some(wme) = NonNull::new(tailq_first(&raw mut (*wp).modes)) {
+            if let Some(formats) = (*(*wme.as_ptr()).mode).formats {
+                formats(wme.as_ptr(), ft);
+            }
         }
     }
 }

--- a/src/format_draw_.rs
+++ b/src/format_draw_.rs
@@ -1387,26 +1387,27 @@ pub unsafe fn format_width(expanded: *const u8) -> u32 {
                     }
                     cp = end.add(1);
                 }
-            } else if let mut more = utf8_open(&raw mut ud, *cp)
-                && more == utf8_state::UTF8_MORE
-            {
-                while ({
-                    cp = cp.add(1);
-                    *cp != b'\0'
-                } && more == utf8_state::UTF8_MORE)
-                {
-                    more = utf8_append(&raw mut ud, *cp);
-                }
-                if more == utf8_state::UTF8_DONE {
-                    width += ud.width as u32;
-                } else {
-                    cp = cp.wrapping_sub(ud.have as usize);
-                }
-            } else if *cp > 0x1f && *cp < 0x7f {
-                width += 1;
-                cp = cp.add(1);
             } else {
-                cp = cp.add(1);
+                let mut more = utf8_open(&raw mut ud, *cp);
+                if more == utf8_state::UTF8_MORE {
+                    while ({
+                        cp = cp.add(1);
+                        *cp != b'\0'
+                    } && more == utf8_state::UTF8_MORE)
+                    {
+                        more = utf8_append(&raw mut ud, *cp);
+                    }
+                    if more == utf8_state::UTF8_DONE {
+                        width += ud.width as u32;
+                    } else {
+                        cp = cp.wrapping_sub(ud.have as usize);
+                    }
+                } else if *cp > 0x1f && *cp < 0x7f {
+                    width += 1;
+                    cp = cp.add(1);
+                } else {
+                    cp = cp.add(1);
+                }
             }
         }
         width
@@ -1459,34 +1460,35 @@ pub unsafe fn format_trim_left(expanded: *const u8, limit: u32) -> *mut u8 {
                     out = out.offset(end.add(1).offset_from(cp));
                     cp = end.add(1);
                 }
-            } else if let mut more = utf8_open(&raw mut ud, *cp)
-                && more == utf8_state::UTF8_MORE
-            {
-                while ({
-                    cp = cp.add(1);
-                    *cp != b'\0'
-                }) && more == utf8_state::UTF8_MORE
-                {
-                    more = utf8_append(&raw mut ud, *cp);
-                }
-                if more == utf8_state::UTF8_DONE {
-                    if width + ud.width as u32 <= limit {
-                        libc::memcpy(out.cast(), ud.data.as_ptr().cast(), ud.size as usize);
-                        out = out.add(ud.size as usize);
-                    }
-                    width += ud.width as u32;
-                } else {
-                    cp = cp.wrapping_sub(ud.have as usize).add(1);
-                }
-            } else if *cp > 0x1f && *cp < 0x7f {
-                if width < limit {
-                    *out = *cp;
-                    out = out.add(1);
-                }
-                width += 1;
-                cp = cp.add(1);
             } else {
-                cp = cp.add(1);
+                let mut more = utf8_open(&raw mut ud, *cp);
+                if more == utf8_state::UTF8_MORE {
+                    while ({
+                        cp = cp.add(1);
+                        *cp != b'\0'
+                    }) && more == utf8_state::UTF8_MORE
+                    {
+                        more = utf8_append(&raw mut ud, *cp);
+                    }
+                    if more == utf8_state::UTF8_DONE {
+                        if width + ud.width as u32 <= limit {
+                            libc::memcpy(out.cast(), ud.data.as_ptr().cast(), ud.size as usize);
+                            out = out.add(ud.size as usize);
+                        }
+                        width += ud.width as u32;
+                    } else {
+                        cp = cp.wrapping_sub(ud.have as usize).add(1);
+                    }
+                } else if *cp > 0x1f && *cp < 0x7f {
+                    if width < limit {
+                        *out = *cp;
+                        out = out.add(1);
+                    }
+                    width += 1;
+                    cp = cp.add(1);
+                } else {
+                    cp = cp.add(1);
+                }
             }
         }
         *out = b'\0';
@@ -1547,34 +1549,35 @@ pub unsafe fn format_trim_right(expanded: *const u8, limit: u32) -> *mut u8 {
                     out = out.offset(end.add(1).offset_from(cp));
                     cp = end.add(1);
                 }
-            } else if let mut more = utf8_open(&raw mut ud, *cp)
-                && more == utf8_state::UTF8_MORE
-            {
-                while ({
-                    cp = cp.add(1);
-                    *(cp) != b'\0'
-                }) && more == utf8_state::UTF8_MORE
-                {
-                    more = utf8_append(&raw mut ud, *cp);
-                }
-                if more == utf8_state::UTF8_DONE {
-                    if width >= skip {
-                        libc::memcpy(out.cast(), ud.data.as_ptr().cast(), ud.size as usize);
-                        out = out.add(ud.size as usize);
-                    }
-                    width += ud.width as u32;
-                } else {
-                    cp = cp.wrapping_sub(ud.have as usize).add(1);
-                }
-            } else if *cp > 0x1f && *cp < 0x7f {
-                if width >= skip {
-                    *out = *cp;
-                    out = out.add(1);
-                }
-                width += 1;
-                cp = cp.add(1);
             } else {
-                cp = cp.add(1);
+                let mut more = utf8_open(&raw mut ud, *cp);
+                if more == utf8_state::UTF8_MORE {
+                    while ({
+                        cp = cp.add(1);
+                        *(cp) != b'\0'
+                    }) && more == utf8_state::UTF8_MORE
+                    {
+                        more = utf8_append(&raw mut ud, *cp);
+                    }
+                    if more == utf8_state::UTF8_DONE {
+                        if width >= skip {
+                            libc::memcpy(out.cast(), ud.data.as_ptr().cast(), ud.size as usize);
+                            out = out.add(ud.size as usize);
+                        }
+                        width += ud.width as u32;
+                    } else {
+                        cp = cp.wrapping_sub(ud.have as usize).add(1);
+                    }
+                } else if *cp > 0x1f && *cp < 0x7f {
+                    if width >= skip {
+                        *out = *cp;
+                        out = out.add(1);
+                    }
+                    width += 1;
+                    cp = cp.add(1);
+                } else {
+                    cp = cp.add(1);
+                }
             }
         }
         *out = b'\0';

--- a/src/input.rs
+++ b/src/input.rs
@@ -1068,10 +1068,10 @@ fn input_parse(ictx: *mut input_ctx, buf: *mut u8, len: usize) {
 
             // Execute the handler, if any. Don't switch state if it
             // returns non-zero.
-            if let Some(handler) = (*itr).handler
-                && handler(ictx) != 0
-            {
-                continue;
+            if let Some(handler) = (*itr).handler {
+                if handler(ictx) != 0 {
+                    continue;
+                }
             }
 
             // And switch state, if necessary.

--- a/src/job_.rs
+++ b/src/job_.rs
@@ -296,10 +296,10 @@ pub unsafe fn job_transfer(job: *mut job, pid: *mut pid_t, tty: *mut u8, ttylen:
         list_remove(job);
         free_((*job).cmd);
 
-        if let Some(freecb) = (*job).freecb
-            && !(*job).data.is_null()
-        {
-            freecb((*job).data);
+        if let Some(freecb) = (*job).freecb {
+            if !(*job).data.is_null() {
+                freecb((*job).data);
+            }
         }
 
         if !(*job).event.is_null() {
@@ -318,10 +318,10 @@ pub unsafe fn job_free(job: *mut job) {
         list_remove(job);
         free_((*job).cmd);
 
-        if let Some(freecb) = (*job).freecb
-            && !((*job).data).is_null()
-        {
-            freecb((*job).data);
+        if let Some(freecb) = (*job).freecb {
+            if !((*job).data).is_null() {
+                freecb((*job).data);
+            }
         }
         if (*job).pid != -1 {
             kill((*job).pid, SIGTERM);

--- a/src/screen_redraw.rs
+++ b/src/screen_redraw.rs
@@ -713,11 +713,11 @@ pub unsafe fn screen_redraw_screen(c: *mut client) {
             log_debug!("{}: redrawing status", _s((*c).name));
             screen_redraw_draw_status(ctx);
         }
-        if let Some(overlay_draw) = (*c).overlay_draw
-            && flags.intersects(client_flag::REDRAWOVERLAY)
-        {
-            log_debug!("{}: redrawing overlay", _s((*c).name));
-            overlay_draw(c, (*c).overlay_data, ctx);
+        if let Some(overlay_draw) = (*c).overlay_draw {
+            if flags.intersects(client_flag::REDRAWOVERLAY) {
+                log_debug!("{}: redrawing overlay", _s((*c).name));
+                overlay_draw(c, (*c).overlay_data, ctx);
+            }
         }
 
         tty_reset(&raw mut (*c).tty);

--- a/src/server_client.rs
+++ b/src/server_client.rs
@@ -851,8 +851,8 @@ pub unsafe fn server_client_check_mouse(c: *mut client, event: *mut key_event) -
                 let mut wp = null_mut();
 
                 // Try the pane borders if not zoomed.
-                if !(*(*(*s).curw).window).flags.intersects(window_flag::ZOOMED)
-                    && let Some(wp_) = tailq_foreach::<_, discr_entry>(
+                if !(*(*(*s).curw).window).flags.intersects(window_flag::ZOOMED) {
+                    if let Some(wp_) = tailq_foreach::<_, discr_entry>(
                         &raw mut (*(*(*s).curw).window).panes,
                     )
                     .find(|wp| {
@@ -863,10 +863,10 @@ pub unsafe fn server_client_check_mouse(c: *mut client, event: *mut key_event) -
                             || ((*wp).yoff + (*wp).sy == py
                                 && (*wp).xoff <= 1 + px
                                 && (*wp).xoff + (*wp).sx >= px)
-                    })
-                {
-                    wp = wp_.as_ptr();
-                    where_ = where_::Border;
+                    }) {
+                        wp = wp_.as_ptr();
+                        where_ = where_::Border;
+                    }
                 }
 
                 // Otherwise try inside the pane.
@@ -2658,10 +2658,10 @@ pub unsafe fn server_client_check_modes(c: *mut client) {
             return;
         }
         for wp in tailq_foreach::<_, discr_entry>(&raw mut (*w).panes).map(NonNull::as_ptr) {
-            if let Some(wme) = NonNull::new(tailq_first(&raw mut (*wp).modes))
-                && let Some(update) = (*(*wme.as_ptr()).mode).update
-            {
-                update(wme);
+            if let Some(wme) = NonNull::new(tailq_first(&raw mut (*wp).modes)) {
+                if let Some(update) = (*(*wme.as_ptr()).mode).update {
+                    update(wme);
+                }
             }
         }
     }

--- a/src/status.rs
+++ b/src/status.rs
@@ -745,8 +745,8 @@ pub unsafe fn status_prompt_clear(c: *mut client) {
             return;
         }
 
-        if let Some(prompt_freecb) = (*c).prompt_freecb
-            && let Some(prompt_data) = NonNull::new((*c).prompt_data)
+        if let (Some(prompt_freecb), Some(prompt_data)) =
+            ((*c).prompt_freecb, NonNull::new((*c).prompt_data))
         {
             prompt_freecb(prompt_data);
         }

--- a/src/window_.rs
+++ b/src/window_.rs
@@ -1294,13 +1294,14 @@ pub unsafe fn window_pane_key(
         return -1;
     }
     unsafe {
-        if let Some(wme) = NonNull::new(tailq_first(&raw mut (*wp).modes))
-            && let Some(key_fn) = (*(*wme.as_ptr()).mode).key
-            && !c.is_null()
-        {
-            key &= !KEYC_MASK_FLAGS;
-            key_fn(wme, c, s, wl, key, m);
-            return 0;
+        if let Some(wme) = NonNull::new(tailq_first(&raw mut (*wp).modes)) {
+            if let Some(key_fn) = (*(*wme.as_ptr()).mode).key {
+                if !c.is_null() {
+                    key &= !KEYC_MASK_FLAGS;
+                    key_fn(wme, c, s, wl, key, m);
+                    return 0;
+                }
+            }
         }
 
         if (*wp).fd == -1 || (*wp).flags.intersects(window_pane_flags::PANE_INPUTOFF) {

--- a/src/window_buffer.rs
+++ b/src/window_buffer.rs
@@ -315,10 +315,10 @@ pub unsafe fn window_buffer_menu(modedata: NonNull<c_void>, c: *mut client, key:
         let data: NonNull<window_buffer_modedata> = modedata.cast();
         let wp: *mut window_pane = (*data.as_ptr()).wp;
 
-        if let Some(wme) = NonNull::new(tailq_first(&raw mut (*wp).modes))
-            && (*wme.as_ptr()).data == modedata.as_ptr()
-        {
-            window_buffer_key(wme, c, null_mut(), null_mut(), key, null_mut());
+        if let Some(wme) = NonNull::new(tailq_first(&raw mut (*wp).modes)) {
+            if (*wme.as_ptr()).data == modedata.as_ptr() {
+                window_buffer_key(wme, c, null_mut(), null_mut(), key, null_mut());
+            }
         }
     }
 }

--- a/src/window_client.rs
+++ b/src/window_client.rs
@@ -278,10 +278,10 @@ pub unsafe fn window_client_menu(modedata: NonNull<c_void>, c: *mut client, key:
         let data: NonNull<window_client_modedata> = modedata.cast();
         let wp: *mut window_pane = (*data.as_ptr()).wp;
 
-        if let Some(wme) = NonNull::new(tailq_first(&raw mut (*wp).modes))
-            && (*wme.as_ptr()).data == modedata.as_ptr()
-        {
-            window_client_key(wme, c, null_mut(), null_mut(), key, null_mut());
+        if let Some(wme) = NonNull::new(tailq_first(&raw mut (*wp).modes)) {
+            if (*wme.as_ptr()).data == modedata.as_ptr() {
+                window_client_key(wme, c, null_mut(), null_mut(), key, null_mut());
+            }
         }
     }
 }

--- a/src/window_copy.rs
+++ b/src/window_copy.rs
@@ -4278,22 +4278,23 @@ pub unsafe fn window_copy_move_after_search_mark(
     unsafe {
         let s = (*data).backing;
 
-        if let Ok(start) = window_copy_search_mark_at(data, *fx, *fy)
-            && *(*data).searchmark.add(start as usize) != 0
-        {
-            while let Ok(at) = window_copy_search_mark_at(data, *fx, *fy) {
-                if (*data).searchmark.add(at as usize) != (*data).searchmark.add(start as usize) {
-                    break;
-                }
-                // Stop if not wrapping and at the end of the grid.
-                if wrapflag == 0
-                    && *fx == screen_size_x(s) - 1
-                    && *fy == screen_hsize(s) + screen_size_y(s) - 1
-                {
-                    break;
-                }
+        if let Ok(start) = window_copy_search_mark_at(data, *fx, *fy) {
+            if *(*data).searchmark.add(start as usize) != 0 {
+                while let Ok(at) = window_copy_search_mark_at(data, *fx, *fy) {
+                    if (*data).searchmark.add(at as usize) != (*data).searchmark.add(start as usize)
+                    {
+                        break;
+                    }
+                    // Stop if not wrapping and at the end of the grid.
+                    if wrapflag == 0
+                        && *fx == screen_size_x(s) - 1
+                        && *fy == screen_hsize(s) + screen_size_y(s) - 1
+                    {
+                        break;
+                    }
 
-                window_copy_move_right(s, fx, fy, wrapflag);
+                    window_copy_move_right(s, fx, fy, wrapflag);
+                }
             }
         }
     }
@@ -4397,18 +4398,26 @@ pub unsafe fn window_copy_search(
 
             // When searching forward, if the cursor is not at the beginning
             // of the mark, search again.
-            if direction != 0
-                && let Ok(at) = window_copy_search_mark_at(data, fx, fy)
-                && at > 0
-                && !(*data).searchmark.is_null()
-                && *(*data).searchmark.add(at as usize) == *(*data).searchmark.add(at as usize - 1)
-            {
-                window_copy_move_after_search_mark(data, &raw mut fx, &raw mut fy, wrapflag);
-                window_copy_search_jump(
-                    wme, gd, ss.grid, fx, fy, endline, cis, wrapflag, direction, regex,
-                );
-                fx = (*data).cx;
-                fy = screen_hsize((*data).backing) - (*data).oy + (*data).cy;
+            if direction != 0 {
+                if let Ok(at) = window_copy_search_mark_at(data, fx, fy) {
+                    if at > 0
+                        && !(*data).searchmark.is_null()
+                        && *(*data).searchmark.add(at as usize)
+                            == *(*data).searchmark.add(at as usize - 1)
+                    {
+                        window_copy_move_after_search_mark(
+                            data,
+                            &raw mut fx,
+                            &raw mut fy,
+                            wrapflag,
+                        );
+                        window_copy_search_jump(
+                            wme, gd, ss.grid, fx, fy, endline, cis, wrapflag, direction, regex,
+                        );
+                        fx = (*data).cx;
+                        fy = screen_hsize((*data).backing) - (*data).oy + (*data).cy;
+                    }
+                }
             }
 
             if direction != 0 {
@@ -4422,18 +4431,19 @@ pub unsafe fn window_copy_search(
                 // When searching backward, position the cursor at the
                 // beginning of the mark.
                 if let Ok(start) = window_copy_search_mark_at(data, fx, fy) {
-                    while let Ok(at) = window_copy_search_mark_at(data, fx, fy)
-                        && !(*data).searchmark.is_null()
-                        && *(*data).searchmark.add(at as usize)
-                            == *(*data).searchmark.add(start as usize)
-                    {
-                        (*data).cx = fx;
-                        (*data).cy = fy - screen_hsize((*data).backing) + (*data).oy;
-                        if at == 0 {
-                            break;
-                        }
+                    while let Ok(at) = window_copy_search_mark_at(data, fx, fy) {
+                        if !(*data).searchmark.is_null()
+                            && *(*data).searchmark.add(at as usize)
+                                == *(*data).searchmark.add(start as usize)
+                        {
+                            (*data).cx = fx;
+                            (*data).cy = fy - screen_hsize((*data).backing) + (*data).oy;
+                            if at == 0 {
+                                break;
+                            }
 
-                        window_copy_move_left(s, &raw mut fx, &raw mut fy, 0);
+                            window_copy_move_left(s, &raw mut fx, &raw mut fy, 0);
+                        }
                     }
                 }
             }

--- a/src/window_tree.rs
+++ b/src/window_tree.rs
@@ -1027,17 +1027,12 @@ unsafe fn window_tree_search(
                 }
             }
             window_tree_type::WINDOW_TREE_WINDOW => {
-                if s.is_some()
-                    && let Some(wl) = wl
-                {
+                if let (Some(_s), Some(wl)) = (s, wl) {
                     return !libc::strstr((*(*wl.as_ptr()).window).name, ss).is_null();
                 }
             }
             window_tree_type::WINDOW_TREE_PANE => {
-                if s.is_some()
-                    && wl.is_some()
-                    && let Some(wp) = wp
-                {
+                if let (Some(_s), Some(_wl), Some(wp)) = (s, wl, wp) {
                     let cmd: *mut u8 =
                         osdep_get_name((*wp.as_ptr()).fd, (&raw const (*wp.as_ptr()).tty).cast());
                     if cmd.is_null() || *cmd == b'\0' {
@@ -1059,10 +1054,10 @@ unsafe fn window_tree_menu(modedata: NonNull<c_void>, c: *mut client, key: key_c
     unsafe {
         let data: NonNull<window_tree_modedata> = modedata.cast();
         let wp: NonNull<window_pane> = NonNull::new_unchecked((*data.as_ptr()).wp);
-        if let Some(wme) = NonNull::new(tailq_first(&raw mut (*wp.as_ptr()).modes))
-            && (*wme.as_ptr()).data == modedata.as_ptr()
-        {
-            window_tree_key(wme, c, null_mut(), null_mut(), key, null_mut());
+        if let Some(wme) = NonNull::new(tailq_first(&raw mut (*wp.as_ptr()).modes)) {
+            if (*wme.as_ptr()).data == modedata.as_ptr() {
+                window_tree_key(wme, c, null_mut(), null_mut(), key, null_mut());
+            }
         }
     }
 }
@@ -1236,17 +1231,12 @@ unsafe fn window_tree_get_target(
                 }
             }
             window_tree_type::WINDOW_TREE_WINDOW => {
-                if let Some(s) = s
-                    && let Some(wl) = wl
-                {
+                if let (Some(s), Some(wl)) = (s, wl) {
                     target = format_nul!("={}:{}.", _s((*s.as_ptr()).name), (*wl.as_ptr()).idx);
                 }
             }
             window_tree_type::WINDOW_TREE_PANE => {
-                if let Some(s) = s
-                    && let Some(wl) = wl
-                    && let Some(wp) = wp
-                {
+                if let (Some(s), Some(wl), Some(wp)) = (s, wl, wp) {
                     target = format_nul!(
                         "={}:{}.%{}",
                         _s((*s.as_ptr()).name),
@@ -1595,10 +1585,10 @@ unsafe fn window_tree_key(
                             }
                         }
                         window_tree_type::WINDOW_TREE_PANE => {
-                            if let Some(nwp) = nwp
-                                && window_pane_index(nwp.as_ptr(), &raw mut idx) == 0
-                            {
-                                prompt = format_nul!("Kill pane {}? ", idx);
+                            if let Some(nwp) = nwp {
+                                if window_pane_index(nwp.as_ptr(), &raw mut idx) == 0 {
+                                    prompt = format_nul!("Kill pane {}? ", idx);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
I tried rebasing the commit from the android-support branch, but it required too much rebasing, so I made my own implementation. The only changes included here are whatever is needed to support Rust 1.87.

Reasons for the change:

* Users who use distro packages may not have Rust 1.88 yet.
* Users who work on a project with an older Rust version (e.g. corporate developers) may not have the latest Rust yet.
* This PR would be a good foundation for Android support. Lowering MSRV to 1.85 would require fewer changes.

Approximately half of the changes add more conditionals and make the code somewhat harder to read. Hopefully it will be reverted once Rust 1.88 becomes more widespread.

The other half are good changes that won't need to be reverted. That includes tuple matching and implementation of the `Default` trait for some structures.

Even if lowering the MSRV is not planned, we can always keep the good part.