### PR TITLE
Use num_enum crate for enum conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +311,33 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -384,6 +433,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "term"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,7 +461,25 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "libc",
+ "num_enum",
  "paste",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -409,6 +487,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-xid"
@@ -513,3 +597,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ utf8proc    = []
 bitflags     = { version = "2.9.1" }
 lalrpop-util = { version = "0.22.2", features = ["unicode"], default-features = false }
 libc         = { version = "0.2.174" }
+num_enum     = { version = "0.7.4" }
 paste        = { version = "1.0.15" }
 
 [build-dependencies]

--- a/src/input.rs
+++ b/src/input.rs
@@ -154,6 +154,7 @@ impl input_table_entry {
 }
 
 // Escape commands.
+#[derive(num_enum::TryFromPrimitive)]
 #[repr(i32)]
 enum input_esc_type {
     INPUT_ESC_DECALN,
@@ -172,7 +173,6 @@ enum input_esc_type {
     INPUT_ESC_SCSG1_ON,
     INPUT_ESC_ST,
 }
-enum_try_from!(input_esc_type, i32, input_esc_type::INPUT_ESC_ST);
 
 /// Escape command table.
 static INPUT_ESC_TABLE: [input_table_entry; 15] = [
@@ -193,8 +193,8 @@ static INPUT_ESC_TABLE: [input_table_entry; 15] = [
     input_table_entry::new_esc('c', c"", input_esc_type::INPUT_ESC_RIS),
 ];
 
-enum_try_from!(input_csi_type, i32, input_csi_type::INPUT_CSI_XDA);
 /// Control (CSI) commands.
+#[derive(num_enum::TryFromPrimitive)]
 #[repr(i32)]
 enum input_csi_type {
     INPUT_CSI_CBT,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,11 +165,9 @@ const NAME_INTERVAL: libc::suseconds_t = 500000;
 const DEFAULT_XPIXEL: u32 = 16;
 const DEFAULT_YPIXEL: u32 = 32;
 
-enum_try_from!(alert_option, i32, alert_option::ALERT_OTHER);
 /// Alert option values
-#[expect(dead_code, reason = "enum_try_from transmutes from i32 to enum")]
 #[repr(i32)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, num_enum::TryFromPrimitive)]
 enum alert_option {
     ALERT_NONE,
     ALERT_ANY,
@@ -177,11 +175,9 @@ enum alert_option {
     ALERT_OTHER,
 }
 
-enum_try_from!(visual_option, i32, visual_option::VISUAL_BOTH);
 /// Visual option values
-#[expect(dead_code, reason = "enum_try_from transmutes from i32 to enum")]
 #[repr(i32)]
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, num_enum::TryFromPrimitive)]
 enum visual_option {
     VISUAL_OFF,
     VISUAL_ON,
@@ -296,10 +292,9 @@ enum c0 {
 // }
 include!("keyc_mouse_key.rs");
 
-enum_try_from!(tty_code_code, u32, tty_code_code::TTYC_XT);
 /// Termcap codes.
 #[repr(u32)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, num_enum::TryFromPrimitive)]
 enum tty_code_code {
     TTYC_ACSC,
     TTYC_AM,
@@ -537,9 +532,8 @@ enum tty_code_code {
 
 const WHITESPACE: *const u8 = c!(" ");
 
-enum_try_from!(modekey, i32, modekey::MODEKEY_VI);
 #[repr(i32)]
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, num_enum::TryFromPrimitive)]
 enum modekey {
     MODEKEY_EMACS = 0,
     MODEKEY_VI = 1,
@@ -1060,11 +1054,9 @@ struct screen_write_ctx {
     bg: u32,
 }
 
-enum_try_from!(box_lines, i32, box_lines::BOX_LINES_NONE);
 /// Box border lines option.
-#[expect(dead_code, reason = "enum_try_from transmutes from i32 to enum")]
 #[repr(i32)]
-#[derive(Copy, Clone, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, num_enum::TryFromPrimitive)]
 enum box_lines {
     #[default]
     BOX_LINES_DEFAULT = -1,
@@ -1077,11 +1069,9 @@ enum box_lines {
     BOX_LINES_NONE,
 }
 
-enum_try_from!(pane_lines, i32, pane_lines::PANE_LINES_NUMBER);
-#[expect(dead_code, reason = "enum_try_from transmutes from i32 to enum")]
 /// Pane border lines option.
 #[repr(i32)]
-#[derive(Copy, Clone, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, num_enum::TryFromPrimitive)]
 enum pane_lines {
     #[default]
     PANE_LINES_SINGLE,
@@ -1091,14 +1081,8 @@ enum pane_lines {
     PANE_LINES_NUMBER,
 }
 
-enum_try_from!(
-    pane_border_indicator,
-    i32,
-    pane_border_indicator::PANE_BORDER_BOTH
-);
-#[expect(dead_code, reason = "enum_try_from transmutes from i32 to enum")]
 #[repr(i32)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, num_enum::TryFromPrimitive)]
 enum pane_border_indicator {
     PANE_BORDER_OFF,
     PANE_BORDER_COLOUR,
@@ -1471,14 +1455,9 @@ type winlinks = rb_head<winlink>;
 type winlink_stack = tailq_head<winlink>;
 // crate::compat::impl_rb_tree_protos!(winlink_stack, winlink);
 
-enum_try_from!(
-    window_size_option,
-    i32,
-    window_size_option::WINDOW_SIZE_LATEST
-);
 /// Window size option.
 #[repr(i32)]
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, num_enum::TryFromPrimitive)]
 enum window_size_option {
     WINDOW_SIZE_LARGEST,
     WINDOW_SIZE_SMALLEST,
@@ -1486,20 +1465,18 @@ enum window_size_option {
     WINDOW_SIZE_LATEST,
 }
 
-enum_try_from!(pane_status, i32, pane_status::PANE_STATUS_BOTTOM);
 /// Pane border status option.
 #[repr(i32)]
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, num_enum::TryFromPrimitive)]
 enum pane_status {
     PANE_STATUS_OFF,
     PANE_STATUS_TOP,
     PANE_STATUS_BOTTOM,
 }
 
-enum_try_from!(layout_type, i32, layout_type::LAYOUT_WINDOWPANE);
 /// Layout direction.
 #[repr(i32)]
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, num_enum::TryFromPrimitive)]
 enum layout_type {
     LAYOUT_LEFTRIGHT,
     LAYOUT_TOPBOTTOM,
@@ -2127,11 +2104,10 @@ struct status_line {
     entries: [status_line_entry; STATUS_LINES_LIMIT],
 }
 
-enum_try_from!(prompt_type, u32, prompt_type::PROMPT_TYPE_WINDOW_TARGET);
 /// Prompt type.
 const PROMPT_NTYPES: u32 = 4;
 #[repr(u32)]
-#[derive(Copy, Clone, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, num_enum::TryFromPrimitive)]
 enum prompt_type {
     #[default]
     PROMPT_TYPE_COMMAND = 0,
@@ -3259,22 +3235,6 @@ macro_rules! c {
     }};
 }
 pub(crate) use c;
-
-macro_rules! enum_try_from {
-    ($enum_ty:ty, $repr:ty, $last_variant:expr) => {
-        impl TryFrom<$repr> for $enum_ty {
-            type Error = ();
-            fn try_from(value: $repr) -> Result<Self, ()> {
-                if value <= $last_variant as $repr {
-                    unsafe { Ok(std::mem::transmute::<$repr, Self>(value)) }
-                } else {
-                    Err(())
-                }
-            }
-        }
-    };
-}
-pub(crate) use enum_try_from;
 
 macro_rules! impl_ord {
     ($ty:ty as $func:ident) => {

--- a/src/window_buffer.rs
+++ b/src/window_buffer.rs
@@ -57,12 +57,7 @@ pub static WINDOW_BUFFER_MODE: window_mode = window_mode {
     formats: None,
 };
 
-enum_try_from!(
-    window_buffer_sort_type,
-    u32,
-    window_buffer_sort_type::WINDOW_BUFFER_BY_SIZE
-);
-#[expect(dead_code, reason = "enum_try_from transmutes from u32 to enum")]
+#[derive(num_enum::TryFromPrimitive)]
 #[repr(u32)]
 enum window_buffer_sort_type {
     WINDOW_BUFFER_BY_TIME,

--- a/src/window_client.rs
+++ b/src/window_client.rs
@@ -44,12 +44,7 @@ pub static WINDOW_CLIENT_MODE: window_mode = window_mode {
     formats: None,
 };
 
-enum_try_from!(
-    window_client_sort_type,
-    u32,
-    window_client_sort_type::WINDOW_CLIENT_BY_ACTIVITY_TIME
-);
-#[expect(dead_code, reason = "enum_try_from transmutes from i32 to enum")]
+#[derive(num_enum::TryFromPrimitive)]
 #[repr(u32)]
 pub enum window_client_sort_type {
     WINDOW_CLIENT_BY_NAME,

--- a/src/window_tree.rs
+++ b/src/window_tree.rs
@@ -79,12 +79,7 @@ pub static WINDOW_TREE_MODE: window_mode = window_mode {
     formats: None,
 };
 
-enum_try_from!(
-    window_tree_sort_type,
-    i32,
-    window_tree_sort_type::WINDOW_TREE_BY_TIME
-);
-#[expect(dead_code, reason = "enum_try_from transmutes from i32 to enum")]
+#[derive(num_enum::TryFromPrimitive)]
 #[repr(i32)]
 enum window_tree_sort_type {
     WINDOW_TREE_BY_INDEX,


### PR DESCRIPTION
It's better to use a specialized crate for enum conversion. There is no runtime overhead for the macros. `enum_try_from!` takes 3 arguments, and it's easy to get them wrong. `TryFromPrimitive` doesn't need any arguments.