### PR TITLE
Make tmux-rs and tmux coexist on the same system

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -231,7 +231,7 @@ unsafe fn make_label(mut label: *const u8, cause: *mut *mut u8) -> *const u8 {
             paths.truncate(1);
             let mut path = paths.pop().unwrap(); /* can only have one socket! */
 
-            base = format_nul!("{}/tmux-{}", path.to_string_lossy(), uid);
+            base = format_nul!("{}/tmux-rs-{}", path.to_string_lossy(), uid);
             if mkdir(base.cast(), S_IRWXU) != 0 && errno!() != EEXIST {
                 *cause = format_nul!(
                     "couldn't create directory {} ({})",


### PR DESCRIPTION
Change the name of the directory containing the `default` socket from `tmux-$UID` to `tmux-rs-$UID`. That way, tmux and tmux-rs won't talk to each other, which is not working anyway.

With this change, tmux and tmux-rs can be run side by side without interference.

Note that running tmux inside tmux-rs and vice versa is still undesirable and will be prevented by the `TMUX` environment variable unless it's unset by the user.

It might be interesting to look what is stopping tmux-3.5a and tmux-rs from taking to each other. However, it's better to avoid the risk of accidental interference.