### PR TITLE
Fix remaining bitwise integer negations

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -5334,7 +5334,7 @@ pub unsafe fn format_grid_word(gd: *mut grid, mut x: u32, mut y: u32) -> *mut u8
             if (*gc).flags.intersects(grid_flag::PADDING) {
                 break;
             }
-            if utf8_cstrhas(ws, &raw mut (*gc).data) != 0
+            if utf8_cstrhas(ws, &raw mut (*gc).data)
                 || ((*gc).data.size == 1 && (*gc).data.data[0] == b' ')
             {
                 found = true;
@@ -5380,7 +5380,7 @@ pub unsafe fn format_grid_word(gd: *mut grid, mut x: u32, mut y: u32) -> *mut u8
             if (*gc).flags.intersects(grid_flag::PADDING) {
                 break;
             }
-            if utf8_cstrhas(ws, &raw mut (*gc).data) != 0
+            if utf8_cstrhas(ws, &raw mut (*gc).data)
                 || ((*gc).data.size == 1 && (*gc).data.data[0] == b' ')
             {
                 break;

--- a/src/mode_tree.rs
+++ b/src/mode_tree.rs
@@ -622,7 +622,7 @@ pub unsafe fn mode_tree_add(
     tag: u64,
     name: *const u8,
     text: *const u8,
-    expanded: i32,
+    expanded: Option<bool>,
 ) -> *mut mode_tree_item {
     unsafe {
         // log_debug("%s: %llu, %s %s", __func__, (unsigned long long)tag, name, (text == NULL ? "" : text));
@@ -643,10 +643,8 @@ pub unsafe fn mode_tree_add(
                 (*mti).tagged = (*saved).tagged;
             }
             (*mti).expanded = (*saved).expanded;
-        } else if expanded == -1 {
-            (*mti).expanded = true;
         } else {
-            (*mti).expanded = expanded != 0;
+            (*mti).expanded = expanded.unwrap_or(true);
         }
 
         tailq_init(&raw mut (*mti).children);

--- a/src/mode_tree.rs
+++ b/src/mode_tree.rs
@@ -81,7 +81,7 @@ pub struct mode_tree_data {
 
     screen: screen,
 
-    preview: i32,
+    preview: bool,
     search: *mut u8,
     filter: *mut u8,
     no_matches: i32,
@@ -444,7 +444,7 @@ pub unsafe fn mode_tree_start(
         (*mtd).sort_list = sort_list;
         (*mtd).sort_size = sort_size;
 
-        (*mtd).preview = (!args_has(args, 'N')) as i32;
+        (*mtd).preview = !args_has(args, 'N');
 
         let sort = args_get_(args, 'O');
         if !sort.is_null() {
@@ -564,7 +564,7 @@ pub unsafe fn mode_tree_build(mtd: *mut mode_tree_data) {
         mode_tree_set_current(mtd, tag);
 
         (*mtd).width = screen_size_x(s);
-        if (*mtd).preview != 0 {
+        if (*mtd).preview {
             mode_tree_set_height(mtd);
         } else {
             (*mtd).height = screen_size_y(s);
@@ -833,7 +833,7 @@ pub unsafe fn mode_tree_draw(mtd: *mut mode_tree_data) {
             }
 
             let sy = screen_size_y(s);
-            if (*mtd).preview == 0 || sy <= 4 || h <= 4 || sy - h <= 4 || w <= 4 {
+            if !(*mtd).preview || sy <= 4 || h <= 4 || sy - h <= 4 || w <= 4 {
                 break 'done;
             }
 
@@ -1225,7 +1225,7 @@ pub unsafe fn mode_tree_key(
                 if *key == keyc::KEYC_MOUSEDOWN3_PANE as u64 {
                     mode_tree_display_menu(mtd, c, x, y, 1);
                 }
-                if (*mtd).preview == 0 {
+                if !(*mtd).preview {
                     *key = KEYC_NONE;
                 }
                 return 0;
@@ -1493,7 +1493,7 @@ pub unsafe fn mode_tree_key(
             code::V => {
                 (*mtd).preview = !(*mtd).preview;
                 mode_tree_build(mtd);
-                if (*mtd).preview != 0 {
+                if (*mtd).preview {
                     mode_tree_check_selected(mtd);
                 }
             }

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -723,8 +723,8 @@ pub unsafe fn utf8_rpadcstr(s: *const u8, width: u32) -> *mut u8 {
     }
 }
 
-pub unsafe fn utf8_cstrhas(s: *const u8, ud: *const utf8_data) -> i32 {
-    let mut found: i32 = 0;
+pub unsafe fn utf8_cstrhas(s: *const u8, ud: *const utf8_data) -> bool {
+    let mut found = false;
 
     unsafe {
         let copy = utf8_fromcstr(s);
@@ -740,7 +740,7 @@ pub unsafe fn utf8_cstrhas(s: *const u8, ud: *const utf8_data) -> i32 {
                 (*loop_).size as usize,
             ) == 0
             {
-                found = 1;
+                found = true;
                 break;
             }
             loop_ = loop_.add(1);

--- a/src/window_buffer.rs
+++ b/src/window_buffer.rs
@@ -228,7 +228,7 @@ pub unsafe fn window_buffer_build(
                 (*item).order as u64,
                 (*item).name,
                 text,
-                -1,
+                None,
             );
             free_(text);
 

--- a/src/window_client.rs
+++ b/src/window_client.rs
@@ -221,7 +221,7 @@ pub unsafe fn window_client_build(
                 c as u64,
                 (*c).name,
                 text,
-                -1,
+                None,
             );
             free_(text);
         }

--- a/src/window_copy.rs
+++ b/src/window_copy.rs
@@ -2257,7 +2257,7 @@ pub unsafe fn window_copy_cmd_select_word(
             nexty += 1;
         }
         if px >= window_copy_find_length(wme, py)
-            || window_copy_in_set(wme, nextx, nexty, WHITESPACE) == 0
+            || !window_copy_in_set(wme, nextx, nexty, WHITESPACE)
         {
             window_copy_cursor_next_word_end(wme, (*data).separators, 1);
         } else {
@@ -5103,7 +5103,7 @@ pub unsafe fn window_copy_synchronize_cursor_end(
                     } else {
                         // Left to right selection.
                         if xx >= window_copy_find_length(wme, yy)
-                            || window_copy_in_set(wme, xx + 1, yy, WHITESPACE) == 0
+                            || !window_copy_in_set(wme, xx + 1, yy, WHITESPACE)
                         {
                             window_copy_cursor_next_word_end_pos(
                                 wme,
@@ -5674,14 +5674,14 @@ pub unsafe fn window_copy_in_set(
     px: u32,
     py: u32,
     set: *const u8,
-) -> i32 {
+) -> bool {
     unsafe {
         let data: *mut window_copy_mode_data = (*wme).data.cast();
         let mut gc: grid_cell = zeroed();
 
         grid_get_cell((*(*data).backing).grid, px, py, &raw mut gc);
         if gc.flags.intersects(grid_flag::PADDING) {
-            return 0;
+            return false;
         }
         utf8_cstrhas(set, &raw mut gc.data)
     }
@@ -6153,7 +6153,7 @@ pub unsafe fn window_copy_cursor_next_word_end_pos(
         grid_reader_start(&raw mut gr, (*back_s).grid, px, py);
         if modekey::try_from(options_get_number_(oo, "mode-keys") as i32) == Ok(modekey::MODEKEY_VI)
         {
-            if grid_reader_in_set(&raw mut gr, WHITESPACE) == 0 {
+            if !grid_reader_in_set(&raw mut gr, WHITESPACE) {
                 grid_reader_cursor_right(&raw mut gr, 0, 0);
             }
             grid_reader_cursor_next_word_end(&raw mut gr, separators);
@@ -6188,7 +6188,7 @@ pub unsafe fn window_copy_cursor_next_word_end(
         grid_reader_start(&raw mut gr, (*back_s).grid, px, py);
         if modekey::try_from(options_get_number_(oo, "mode-keys") as i32) == Ok(modekey::MODEKEY_VI)
         {
-            if grid_reader_in_set(&raw mut gr, WHITESPACE) == 0 {
+            if !grid_reader_in_set(&raw mut gr, WHITESPACE) {
                 grid_reader_cursor_right(&raw mut gr, 0, 0);
             }
             grid_reader_cursor_next_word_end(&raw mut gr, separators);

--- a/src/window_customize.rs
+++ b/src/window_customize.rs
@@ -252,7 +252,7 @@ unsafe fn window_customize_build_array(
 
             let text: *mut u8 = format_expand(ft, (*data).format);
             let tag = window_customize_get_tag(o, idx as i32, oe);
-            mode_tree_add((*data).data, top, item.cast(), tag, name, text, -1);
+            mode_tree_add((*data).data, top, item.cast(), tag, name, text, None);
             free_(text);
 
             free_(name);
@@ -337,7 +337,7 @@ unsafe fn window_customize_build_option(
             text = format_expand(ft, (*data).format);
         }
         let tag = window_customize_get_tag(o, -1, oe);
-        let top = mode_tree_add((*data).data, top, item.cast(), tag, name, text, 0);
+        let top = mode_tree_add((*data).data, top, item.cast(), tag, name, text, Some(false));
         free_(text);
 
         if array != 0 {
@@ -405,7 +405,7 @@ unsafe fn window_customize_build_options(
             tag,
             title,
             null_mut(),
-            0,
+            Some(false),
         );
         mode_tree_no_tag(top);
 
@@ -488,7 +488,7 @@ unsafe fn window_customize_build_keys(
             tag,
             title,
             null_mut(),
-            0,
+            Some(false),
         );
         mode_tree_no_tag(top);
         free_(title);
@@ -527,7 +527,7 @@ unsafe fn window_customize_build_keys(
                 bd as u64,
                 expanded,
                 null_mut(),
-                0,
+                Some(false),
             );
             free_(expanded);
 
@@ -541,7 +541,7 @@ unsafe fn window_customize_build_keys(
                 tag | ((*bd).key << 3) | 1,
                 c!("Command"),
                 text,
-                -1,
+                None,
             );
             mode_tree_draw_as_parent(mti);
             mode_tree_no_tag(mti);
@@ -559,7 +559,7 @@ unsafe fn window_customize_build_keys(
                 tag | ((*bd).key << 3) | (1 << 1) | 1,
                 c!("Note"),
                 text,
-                -1,
+                None,
             );
             mode_tree_draw_as_parent(mti);
             mode_tree_no_tag(mti);
@@ -577,7 +577,7 @@ unsafe fn window_customize_build_keys(
                 tag | ((*bd).key << 3) | (2 << 1) | 1,
                 c!("Repeat"),
                 flag,
-                -1,
+                None,
             );
             mode_tree_draw_as_parent(mti);
             mode_tree_no_tag(mti);

--- a/src/window_customize.rs
+++ b/src/window_customize.rs
@@ -89,7 +89,7 @@ pub struct window_customize_modedata {
 
     data: *mut mode_tree_data,
     format: *mut u8,
-    hide_global: i32,
+    hide_global: bool,
 
     item_list: *mut *mut window_customize_itemdata,
     item_size: u32,
@@ -293,7 +293,7 @@ unsafe fn window_customize_build_option(
         {
             global = 1;
         }
-        if (*data).hide_global != 0 && global != 0 {
+        if (*data).hide_global && global != 0 {
             return;
         }
 

--- a/src/window_tree.rs
+++ b/src/window_tree.rs
@@ -350,7 +350,7 @@ unsafe fn window_tree_build_pane(
             wp as u64,
             name,
             text,
-            -1,
+            None,
         );
         free_(text);
         free_(name);
@@ -395,7 +395,6 @@ unsafe fn window_tree_build_window(
         let mut l: *mut *mut window_pane;
 
         let mut n: u32;
-        let expanded: i32;
 
         'empty: {
             item = window_tree_add_item(data);
@@ -414,14 +413,11 @@ unsafe fn window_tree_build_window(
             );
             name = format_nul!("{}", (*wl).idx);
 
-            if matches!(
+            let expanded = !matches!(
                 (*data.as_ptr()).type_,
                 window_tree_type::WINDOW_TREE_SESSION | window_tree_type::WINDOW_TREE_WINDOW
-            ) {
-                expanded = 0;
-            } else {
-                expanded = 1;
-            }
+            );
+
             mti = mode_tree_add(
                 (*data.as_ptr()).data,
                 parent,
@@ -429,7 +425,7 @@ unsafe fn window_tree_build_window(
                 wl as u64,
                 name,
                 text,
-                expanded,
+                Some(expanded),
             );
             free_(text);
             free_(name);
@@ -509,11 +505,7 @@ unsafe fn window_tree_build_session(
             null_mut(),
         );
 
-        let expanded = if (*data).type_ == window_tree_type::WINDOW_TREE_SESSION {
-            0
-        } else {
-            1
-        };
+        let expanded = (*data).type_ != window_tree_type::WINDOW_TREE_SESSION;
         let mti = mode_tree_add(
             (*data).data,
             null_mut(),
@@ -521,7 +513,7 @@ unsafe fn window_tree_build_session(
             s as u64,
             (*s).name,
             text,
-            expanded,
+            Some(expanded),
         );
         free_(text);
 


### PR DESCRIPTION
This fixes all remaining bitwise integer negations that are not meant to be bitwise.

Two commits are included.

* `!grid_reader_in_set` was used in a few places. That function is obviously meant to return `bool` so I changed it. To make the code compile, I made `utf8_cstrhas` and `window_copy_in_set` return `bool` as well.
* Some fields in `repr(C)` structs were negated. I didn't what to change them to `bool` for now. I added a new function `logical_not` to make logical negation easier to read.