### PR TITLE
Use full-featured bash in PATH under `nix develop`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,7 @@
         devShells.default = craneLib.devShell {
           checks = self.checks.${system};
           packages = [
+            pkgs.bashInteractive # full-featured bash with readline
             pkgs.rust-analyzer
             pkgs.clippy
             pkgs.rustfmt


### PR DESCRIPTION
I've noticed that if I run `tmux-rs` under `nix develop` on NixOS, it shows `\[` and `\]` from `PS1` on the terminal and fails to recognize arrows to navigate bash history. I assumed it was a tmux-rs issue, but then I found that the same happens if I run the upstream tmux and even if I run `bash` from the command line.

It turns out `nix develop` puts a stripped-down bash first in PATH, even though it runs the full-featured bash as the shell. This is supposedly done to better emulate the Nix build environment. But it's not a good choice to tmux-rs. Part of the development is testing, and tmux-rs is expected to run a full-featured shell.

Only Nix users who run `nix develop` are affected by the issue and by the fix.