### PR TITLE
Fix strrchr implementation

### DIFF
--- a/src/libc.rs
+++ b/src/libc.rs
@@ -92,7 +92,7 @@ pub unsafe fn strcspn(cs: *const u8, ct: *const u8) -> usize {
 }
 
 pub unsafe fn strrchr(cs: *const u8, c: c_int) -> *mut u8 {
-    unsafe { ::libc::strchr(cs.cast(), c).cast() }
+    unsafe { ::libc::strrchr(cs.cast(), c).cast() }
 }
 
 pub unsafe fn strchr(cs: *const u8, c: i32) -> *mut u8 {


### PR DESCRIPTION
When making arg0 (the process name visible in procfs), tmux-rs was leaving everything after the first slash rather than after the last slash as intended. On NixOS, it caused very long process names in the window list.

Closes #100