### PR TITLE
Avoid function pointer comparison

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,6 @@ paste        = { version = "1.0.15" }
 [build-dependencies]
 lalrpop      = { version = "0.22.2", default-features = false }
 
-# https://doc.rust-lang.org/rustc/lints/index.html
-[lints.rust]
-unpredictable_function_pointer_comparisons = "allow" # FIXME
-
 # https://rust-lang.github.io/rust-clippy/master/index.html
 [lints.clippy]
 # disabled

--- a/src/cmd_/cmd_confirm_before.rs
+++ b/src/cmd_/cmd_confirm_before.rs
@@ -86,7 +86,7 @@ unsafe fn cmd_confirm_before_exec(self_: *mut cmd, item: *mut cmdq_item) -> cmd_
             cmd_confirm_before_callback,
             cmd_confirm_before_free,
             Box::into_raw(cdata),
-            PROMPT_SINGLE,
+            prompt_flags::PROMPT_SINGLE,
             prompt_type::PROMPT_TYPE_COMMAND,
         );
         free_(new_prompt);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2257,11 +2257,17 @@ const CLIENT_NOSIZEFLAGS: client_flag = client_flag::DEAD
     .union(client_flag::SUSPENDED)
     .union(client_flag::EXIT);
 
-const PROMPT_SINGLE: i32 = 0x1;
-const PROMPT_NUMERIC: i32 = 0x2;
-const PROMPT_INCREMENTAL: i32 = 0x4;
-const PROMPT_NOFORMAT: i32 = 0x8;
-const PROMPT_KEY: i32 = 0x8;
+bitflags::bitflags! {
+    #[repr(transparent)]
+    #[derive(Copy, Clone, Default, Eq, PartialEq)]
+    struct prompt_flags: u32 {
+        const PROMPT_SINGLE = 0x1;
+        const PROMPT_NUMERIC = 0x2;
+        const PROMPT_INCREMENTAL = 0x4;
+        const PROMPT_NOFORMAT = 0x8;
+        const PROMPT_KEY = 0x10;
+    }
+}
 
 impl_tailq_entry!(client, entry, tailq_entry<client>);
 #[repr(C)]
@@ -2339,7 +2345,7 @@ struct client {
     prompt_mode: prompt_mode,
     prompt_saved: *mut utf8_data,
 
-    prompt_flags: c_int,
+    prompt_flags: prompt_flags,
     prompt_type: prompt_type,
     prompt_cursor: c_int,
 

--- a/src/mode_tree.rs
+++ b/src/mode_tree.rs
@@ -1437,7 +1437,7 @@ pub unsafe fn mode_tree_key(
                     mode_tree_search_callback,
                     mode_tree_search_free,
                     mtd,
-                    PROMPT_NOFORMAT,
+                    prompt_flags::PROMPT_NOFORMAT,
                     prompt_type::PROMPT_TYPE_SEARCH,
                 );
             }
@@ -1459,7 +1459,7 @@ pub unsafe fn mode_tree_key(
                     mode_tree_filter_callback,
                     mode_tree_filter_free,
                     mtd,
-                    PROMPT_NOFORMAT,
+                    prompt_flags::PROMPT_NOFORMAT,
                     prompt_type::PROMPT_TYPE_SEARCH,
                 );
             }

--- a/src/window_customize.rs
+++ b/src/window_customize.rs
@@ -1443,7 +1443,7 @@ pub unsafe fn window_customize_set_option(
                 window_customize_set_option_callback,
                 window_customize_free_item_callback,
                 Box::into_raw(new_item),
-                PROMPT_NOFORMAT,
+                prompt_flags::PROMPT_NOFORMAT,
                 prompt_type::PROMPT_TYPE_COMMAND,
             );
 
@@ -1610,7 +1610,7 @@ pub unsafe fn window_customize_set_key(
                 window_customize_set_command_callback,
                 window_customize_free_item_callback,
                 Box::into_raw(new_item),
-                PROMPT_NOFORMAT,
+                prompt_flags::PROMPT_NOFORMAT,
                 prompt_type::PROMPT_TYPE_COMMAND,
             );
             free_(prompt);
