### PR TITLE
parse_window_name: decrement `ptr`, not `*ptr`

### DIFF
--- a/src/names.rs
+++ b/src/names.rs
@@ -173,7 +173,7 @@ pub unsafe fn parse_window_name(in_: *const u8) -> *mut u8 {
                 && !(*ptr as u8).is_ascii_punctuation()
             {
                 *ptr = b'\0';
-                *ptr -= 1;
+                ptr = ptr.wrapping_sub(1);
             }
         }
 


### PR DESCRIPTION
Verified against tmux sources.