### PR TITLE
Fix nightly clippy warnings about unused imports

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -475,7 +475,7 @@ macro_rules! args_print_add {
         crate::arguments::args_print_add_($buf, $len, format_args!($fmt $(, $args)*))
     };
 }
-pub(crate) use args_print_add;
+
 pub unsafe fn args_print_add_(buf: *mut *mut u8, len: *mut usize, fmt: std::fmt::Arguments) {
     unsafe {
         let s = CString::new(fmt.to_string()).unwrap();

--- a/src/format.rs
+++ b/src/format.rs
@@ -492,7 +492,7 @@ macro_rules! format_printf {
         crate::format::format_printf_(format_args!($fmt $(, $args)*))
     };
 }
-pub(crate) use format_printf;
+
 pub unsafe fn format_printf_(args: std::fmt::Arguments) -> *mut u8 {
     let mut s = args.to_string();
     s.push('\0');


### PR DESCRIPTION
Only nightly clippy reports this issue. The CI scripts run clippy with the stable toolchain only.