@@ -1641,7 +1641,7 @@ pub unsafe fn window_customize_set_key(
                 window_customize_set_note_callback,
                 window_customize_free_item_callback,
                 Box::leak(new_item),
-                PROMPT_NOFORMAT,
+                prompt_flags::PROMPT_NOFORMAT,
                 prompt_type::PROMPT_TYPE_COMMAND,
             );
             free_(prompt);
@@ -1869,7 +1869,7 @@ pub unsafe fn window_customize_key(
                         window_customize_change_current_callback,
                         window_customize_free_callback,
                         data,
-                        PROMPT_SINGLE | PROMPT_NOFORMAT,
+                        prompt_flags::PROMPT_SINGLE | prompt_flags::PROMPT_NOFORMAT,
                         prompt_type::PROMPT_TYPE_COMMAND,
                     );
                     free_(prompt);
@@ -1889,7 +1889,7 @@ pub unsafe fn window_customize_key(
                         window_customize_change_tagged_callback,
                         window_customize_free_callback,
                         data,
-                        PROMPT_SINGLE | PROMPT_NOFORMAT,
+                        prompt_flags::PROMPT_SINGLE | prompt_flags::PROMPT_NOFORMAT,
                         prompt_type::PROMPT_TYPE_COMMAND,
                     );
                     free_(prompt);
@@ -1913,7 +1913,7 @@ pub unsafe fn window_customize_key(
                         window_customize_change_current_callback,
                         window_customize_free_callback,
                         data,
-                        PROMPT_SINGLE | PROMPT_NOFORMAT,
+                        prompt_flags::PROMPT_SINGLE | prompt_flags::PROMPT_NOFORMAT,
                         prompt_type::PROMPT_TYPE_COMMAND,
                     );
                     free_(prompt);
@@ -1933,7 +1933,7 @@ pub unsafe fn window_customize_key(
                         window_customize_change_tagged_callback,
                         window_customize_free_callback,
                         data,
-                        PROMPT_SINGLE | PROMPT_NOFORMAT,
+                        prompt_flags::PROMPT_SINGLE | prompt_flags::PROMPT_NOFORMAT,
                         prompt_type::PROMPT_TYPE_COMMAND,
                     );
                     free_(prompt);

--- a/src/window_tree.rs
+++ b/src/window_tree.rs
@@ -1584,7 +1584,7 @@ unsafe fn window_tree_key(
                         window_tree_kill_current_callback,
                         window_tree_command_free,
                         data,
-                        PROMPT_SINGLE | PROMPT_NOFORMAT,
+                        prompt_flags::PROMPT_SINGLE | prompt_flags::PROMPT_NOFORMAT,
                         prompt_type::PROMPT_TYPE_COMMAND,
                     );
                     free_(prompt);
@@ -1604,7 +1604,7 @@ unsafe fn window_tree_key(
                         window_tree_kill_tagged_callback,
                         window_tree_command_free,
                         data,
-                        PROMPT_SINGLE | PROMPT_NOFORMAT,
+                        prompt_flags::PROMPT_SINGLE | prompt_flags::PROMPT_NOFORMAT,
                         prompt_type::PROMPT_TYPE_COMMAND,
                     );
                     free_(prompt);
@@ -1625,7 +1625,7 @@ unsafe fn window_tree_key(
                         window_tree_command_callback,
                         window_tree_command_free,
                         data,
-                        PROMPT_NOFORMAT,
+                        prompt_flags::PROMPT_NOFORMAT,
                         prompt_type::PROMPT_TYPE_COMMAND,
                     );
                     free_(prompt);


### PR DESCRIPTION
This fixes the only one rustc (not clippy) warning that had to be suppressed. This also fixes a wrong value for `PROMPT_KEY` and converts `prompt_flags` into a bitflags struct.