### PR TITLE
Fix nightly clippy warnings, enable nightly clippy in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy -- -Dwarnings
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+      - run: cargo +stable clippy -- -Dwarnings
+      - run: cargo +nightly clippy -- -Dwarnings
 
   fmt:
     runs-on: ubuntu-latest

--- a/src/cmd_/cmd_find.rs
+++ b/src/cmd_/cmd_find.rs
@@ -1316,7 +1316,7 @@ pub unsafe fn cmd_find_current_client(item: *mut cmdq_item, quiet: i32) -> *mut 
     let __func__ = "cmd_find_current_client";
     unsafe {
         let mut c: *mut client = null_mut();
-        let mut wp = null_mut();
+        let wp;
         let mut fs: cmd_find_state = zeroed();
 
         if !item.is_null() {

--- a/src/cmd_/mod.rs
+++ b/src/cmd_/mod.rs
@@ -823,7 +823,7 @@ pub unsafe fn cmd_mouse_window(
     sp: *mut *mut session,
 ) -> Option<NonNull<winlink>> {
     unsafe {
-        let mut s: *mut session = null_mut();
+        let s: *mut session;
 
         if !(*m).valid {
             return None;

--- a/src/compat/getopt.rs
+++ b/src/compat/getopt.rs
@@ -38,7 +38,7 @@ pub static mut OPTARG: *mut u8 = null_mut();
 pub unsafe fn getopt(nargc: i32, nargv: *const *mut u8, ostr: *const u8) -> Option<u8> {
     unsafe {
         static mut PLACE: *const u8 = c"".as_ptr().cast();
-        let mut oli: *mut u8 = null_mut();
+        let mut oli: *mut u8;
         if ostr.is_null() {
             return None;
         }

--- a/src/server_client.rs
+++ b/src/server_client.rs
@@ -1820,7 +1820,7 @@ pub unsafe fn server_client_key_callback(item: *mut cmdq_item, data: *mut c_void
         let mut bd: *mut key_binding;
         let mut table: *mut key_table;
         let mut first: *mut key_table;
-        let mut wme: *mut window_mode_entry = null_mut();
+        let wme: *mut window_mode_entry;
         let mut fs: cmd_find_state = zeroed();
         let wl: *mut winlink;
         let wp: *mut window_pane;


### PR DESCRIPTION
`cargo +nightly clippy` is reporting new issues. The suggestions are good, we can get rid of some `null_mut()` initializers and some unnecessary `mut` occurrences as well. The best part is that even Rust 1.88 compiles the improved code without any warnings.

I have also added `cargo +nightly clippy` to the CI. Sure, it can break once in a while when clippy adds new rules. I believe we can deal with it. If that becomes problematic, we can target the MSRV and the latest stable Rust.