### PR TITLE
Fix clippy warnings and macOS build errors

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -475,7 +475,7 @@ macro_rules! args_print_add {
         crate::arguments::args_print_add_($buf, $len, format_args!($fmt $(, $args)*))
     };
 }
-pub(crate) use args_print_add;
+
 pub unsafe fn args_print_add_(buf: *mut *mut u8, len: *mut usize, fmt: std::fmt::Arguments) {
     unsafe {
         let s = CString::new(fmt.to_string()).unwrap();

--- a/src/format.rs
+++ b/src/format.rs
@@ -492,7 +492,7 @@ macro_rules! format_printf {
         crate::format::format_printf_(format_args!($fmt $(, $args)*))
     };
 }
-pub(crate) use format_printf;
+
 pub unsafe fn format_printf_(args: std::fmt::Arguments) -> *mut u8 {
     let mut s = args.to_string();
     s.push('\0');

--- a/src/libc.rs
+++ b/src/libc.rs
@@ -1,7 +1,36 @@
 #![allow(clippy::disallowed_types)]
 
 // reexport everything in libc from this module, then override things we want to change the interface for
-pub use ::libc::*;
+pub use ::libc::{
+    _POSIX_VDISABLE, _exit, AF_UNIX, BUFSIZ, CLOCK_MONOTONIC, CLOCK_REALTIME, CODESET, CREAD, CS8,
+    E2BIG, EAGAIN, EBADF, ECHILD, ECHO, ECHOCTL, ECHOE, ECHOKE, ECHONL, ECHOPRT, ECONNABORTED,
+    ECONNREFUSED, EEXIST, EINTR, EINVAL, EIO, EMFILE, ENAMETOOLONG, ENFILE, ENOENT, ENOMEM, EOF,
+    F_GETFL, F_SETFD, F_SETFL, FD_CLOEXEC, FILE, FIONREAD, FNM_CASEFOLD, GLOB_NOMATCH,
+    GLOB_NOSPACE, HUPCL, ICANON, ICRNL, IEXTEN, IGNBRK, IGNCR, IMAXBEL, INLCR, ISIG, ISTRIP, IXANY,
+    IXOFF, IXON, LC_CTYPE, LC_TIME, LOCK_EX, LOCK_NB, O_APPEND, O_CREAT, O_NONBLOCK, O_RDONLY,
+    O_RDWR, O_TRUNC, O_WRONLY, OCRNL, ONLCR, ONLRET, OPOST, PATH_MAX, PF_UNSPEC, REG_EXTENDED,
+    REG_ICASE, REG_NOSUB, REG_NOTBOL, S_IRGRP, S_IROTH, S_IRUSR, S_IRWXG, S_IRWXO, S_IRWXU,
+    S_IXGRP, S_IXOTH, S_IXUSR, SA_RESTART, SEEK_END, SEEK_SET, SHUT_WR, SIG_BLOCK, SIG_DFL,
+    SIG_IGN, SIG_SETMASK, SIGCHLD, SIGCONT, SIGHUP, SIGINT, SIGPIPE, SIGQUIT, SIGTERM, SIGTSTP,
+    SIGTTIN, SIGTTOU, SIGUSR1, SIGUSR2, SIGWINCH, SOCK_STREAM, STDERR_FILENO, STDIN_FILENO,
+    STDOUT_FILENO, TCOFLUSH, TCSAFLUSH, TCSANOW, TIOCGWINSZ, TIOCSWINSZ, VERASE, VMIN, VTIME,
+    WEXITSTATUS, WIFEXITED, WIFSIGNALED, WIFSTOPPED, WNOHANG, WSTOPSIG, WTERMSIG, WUNTRACED, X_OK,
+    accept, access, bind, c_char, c_int, c_short, c_void, calloc, cc_t, cfgetispeed, cfgetospeed,
+    cfmakeraw, cfsetispeed, cfsetospeed, chmod, clock_gettime, close, connect, ctime_r, dirname,
+    dup, dup2, execl, execvp, exit, fclose, fcntl, fdopen, ferror, flock, fork, fread, free,
+    fseeko, ftello, fwrite, getpid, getppid, getpwnam, getpwuid, gettimeofday, getuid, gid_t,
+    glob_t, globfree, gmtime_r, ioctl, isalnum, isatty, isdigit, ispunct, isspace, kill, killpg,
+    listen, localtime, localtime_r, lstat, malloc, memchr, memcmp, memcpy, memmem, memmove, memset,
+    mkdir, mkstemp, nl_langinfo, off_t, passwd, pid_t, printf, qsort, regex_t, regfree, regmatch_t,
+    sa_family_t, shutdown, sigaction, sigemptyset, sigfillset, sigprocmask, sigset_t, size_t,
+    snprintf, sockaddr, sockaddr_storage, sockaddr_un, socket, socketpair, socklen_t, sscanf, stat,
+    strsignal, suseconds_t, system, tcflush, tcgetattr, tcgetpgrp, tcsetattr, termios, time_t,
+    timespec, timeval, tm, uid_t, umask, uname, usleep, utsname, waitpid, winsize, write,
+};
+#[cfg(target_os = "linux")]
+pub use ::libc::{_SC_MB_LEN_MAX, PR_SET_NAME, TIOCGSID, fgetc, malloc_trim, prctl, readlink};
+#[cfg(target_os = "macos")]
+pub use ::libc::{PROC_PIDVNODEPATHINFO, proc_pidinfo, proc_vnodepathinfo};
 
 pub type wchar_t = core::ffi::c_int;
 

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -474,7 +474,7 @@ pub unsafe fn proc_fork_and_daemon(fd: *mut i32) -> pid_t {
             0 => {
                 close(pair[0]);
                 *fd = pair[1];
-                if libc::daemon(1, 0) != 0 {
+                if ::libc::daemon(1, 0) != 0 {
                     fatal("daemon failed");
                 }
                 0


### PR DESCRIPTION
macOS build was failing due to ambiguous symbols like `strtonum` that are both imported from the `libc` crate and defined in `src/compat`. I'm actually surprised why it wasn't a problem on Linux.

The solution is to only import used symbols from the `libc` crate. There are a lot of them, but it's good to know what we are actually using.

Importing `::libc::daemon` was causing a deprecation warning on macOS. I decided to call `::libc::daemon` directly in `proc_fork_and_daemon` where the warning is expected already.

Finally, there were two clippy warnings about unnecessary `pub use`, I fixed them as well.